### PR TITLE
extra-cmake-modules: needs cmake at runtime, remove unneeded build depen...

### DIFF
--- a/srcpkgs/extra-cmake-modules/template
+++ b/srcpkgs/extra-cmake-modules/template
@@ -2,10 +2,11 @@
 pkgname=extra-cmake-modules
 version=1.6.1
 _frameworks=5.6
-revision=2
+revision=3
 noarch=yes
 build_style=cmake
-hostmakedepends="cmake python-Sphinx qt5-tools-devel"
+hostmakedepends="cmake python-Sphinx"
+depends="cmake"
 short_desc="Extra modules and scripts for CMake"
 maintainer="TheNumb <me@thenumb.eu>"
 license="BSD"


### PR DESCRIPTION
...dency.