### PR TITLE
weechat: fix python plugin

### DIFF
--- a/srcpkgs/weechat/template
+++ b/srcpkgs/weechat/template
@@ -1,10 +1,10 @@
 # Template file for 'weechat'
 pkgname=weechat
 version=1.1
-revision=1
+revision=2
 lib32disabled=yes
 build_style=cmake
-configure_args="-DENABLE_MAN=ON"
+configure_args="-DENABLE_MAN=ON -DPYTHON_EXECUTABLE=/usr/bin/python2.7 -DPYTHON_LIBRARY=/usr/lib/libpython2.7.so"
 hostmakedepends="cmake pkg-config python-devel libgcrypt-devel tcl-devel>=8.6 asciidoc"
 makedepends="tcl-devel>=8.6 aspell-devel libgcrypt-devel gnutls-devel>=3.1.5
  python-devel ruby-devel>=2.2 lua-devel>=5.2 libcurl-devel"


### PR DESCRIPTION
this fixes ``/usr/lib/weechat/plugins/python.so: undefined symbol: forkpty`` in weechet while trying ``/plugin load python``