### PR TITLE
New package: xmp 4.0.10

### DIFF
--- a/srcpkgs/xmp/template
+++ b/srcpkgs/xmp/template
@@ -1,0 +1,14 @@
+# Template file for 'xmp'
+pkgname=xmp
+version=4.0.10
+revision=1
+short_desc="Extended module player"
+maintainer="Jakub Skrzypnik <jot.skrzyp@gmail.com>"
+homepage="http://xmp.sourceforge.net"
+license="GPL-2"
+hostmakedepends="pkg-config"
+makedepends="libxmp-devel"
+build_style=gnu-configure
+distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}/${version}/${pkgname}-${version}.tar.gz"
+checksum="b6d45fef0dbdb4ad4948b9f82335cbfaf60eaec3a63cc9a0050a1e5cf7a65e3e"
+


### PR DESCRIPTION
This is an extended module player which uses libxmp.
I'm going to package `uade` and `asap` aso.