### PR TITLE
mpv: revbump: rebuild against new ffmpeg

### DIFF
--- a/srcpkgs/mpv/template
+++ b/srcpkgs/mpv/template
@@ -1,7 +1,7 @@
 # Template file for 'mpv'
 pkgname=mpv
 version=0.8.2
-revision=1
+revision=2
 short_desc="Video player based on MPlayer/mplayer2"
 maintainer="Juan RP <xtraeme@gmail.com>"
 license="GPL-2"


### PR DESCRIPTION
Warning: mpv was compiled against a different version of ffmpeg than the shared library it is linked against.