### PR TITLE
xdm: Don't create a separate log file for errors

### DIFF
--- a/srcpkgs/xdm/files/xdm/run
+++ b/srcpkgs/xdm/files/xdm/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec xdm -nodaemon 2>&1
+exec xdm -error /dev/stdout -nodaemon 2>&1

--- a/srcpkgs/xdm/template
+++ b/srcpkgs/xdm/template
@@ -1,7 +1,7 @@
 # Template build file for 'xdm'.
 pkgname=xdm
 version=1.1.11
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="--with-random-device=/dev/urandom
  --with-utmp-file=/var/run/utmp


### PR DESCRIPTION
By logging errors to `stdout` as well.