### PR TITLE
New package: micropython 1.3.10

### DIFF
--- a/srcpkgs/micropython/template
+++ b/srcpkgs/micropython/template
@@ -1,0 +1,18 @@
+# Template file for 'micropython'
+pkgname=micropython
+version=1.3.10
+revision=1
+build_style=gnu-makefile
+make_build_args="-C unix"
+hostmakedepends="pkg-config python libffi-devel readline-devel"
+short_desc="Python for embedded systems"
+maintainer="necrophcodr <necrophcodr@necrophcodr.me>"
+license="MIT"
+homepage="http://micropython.org/"
+distfiles="http://github.com/micropython/micropython/archive/v${version}.tar.gz"
+checksum=42ff1b08cb30f5450285b7b1a1aec4c944ddf3840c4cb36faac51b5e79c8dc5c
+
+do_install() {
+	vbin unix/micropython
+	vbin tools/pip-micropython
+}


### PR DESCRIPTION
This commit contains the simple addition of a package known as micropython, which is essentially a Python for embedded systems. It contains a very slim standard library (although the entire library of Python is available in a seperate repo, and may be added as a seperate package I suppose), and is very performant in comparison to CPython.

In addition, this also allows users of low-power devices, such as ARM developer boards, to produce great content without having to sacrifice performance.

Please let me know where this package doesn't work. Compiled it on ARM, x86_64, and cross (for ARM on x86_64), and it seems to work out of the box.