### PR TITLE
runit-void: Install only active services by default

### DIFF
--- a/srcpkgs/runit-void/INSTALL
+++ b/srcpkgs/runit-void/INSTALL
@@ -8,7 +8,7 @@ post)
 
 	mkdir -p etc/runit/runsvdir/default
 	for f in 1 2 3 4 5 6; do
-		ln -sf /etc/sv/agetty-tty$f etc/runit/runsvdir/default
+		[ -e /etc/sv/agetty-tty${f}/down ] || ln -sf /etc/sv/agetty-tty$f etc/runit/runsvdir/default
 	done
 	;;
 esac

--- a/srcpkgs/runit-void/template
+++ b/srcpkgs/runit-void/template
@@ -1,7 +1,7 @@
 # Template file for 'runit-void'
 pkgname=runit-void
 version=20150127
-revision=2
+revision=3
 build_style=gnu-makefile
 homepage="http://www.voidlinux.eu"
 short_desc="Void Linux runit scripts"


### PR DESCRIPTION
When a user has deactivated a service with a `down` file, I think it is prudent to not install it by default.