### PR TITLE
base-files: Prevent 'vkpurge list' from displaying errors at unknown kernel files

### DIFF
--- a/srcpkgs/base-files/files/vkpurge
+++ b/srcpkgs/base-files/files/vkpurge
@@ -23,14 +23,15 @@ _EOF
 
 list_kernels()
 {
-	local k kpkg installed kver skip _f
+	local k kpkg installed kver _f
 
 	for k in /boot/vmlinuz-*; do
 		_f=$(basename $k)
 		kver=$(echo ${_f}|sed -e 's|-rc|rc|')
 		installed=$(xbps-query -o "$k" 2>/dev/null)
 		[ -n "$installed" ] && continue
-		echo "$(xbps-uhelper getpkgversion ${_f})"
+		kpkg="$(xbps-uhelper getpkgversion ${_f} 2>/dev/null)"
+		[ -n "$kpkg" ] && echo "$kpkg"
 	done
 }
 

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,7 +1,7 @@
 # Template file for 'base-files'
 pkgname=base-files
 version=0.114
-revision=2
+revision=3
 bootstrap=yes
 build_style="meta"
 depends="base-directories xbps-triggers"


### PR DESCRIPTION
I have some kernels from another distro on my boot partition and "vkpurge list" always throws "Invalid string..." errors when trying to list them. I re-used an apparently discarded local variable and dropped another in the process.