### PR TITLE
openjdk: Fix for nonreparenting windowmanagers

### DIFF
--- a/srcpkgs/openjdk/files/003_nonreparenting-wm.patch
+++ b/srcpkgs/openjdk/files/003_nonreparenting-wm.patch
@@ -1,0 +1,38 @@
+--- a/src/solaris/classes/sun/awt/X11/XWM.java	2015-01-29 20:08:28.387583688 +0100
++++ b/src/solaris/classes/sun/awt/X11/XWM.java	2015-01-29 20:12:52.955595493 +0100
+@@ -104,7 +104,8 @@
+         COMPIZ_WM = 12,
+         LG3D_WM = 13,
+         CWM_WM = 14,
+-        MUTTER_WM = 15;
++        MUTTER_WM = 15,
++	OTHER_NONREPARENTING_WM = 16;
+     public String toString() {
+         switch  (WMID) {
+           case NO_WM:
+@@ -596,7 +597,7 @@
+     }
+ 
+     static boolean isNonReparentingWM() {
+-        return (XWM.getWMID() == XWM.COMPIZ_WM || XWM.getWMID() == XWM.LG3D_WM || XWM.getWMID() == XWM.CWM_WM);
++        return (XWM.getWMID() == XWM.COMPIZ_WM || XWM.getWMID() == XWM.LG3D_WM || XWM.getWMID() == XWM.CWM_WM || XWM.getWMID() == XWM.OTHER_NONREPARENTING_WM);
+     }
+ 
+     /*
+@@ -785,6 +786,8 @@
+                 awt_wmgr = CWM_WM;
+             } else if (doIsIceWM && isIceWM()) {
+                 awt_wmgr = XWM.ICE_WM;
++            } else if (XToolkit.getEnv("_JAVA_AWT_WM_NONREPARENTING") != null) {
++                awt_wmgr = XWM.OTHER_NONREPARENTING_WM;
+             }
+             /*
+              * We don't check for legacy WM when we already know that WM
+@@ -1333,6 +1336,7 @@
+                   break;
+               case NO_WM:
+               case LG3D_WM:
++              case OTHER_NONREPARENTING_WM:
+                   res = zeroInsets;
+                   break;
+               case MOTIF_WM:

--- a/srcpkgs/openjdk/template
+++ b/srcpkgs/openjdk/template
@@ -12,7 +12,7 @@ _openjdk_version="openjdk-1.8.0_${_jdk_update}"
 # Template file for 'openjdk'
 pkgname=openjdk
 version=${_java_ver}u${_jdk_update}
-revision=2
+revision=3
 nocross=yes
 wrksrc=jdk8u-jdk8u${_jdk_update}-b${_jdk_build}/
 build_style=gnu-configure
@@ -80,6 +80,8 @@ post_extract() {
 	patch -p1 < ${FILESDIR}/001_adjust-mflags-for-gmake-4.patch
 	# https://bugs.openjdk.java.net/browse/JDK-8041658
 	patch -p1 < ${FILESDIR}/002_gcc.make-4.9.patch
+	cd ../jdk
+	patch -p1 < ${FILESDIR}/003_nonreparenting-wm.patch
 }
 
 post_install() {


### PR DESCRIPTION
Make openjdk respect the `_JAVA_AWT_WM_NONREPARENTING` environment variable for use with unknown nonreparenting windowmanagers.