### PR TITLE
zpaq: fix empty manual

### DIFF
--- a/srcpkgs/zpaq/template
+++ b/srcpkgs/zpaq/template
@@ -1,11 +1,11 @@
 # template for 'zpaq'
 pkgname=zpaq
 version=6.60
-revision=2
+revision=3
 license="GPL-3"
 short_desc="Incremental Journaling Backup Utility and Archiver"
 build_style=gnu-makefile
-hostmakedepends="unzip pod2mdoc"
+hostmakedepends="unzip perl"
 maintainer="necrophcodr <necrophcodr@necrophcodr.me>"
 homepage="http://mattmahoney.net/dc/zpaq.html"
 distfiles="http://mattmahoney.net/dc/zpaq660.zip"
@@ -14,7 +14,7 @@ checksum=58fe7d94421ac115fb04eb58bacc17093ebd1294b05320989bcb1ce3be29cbdc
 
 do_build() {
 	$CXX $CFLAGS -Dunix zpaq.cpp libzpaq.cpp -pthread -o zpaq
-	pod2mdoc zpaq.pod > zpaq.1
+	pod2man zpaq.pod > zpaq.1
 }
 
 do_install() {


### PR DESCRIPTION
Dropped pod2mdoc dependency, and use perl (=> /usr/bin/pod2man) instead, due to issues with pod2mdoc.
Appearantly it generated an empty file with only date and title, and this fixes that. The manual is now working (proper testing has been done on my end).