### PR TITLE
New package: rxvt-unicode-terminfo

### DIFF
--- a/srcpkgs/rxvt-unicode-terminfo
+++ b/srcpkgs/rxvt-unicode-terminfo
@@ -1,0 +1,1 @@
+rxvt-unicode

--- a/srcpkgs/rxvt-unicode/template
+++ b/srcpkgs/rxvt-unicode/template
@@ -1,7 +1,7 @@
 # Template build file for 'rxvt-unicode'.
 pkgname=rxvt-unicode
 version=9.21
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="
  --with-terminfo=/usr/share/terminfo --enable-256-color
@@ -11,7 +11,7 @@ configure_args="
  --enable-combining --with-term=rxvt-unicode-256color"
 hostmakedepends="pkg-config"
 makedepends="renderproto fontconfig-devel libXrender-devel libXft-devel libSM-devel"
-depends="ncurses"
+depends="ncurses rxvt-unicode-terminfo"
 short_desc="rxvt clone supporting Xft fonts and Unicode"
 maintainer="Juan RP <xtraeme@gmail.com>"
 homepage="http://software.schmorp.de/pkg/rxvt-unicode.html"
@@ -91,4 +91,11 @@ do_configure() {
 	else
 		./configure $configure_args
 	fi
+}
+
+rxvt-unicode-terminfo_package() {
+	short_desc+=" - terminfo data"
+	pkg_install() {
+		vmove usr/share/terminfo
+	}
 }


### PR DESCRIPTION
It contains only terminfo data `/usr/share/terminfo` for headless systems (e.g. servers) which does not require X, but used to accept connections from other hosts trough urxvt.

As side note, it's a bit urgent to me, while I have configured a simple server with Void right now and I need that package to connect with this server comfortably, using urxvt :smile: 