### PR TITLE
opencolorio: update to 1.0.9.

### DIFF
--- a/srcpkgs/opencolorio/template
+++ b/srcpkgs/opencolorio/template
@@ -1,7 +1,7 @@
 # Template file for 'opencolorio'
 pkgname=opencolorio
-version=1.0.8
-revision=2
+version=1.0.9
+revision=1
 wrksrc=OpenColorIO-${version}
 build_style=cmake
 configure_args="-DUSE_EXTERNAL_TINYXML=ON -DUSE_EXTERNAL_LCMS=ON"
@@ -16,7 +16,7 @@ maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="openimageio"
 homepage="http://opencolorio.org"
 distfiles="https://github.com/imageworks/OpenColorIO/archive/v${version}.tar.gz"
-checksum=7bc010f11c033a1d5d37da1f45f83f146458f76dc509c727414df34622f0a736
+checksum=27c81e691c15753cd2b560c2ca4bd5679a60c2350eedd43c99d44ca25d65ea7f
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
does this need revbump for openimageio and blender?