### PR TITLE
slashpackage.sh: Set compiler to $CC

### DIFF
--- a/common/build-style/slashpackage.sh
+++ b/common/build-style/slashpackage.sh
@@ -25,6 +25,7 @@
 #   distfiles="http://cr.yp.to/daemontools/${pkgname}-${version}.tar.gz"
 
 do_build() {
+	sed -i -e "s/^gcc/$CC/" src/conf-cc
 	package/compile
 }
 


### PR DESCRIPTION
If $CC is correct at this point this should fix cross compiling for anything slashpackage.