### PR TITLE
plan9port: Don't modify $ROOTPATH and $MANPATH

### DIFF
--- a/srcpkgs/plan9port/files/plan9.sh
+++ b/srcpkgs/plan9port/files/plan9.sh
@@ -1,4 +1,2 @@
 export PLAN9=/opt/plan9
 export PATH=$PATH:$PLAN9/bin
-export ROOTPATH=$ROOTPATH:$PLAN9/bin
-export MANPATH=$MANPATH:$PLAN9/man

--- a/srcpkgs/plan9port/template
+++ b/srcpkgs/plan9port/template
@@ -1,7 +1,7 @@
 # Template file for 'plan9port'
 pkgname=plan9port
 version=20140306
-revision=3
+revision=4
 wrksrc=$pkgname
 hostmakedepends="which perl"
 makedepends="libX11-devel libXt-devel libXext-devel freetype-devel fontconfig-devel"


### PR DESCRIPTION
I couldn't determine any use-case for setting `ROOTPATH` in fact I couldn't even determine the package which reads this environment variable so I decided to remove it. The problem with `MANPATH` is a bit more complicated…our `/etc/profile` doesn't set `MANPATH` because OpenBSDs `man(1)` doesn't require it. Since `MANPATH` was empty before `plan9.sh` sets it to `:/opt/plan9/man` this will completely override `MANPATH` and `man(1)` will only look in `/opt/plan9/man` for man pages. Furthermore it isn't really necessary to append `/opt/plan9/man` to `MANPATH` because the recommended way to read a plan9port man page is using the `9` script e.g: `9 man intro`, therefore I decided to remove that environment variable as well.