### PR TITLE
tlp: add runit services

### DIFF
--- a/srcpkgs/tlp/files/tlp/finish
+++ b/srcpkgs/tlp/files/tlp/finish
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec tlp init stop

--- a/srcpkgs/tlp/files/tlp/run
+++ b/srcpkgs/tlp/files/tlp/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+tlp init start
+exec pause

--- a/srcpkgs/tlp/files/tlp/run
+++ b/srcpkgs/tlp/files/tlp/run
@@ -1,3 +1,3 @@
 #!/bin/sh
-tlp init start
-exec pause
+tlp init start || exit 1
+exec chpst -b tlp pause

--- a/srcpkgs/tlp/template
+++ b/srcpkgs/tlp/template
@@ -1,7 +1,7 @@
 # Template file for 'tlp'
 pkgname=tlp
 version=0.5
-revision=2
+revision=3
 hostmakedepends="git"
 depends="hdparm bash iw rfkill ethtool"
 conf_files="/etc/default/tlp"
@@ -21,8 +21,6 @@ do_build() {
 	sed -i -e 's|/usr/sbin/|/usr/bin|' Makefile
 	sed -i -e 's|$(SBIN)|$(BIN)|' Makefile
 	sed -i -e 's|SBIN  = $(DESTDIR)/usr/sbin||' Makefile
-	sed -i -e 's|/usr/sbin/|/usr/bin/|' tlp.service
-	sed -i -e 's|/usr/sbin/tlp|/usr/bin/tlp|' tlp.rules
 }
 
 do_install() {
@@ -36,6 +34,7 @@ do_install() {
 	vmkdir usr/lib/systemd/system
 	vinstall tlp.service 644 usr/lib/systemd/system
 	vinstall tlp-sleep.service 644 usr/lib/systemd/system
+	vsv tlp
 
 	vmkdir usr/share/bash-completion/completions
 	mv ${DESTDIR}/etc/bash_completion.d/tlp ${DESTDIR}/usr/share/bash-completion/completions


### PR DESCRIPTION
Also removed 2 lines which changed the absolute path to /usr/bin in udev config and systemd services, while tlp is located in /usr/sbin.