### PR TITLE
xbps-src: Set the MAKEFLAGS environment variable

### DIFF
--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -217,7 +217,7 @@ setup_pkg() {
     [ -z "$pkg" ] && return 1
 
     # Start with a sane environment
-    unset -v PKG_BUILD_OPTIONS XBPS_CROSS_CFLAGS XBPS_CROSS_CXXFLAGS XBPS_CROSS_CPPFLAGS XBPS_CROSS_LDFLAGS
+    unset -v MAKEFLAGS PKG_BUILD_OPTIONS XBPS_CROSS_CFLAGS XBPS_CROSS_CXXFLAGS XBPS_CROSS_CPPFLAGS XBPS_CROSS_LDFLAGS
     unset -v subpackages run_depends build_depends host_build_depends
 
     unset_package_funcs
@@ -375,6 +375,10 @@ setup_pkg() {
         else
             source_file ${XBPS_COMMONDIR}/build-profiles/${XBPS_MACHINE}.sh
         fi
+    fi
+
+    if [ -n "${makejobs}" ]; then
+        export MAKEFLAGS="${makejobs}"
     fi
 
     export CFLAGS="$XBPS_TARGET_CFLAGS $XBPS_CFLAGS $XBPS_CROSS_CFLAGS $CFLAGS $dbgflags"


### PR DESCRIPTION
This ensures that packages with custom build functions also use our provided MAKEFLAGS. Without this commit it was necessary to always append the "${makejobs}" variable manually to make. For compatibility reasons that is still possible but should probably be removed in the future by making "makejobs" a local variable.

See also:
https://projects.archlinux.org/pacman.git/tree/scripts/makepkg.sh.in#n1538

---

This also means that the `${makejobs}` variable can be removed from build-styles. I noticed that some build-styles also use a `${make_build_args}` variable. I am not 100% sure what this variable does but maybe it should be append to `MAKEFLAGS` as well?