### PR TITLE
libstrophe: remove git make dependency

### DIFF
--- a/srcpkgs/libstrophe/template
+++ b/srcpkgs/libstrophe/template
@@ -1,9 +1,9 @@
 # Template file for 'libstrophe'
 pkgname=libstrophe
 version=0.8.7
-revision=4
+revision=5
 build_style=gnu-configure
-hostmakedepends="automake libtool pkg-config git"
+hostmakedepends="automake libtool pkg-config"
 makedepends="expat-devel zlib-devel libressl-devel"
 short_desc="A minimal XMPP library written in C"
 maintainer="Juan RP <xtraeme@gmail.com>"


### PR DESCRIPTION
The initial libstrophe package used git to fetch the sources. The current version doesn't so git isn't required as a hostmakedependency anymore.