### PR TITLE
lilo: add kernel hooks

### DIFF
--- a/srcpkgs/lilo/files/kernel.d/lilo.post-install
+++ b/srcpkgs/lilo/files/kernel.d/lilo.post-install
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Kernel hook for LILO.
+#
+# Arguments passed to this script: $1 pkgname, $2 version.
+#
+PKGNAME="${1}"
+VERSION="${2}"
+
+boot="${ROOTDIR}/boot"
+etc="${ROOTDIR}/etc"
+entries="${etc}/lilo.d"
+name="void-${VERSION}"
+entry="${entries}/${name}.conf"
+
+[ -d "${boot}" ] && [ -d "${etc}" ] || exit 0
+mkdir -p "${entries}"
+
+cat <<-EOF > "${entry}"
+image = /${boot}/vmlinuz-${VERSION}
+	label  = "${name}"
+	initrd = /${boot}/initramfs-${VERSION}.img
+EOF
+
+# Replace existing default entry with this one
+echo "default=${name}" > "${entries}/default.conf"
+
+conf="$(mktemp)"
+cat "${etc}/lilo.conf" "${entries}"/*.conf > "${conf}"
+
+[ -x "$(command -v lilo)" ] && \
+	lilo -C "${conf}"
+
+# Remove temporary config file
+rm -f "${conf}"

--- a/srcpkgs/lilo/files/kernel.d/lilo.post-remove
+++ b/srcpkgs/lilo/files/kernel.d/lilo.post-remove
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# Kernel hook for LILO.
+#
+# Arguments passed to this script: $1 pkgname, $2 version.
+#
+PKGNAME="${1}"
+VERSION="${2}"
+
+boot="${ROOTDIR}/boot"
+etc="${ROOTDIR}/etc"
+entries="${etc}/lilo.d"
+name="void-${VERSION}"
+entry="${entries}/${name}.conf"
+
+[ -d "${boot}" ] && [ -d "${etc}" ] || exit 0
+rm -f "${entry}"
+
+# No default entry if the removed one was the default
+sed "/^default=${name}\$/d" -i "${entries}/default.conf"
+
+conf="$(mktemp)"
+cat "${etc}/lilo.conf" "${entries}"/*.conf > "${conf}"
+
+[ -x "$(command -v lilo)" ] && \
+	lilo -C "${conf}"
+
+# Remove temporary config file
+rm -f "${conf}"

--- a/srcpkgs/lilo/files/lilo.conf
+++ b/srcpkgs/lilo/files/lilo.conf
@@ -1,0 +1,29 @@
+# Example lilo(8) configuration.
+# See lilo.conf(5) for more information.
+
+# Additional kernel parameter.
+append="quiet"
+
+# Specifies the boot device.
+boot="/dev/sda"
+
+# Devices which should be mounted as root.
+root="/dev/sda2"
+
+# Enables map compaction.
+compact
+
+# Prompt to start one certain kernel from the displayed menu.
+prompt
+
+# Time to wait before booting the default kernel.
+timeout=100
+
+# Allow use of partitions above 1024 cylinders.
+lba32
+
+# Mount the root file system read-only.
+read-only
+
+# Images are configured in /etc/lilo.d/*.conf
+# End of file

--- a/srcpkgs/lilo/template
+++ b/srcpkgs/lilo/template
@@ -1,10 +1,11 @@
 # Template file for 'lilo'
 pkgname=lilo
 version=24.1
-revision=1
+revision=2
 only_for_archs="i686 x86_64"
 hostmakedepends="bin86"
 makedepends="device-mapper-devel"
+make_dirs="/etc/lilo.d 0755 root root"
 conf_files="/etc/lilo.conf"
 short_desc="Standard Linux boot loader"
 maintainer="Sören Tempel <soeren+void@soeren-tempel.net>"
@@ -21,12 +22,22 @@ pre_build() {
 
 do_build() {
 	# LILO needs LC_ALL=C
-	LC_ALL=C make CC=$CC all
+	export LC_ALL=C
+	make CC=${CC} all
 }
 
 do_install() {
 	make DESTDIR=${DESTDIR} install
-	rm -r ${DESTDIR}/etc/initramfs ${DESTDIR}/etc/kernel
 	mv ${DESTDIR}/sbin/* ${DESTDIR}/usr/sbin
-	mv ${DESTDIR}/etc/lilo.conf_example ${DESTDIR}/etc/lilo.conf
+
+	# Setup config files
+	rm ${DESTDIR}/etc/lilo.conf_example
+	vinstall ${FILESDIR}/lilo.conf 600 etc
+
+	# Setup kernel hooks
+	rm -rf ${DESTDIR}/etc/initramfs ${DESTDIR}/etc/kernel
+	vinstall ${FILESDIR}/kernel.d/lilo.post-install 750 \
+		etc/kernel.d/post-install 50-lilo
+	vinstall ${FILESDIR}/kernel.d/lilo.post-remove 750 \
+		etc/kernel.d/post-remove 50-lilo
 }


### PR DESCRIPTION
This adds a post-install and a post-remove kernel hooks for LILO. For each image that gets installed a file in in `/etc/lilo.d/` is created. Furthermore, a file called `/etc/lilo.d/default.conf` is created, this particular file just specifies the default image to boot. The files in `/etc/lilo.d` are not parsed by LILO by default, thus a temporary file is created to concat `/etc/lilo.conf` with `/etc/lilo.d/*.conf` this temporary file is passed to LILO using the `-C` flag. That's it.