### PR TITLE
xdm: add pam support.

### DIFF
--- a/srcpkgs/xdm/files/xdm.pam
+++ b/srcpkgs/xdm/files/xdm.pam
@@ -1,0 +1,8 @@
+auth		required	pam_unix.so
+auth		required	pam_nologin.so
+auth		required	pam_env.so
+account		required	pam_unix.so
+password	required	pam_unix.so
+session		required	pam_unix.so
+session		required	pam_limits.so
+session		required	pam_loginuid.so

--- a/srcpkgs/xdm/template
+++ b/srcpkgs/xdm/template
@@ -1,14 +1,16 @@
 # Template build file for 'xdm'.
 pkgname=xdm
 version=1.1.11
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--with-random-device=/dev/urandom
  --with-utmp-file=/var/run/utmp
  --with-wtmp-file=/var/log/wtmp
- --with-xdmconfigdir=/etc/X11/xdm"
+ --with-xdmconfigdir=/etc/X11/xdm
+ --with-pam"
+conf_files="/etc/pam.d/xdm"
 hostmakedepends="pkg-config"
-makedepends="libXaw-devel"
+makedepends="pam-devel libXaw-devel"
 depends="sessreg xconsole"
 short_desc="X Display Manager"
 homepage="http://xorg.freedesktop.org"
@@ -19,4 +21,5 @@ checksum=d4da426ddea0124279a3f2e00a26db61944690628ee818a64df9d27352081c47
 
 post_install() {
 	vsv xdm
+	vinstall ${FILESDIR}/xdm.pam 644 etc/pam.d xdm
 }


### PR DESCRIPTION
This adds PAM support for xdm. The file `/etc/pam.d/xdm` was copied from Arch Linux (with minimal modifications).