### PR TITLE
xdm: runit service and updated config path

### DIFF
--- a/srcpkgs/xdm/files/xdm/run
+++ b/srcpkgs/xdm/files/xdm/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec xdm -nodaemon 2>&1

--- a/srcpkgs/xdm/template
+++ b/srcpkgs/xdm/template
@@ -1,11 +1,12 @@
 # Template build file for 'xdm'.
 pkgname=xdm
 version=1.1.11
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-random-device=/dev/urandom
  --with-utmp-file=/var/run/utmp
- --with-wtmp-file=/var/log/wtmp"
+ --with-wtmp-file=/var/log/wtmp
+ --with-xdmconfigdir=/etc/X11/xdm"
 hostmakedepends="pkg-config"
 makedepends="libXaw-devel"
 depends="sessreg xconsole"

--- a/srcpkgs/xdm/template
+++ b/srcpkgs/xdm/template
@@ -1,7 +1,7 @@
 # Template build file for 'xdm'.
 pkgname=xdm
 version=1.1.11
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-random-device=/dev/urandom
  --with-utmp-file=/var/run/utmp
@@ -15,3 +15,7 @@ license="MIT"
 maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
 distfiles="${XORG_SITE}/app/$pkgname-$version.tar.bz2"
 checksum=d4da426ddea0124279a3f2e00a26db61944690628ee818a64df9d27352081c47
+
+post_install() {
+	vsv xdm
+}


### PR DESCRIPTION
This adds a runit service for the standard X log manager xdm. Furthermore, it also adds a configure flag which forces xdm to keep its configuration files in `/etc/X11/xdm`.