### PR TITLE
base-system-busybox: Depend on glibc-locales when not built with musl

### DIFF
--- a/srcpkgs/base-system-busybox/template
+++ b/srcpkgs/base-system-busybox/template
@@ -1,7 +1,7 @@
 # Build template for 'base-system-busybox'.
 pkgname=base-system-busybox
 version=1.23.1
-revision=1
+revision=2
 wrksrc="busybox-${version}"
 homepage="http://www.busybox.net"
 hostmakedepends="perl"
@@ -34,6 +34,7 @@ depends="base-files runit-void xbps kbd eudev shadow kmod ncurses-base procps-ng
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) depends+=" musl";;
+	*) depends+=" glibc-locales";;
 esac
 
 pre_build() {


### PR DESCRIPTION
`base-system` also does it this way, thus I figured that `base-system-busybox` should do that as well, right?