### PR TITLE
apache-2.4.10: fix default httpd.conf

### DIFF
--- a/srcpkgs/apache/template
+++ b/srcpkgs/apache/template
@@ -1,7 +1,7 @@
 # Template file for 'apache'
 pkgname=apache
 version=2.4.10
-revision=4
+revision=5
 wrksrc=httpd-${version}
 build_style=gnu-configure
 configure_args="--prefix= --enable-pie --enable-modules=all
@@ -77,14 +77,30 @@ post_install() {
 	# Enable userdir, languages, autoindex, errors.
 	# Set a working ServerRoot, disable mod_unique_id.
 	# Set and enable ServerName to 127.0.0.1.
-	sed -e 's|#\(Include /etc/httpd/extra/httpd-multilang-errordoc.conf\)|\1|' \
+
+	# FIXME:
+	#
+	# don't include:
+	# #Include /etc/httpd/extra/httpd-multilang-errordoc.conf
+	# #Include /etc/httpd/extra/httpd-languages.conf
+	# #Include /etc/httpd/extra/httpd-userdir.conf
+	#
+	# and load:
+	# LoadModule slotmem_shm_module /usr/libexec/httpd/mod_slotmem_shm.so
+	#
+	# until a solution is found, since they don't allow httpd to start!
+	#
+	#	-e 's|#\(Include /etc/httpd/extra/httpd-multilang-errordoc.conf\)|\1|' \
+	#	-e 's|#\(Include /etc/httpd/extra/httpd-languages.conf\)|\1|' \
+	#	-e 's|#\(Include /etc/httpd/extra/httpd-userdir.conf\)|\1|' \
+
+	sed \
 		-e 's|#\(Include /etc/httpd/extra/httpd-autoindex.conf\)|\1|' \
-		-e 's|#\(Include /etc/httpd/extra/httpd-languages.conf\)|\1|' \
-		-e 's|#\(Include /etc/httpd/extra/httpd-userdir.conf\)|\1|' \
 		-e 's|#\(Include /etc/httpd/extra/httpd-default.conf\)|\1|' \
 		-e 's|ServerRoot \"\"|ServerRoot \"/etc/httpd\"|' \
 		-e 's|#\(ServerName\).*|\1 127.0.0.1:80|' \
 		-e 's|\(LoadModule unique_id_module.*\)|#\1|' \
+		-e 's|#\(LoadModule slotmem_shm_module /usr/libexec/httpd/mod_slotmem_shm.so\)|\1|' \
 		-i ${DESTDIR}/etc/httpd/httpd.conf
 
         # symlinks for /etc/httpd

--- a/srcpkgs/apache/template
+++ b/srcpkgs/apache/template
@@ -65,10 +65,10 @@ pre_configure() {
 	# SSL_CTX_use_certificate_chain() conflicts with libressl-2.1.
 	sed -e 's,SSL_CTX_use_certificate_chain,_SSL_CTX_use_certificate_chain,g' -i modules/ssl/*.[ch]
 
-        # set default user
+	# set default user
 	sed -e 's#User daemon#User httpd#' \
-	    -e 's#Group daemon#Group httpd#' \
-	    -i docs/conf/httpd.conf.in
+		-e 's#Group daemon#Group httpd#' \
+		-i docs/conf/httpd.conf.in
 
 	cat ${FILESDIR}/xbps.layout >> config.layout
 }
@@ -103,7 +103,7 @@ post_install() {
 		-e 's|#\(LoadModule slotmem_shm_module /usr/libexec/httpd/mod_slotmem_shm.so\)|\1|' \
 		-i ${DESTDIR}/etc/httpd/httpd.conf
 
-        # symlinks for /etc/httpd
+	# symlinks for /etc/httpd
 	ln -fs /var/log/httpd ${DESTDIR}/etc/httpd/logs
 	ln -fs /var/run/httpd ${DESTDIR}/etc/httpd/run
 	ln -fs /usr/libexec/httpd ${DESTDIR}/etc/httpd/modules


### PR DESCRIPTION
Work around errors:

    AH00526: Syntax error on line 31 of /etc/httpd/extra/httpd-multilang-errordoc.conf:
    Invalid command 'LanguagePriority', perhaps misspelled or defined by a module not included in the server configuration

    AH00526: Syntax error on line 78 of /etc/httpd/extra/httpd-languages.conf:
    Invalid command 'LanguagePriority', perhaps misspelled or defined by a module not included in the server configuration

    AH00526: Syntax error on line 10 of /etc/httpd/extra/httpd-userdir.conf:
    Invalid command 'UserDir', perhaps misspelled or defined by a module not included in the server configuration

    [Tue Jan 06 01:34:14.130358 2015] [proxy_balancer:emerg] [pid 24013:tid 140060053915520] AH01177: Failed to lookup provider 'shm' for 'slotmem': is mod_slotmem_shm loaded??
    [Tue Jan 06 01:34:14.130456 2015] [:emerg] [pid 24013:tid 140060053915520] AH00020: Configuration Failed, exiting