### PR TITLE
bash: add -DSYS_BASHRC to CFLAGS

### DIFF
--- a/srcpkgs/bash/template
+++ b/srcpkgs/bash/template
@@ -3,7 +3,7 @@ pkgname=bash
 _bash_distver=4.3
 _bash_patchlevel=033
 version=${_bash_distver}.${_bash_patchlevel}
-revision=2
+revision=3
 wrksrc=${pkgname}-${_bash_distver}
 build_pie=yes
 build_style=gnu-configure
@@ -18,6 +18,7 @@ homepage="http://www.gnu.org/software/bash/bash.html"
 license="GPL-3"
 distfiles="http://ftp.gnu.org/gnu/bash/bash-${_bash_distver}.tar.gz"
 checksum=afc687a28e0e24dc21b988fa159ff9dbcf6b7caa92ade8645cc6d5605cd024d4
+CFLAGS="-DSYS_BASHRC='\"/etc/bash/bashrc\"'"
 
 pre_configure() {
 	local url="http://ftp.gnu.org/gnu/bash/bash-${_bash_distver}-patches"


### PR DESCRIPTION
this enables bash to source a system-wide bashrc.
currently set to /etc/bash/bashrc.