### PR TITLE
zpaq: update to 7.00

### DIFF
--- a/srcpkgs/zpaq/template
+++ b/srcpkgs/zpaq/template
@@ -1,16 +1,16 @@
 # template for 'zpaq'
 pkgname=zpaq
-version=6.60
-revision=3
+version=7.00
+revision=1
 license="GPL-3"
 short_desc="Incremental Journaling Backup Utility and Archiver"
 build_style=gnu-makefile
 hostmakedepends="unzip perl"
 maintainer="necrophcodr <necrophcodr@necrophcodr.me>"
 homepage="http://mattmahoney.net/dc/zpaq.html"
-distfiles="http://mattmahoney.net/dc/zpaq660.zip"
+distfiles="http://mattmahoney.net/dc/zpaq700.zip"
 create_wrksrc=yes
-checksum=58fe7d94421ac115fb04eb58bacc17093ebd1294b05320989bcb1ce3be29cbdc
+checksum=2cfd210cab7ace0ee0a938fb1ced28f7eebb7115c3d613721fbdaee0693f96e9
 
 do_build() {
 	$CXX $CFLAGS -Dunix zpaq.cpp libzpaq.cpp -pthread -o zpaq


### PR DESCRIPTION
Changes:

 Jan. 30, 2015. Adds compression methods to libzpaq. Removes -quiet, -fragment, -fragile, -since, -duplicates, -newkey. Allows add -to, extract -all, list files (compare).