### PR TITLE
apache-2.4.10: revert and fix httpd.conf

### DIFF
--- a/srcpkgs/apache/template
+++ b/srcpkgs/apache/template
@@ -1,7 +1,7 @@
 # Template file for 'apache'
 pkgname=apache
 version=2.4.10
-revision=5
+revision=6
 wrksrc=httpd-${version}
 build_style=gnu-configure
 configure_args="--prefix= --enable-pie --enable-modules=all
@@ -74,34 +74,41 @@ pre_configure() {
 }
 
 post_install() {
-	# Enable userdir, languages, autoindex, errors.
-	# Set a working ServerRoot, disable mod_unique_id.
+	# Set a working ServerRoot
+	#
+	# Load modules:
+	#  * mod_include.so
+	#  * mod_slotmem_shm.so
+	#  * mod_negotiation.so
+	#  * mod_userdir.so
+	#
+	# Avoid loading modules:
+	#  * mod_unique_id.so
+	#
 	# Set and enable ServerName to 127.0.0.1.
-
-	# FIXME:
 	#
-	# don't include:
-	# #Include /etc/httpd/extra/httpd-multilang-errordoc.conf
-	# #Include /etc/httpd/extra/httpd-languages.conf
-	# #Include /etc/httpd/extra/httpd-userdir.conf
+	# include extras:
+	#  * httpd-multilang-errordoc.conf
+	#  * httpd-autoindex.conf
+	#  * httpd-languages.conf
+	#  * httpd-userdir.conf
+	#  * httpd-default.conf
 	#
-	# and load:
-	# LoadModule slotmem_shm_module /usr/libexec/httpd/mod_slotmem_shm.so
-	#
-	# until a solution is found, since they don't allow httpd to start!
-	#
-	#	-e 's|#\(Include /etc/httpd/extra/httpd-multilang-errordoc.conf\)|\1|' \
-	#	-e 's|#\(Include /etc/httpd/extra/httpd-languages.conf\)|\1|' \
-	#	-e 's|#\(Include /etc/httpd/extra/httpd-userdir.conf\)|\1|' \
 
 	sed \
-		-e 's|#\(Include /etc/httpd/extra/httpd-autoindex.conf\)|\1|' \
-		-e 's|#\(Include /etc/httpd/extra/httpd-default.conf\)|\1|' \
-		-e 's|ServerRoot \"\"|ServerRoot \"/etc/httpd\"|' \
-		-e 's|#\(ServerName\).*|\1 127.0.0.1:80|' \
-		-e 's|\(LoadModule unique_id_module.*\)|#\1|' \
+		-e 's|ServerRoot ""|ServerRoot "/etc/httpd"|' \
+		-e 's|#\(LoadModule include_module /usr/libexec/httpd/mod_include.so\)|\1|' \
+		-e 's|\(LoadModule unique_id_module /usr/libexec/httpd/mod_unique_id.so\)|#\1|' \
 		-e 's|#\(LoadModule slotmem_shm_module /usr/libexec/httpd/mod_slotmem_shm.so\)|\1|' \
-		-i ${DESTDIR}/etc/httpd/httpd.conf
+		-e 's|#\(LoadModule negotiation_module /usr/libexec/httpd/mod_negotiation.so\)|\1|' \
+		-e 's|#\(LoadModule userdir_module /usr/libexec/httpd/mod_userdir.so\)|\1|' \
+		-e 's|#ServerName www.example.com:80|ServerName 127.0.0.1:80|' \
+		-e 's|#\(Include /etc/httpd/extra/httpd-multilang-errordoc.conf\)|\1|' \
+		-e 's|#\(Include /etc/httpd/extra/httpd-autoindex.conf\)|\1|' \
+		-e 's|#\(Include /etc/httpd/extra/httpd-languages.conf\)|\1|' \
+		-e 's|#\(Include /etc/httpd/extra/httpd-userdir.conf\)|\1|' \
+		-e 's|#\(Include /etc/httpd/extra/httpd-default.conf\)|\1|' \
+		-i "${DESTDIR}/etc/httpd/httpd.conf"
 
 	# symlinks for /etc/httpd
 	ln -fs /var/log/httpd ${DESTDIR}/etc/httpd/logs


### PR DESCRIPTION
Just add missing dependencies instead of removing broken features.