### PR TITLE
spotify: Limited library search to 1 result

### DIFF
--- a/srcpkgs/spotify/INSTALL
+++ b/srcpkgs/spotify/INSTALL
@@ -5,7 +5,7 @@ _BUILDDIR="/tmp/spotify.build"
 _LIBS=$(ldconfig -vNX -n /usr/lib 2>/dev/null)
 
 linklib() {
-    _LIB=$(echo "$_LIBS" | grep "${1}\.so" | sed 's/\s*\([^ ]*\).*$/\1/')
+    _LIB=$(echo "$_LIBS" | grep -m 1 "${1}\.so" | sed 's/\s*\([^ ]*\).*$/\1/')
     ln -s "/usr/lib/${_LIB}" "/usr/share/spotify/libs/${1}.so.${2}"
 }
 

--- a/srcpkgs/spotify/template
+++ b/srcpkgs/spotify/template
@@ -1,7 +1,7 @@
 # Template build file for 'spotify'.
 pkgname=spotify
 version=0.9
-revision=2
+revision=3
 short_desc="Proprietary music streaming client"
 maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
 homepage="https://www.spotify.com"


### PR DESCRIPTION
Sorry for the new pull request, but just now a second version of libssl was added and my library version detection probably would not have liked that.