### PR TITLE
New package: tvheadend-3.4

### DIFF
--- a/srcpkgs/tvheadend/template
+++ b/srcpkgs/tvheadend/template
@@ -1,0 +1,16 @@
+# Template file for 'tvheadend'
+pkgname=tvheadend
+version=3.4
+_patch=patch1
+revision=1
+wrksrc=tvheadend-${version}${_patch}
+build_style=gnu-configure
+configure_args="--disable-dvbscan"
+hostmakedepends="pkg-config"
+makedepends="libressl-devel zlib-devel"
+short_desc="TV streaming server"
+maintainer="lemmi <lemmi@nerd2nerd.org>"
+license="GPL-3"
+homepage="http://tvheadend.org"
+distfiles="https://github.com/tvheadend/tvheadend/archive/${version}${_patch}.tar.gz"
+checksum=50438809ff43ab332d255248096e9531ac85e6c51511206a3f68cfc1697f4ead


### PR DESCRIPTION
minimal template for tvheadend. i tried version 3.9 at first but seems not stable. so i went back to 3.4 (works stable for me), it is also the version in portage. 
tvheadend is able to generate a default config, but i'm not sure how to exploit that within the template.