### PR TITLE
atari800: Disable floppy drive sounds and unneeded optimization

### DIFF
--- a/srcpkgs/atari800/template
+++ b/srcpkgs/atari800/template
@@ -15,12 +15,12 @@ configure_args="
 --enable-rserial --enable-rnetwork
 --enable-linuxjoystick --enable-eventrecording
 --enable-voicebox --enable-stereosound
---enable-clipsound --enable-consolesound --enable-volonlysound --enable-seriosound
+--enable-clipsound --enable-consolesound --enable-volonlysound
 --enable-interpolatesound --enable-nonlinear_mixing --enable-synchronized_sound
 --enable-pbi_mio --enable-pbi_bb --enable-pbi_xld --enable-ide
 --enable-monitortrace --enable-monitorprofile --enable-monitorhints
 --enable-monitorbreakpoints --enable-monitorbreak --enable-monitorasm
---enable-bufferedlog --enable-newcycleexact --enable-unalignedwords"
+--enable-bufferedlog --enable-newcycleexact"
 distfiles="${SOURCEFORGE_SITE}/atari800/atari800/${version}/atari800-${version}.tar.gz"
 checksum="901b02cce92ddb0b614f8034e6211f24cbfc2f8fb1c6581ba0097b1e68f91e0c"
 


### PR DESCRIPTION
[As upstream said](http://www.atari.org.pl/forum/viewtopic.php?pid=205459#p205459), those options are not recommended in distribution packages.

As usual, sorry for this whole mess in PRs and commits, I'm still learning how to deal with various branches.