### PR TITLE
New package: jbigkit-2.1

### DIFF
--- a/srcpkgs/jbigkit-devel
+++ b/srcpkgs/jbigkit-devel
@@ -1,0 +1,1 @@
+jbigkit/

--- a/srcpkgs/jbigkit/template
+++ b/srcpkgs/jbigkit/template
@@ -1,0 +1,38 @@
+# Template file for 'jbigkit'
+pkgname=jbigkit
+version=2.1
+revision=1
+build_style=gnu-makefile
+short_desc="Data compression library/utilities for bi-level high-resolution images"
+maintainer="Andrea Brancaleoni <miwaxe@gmail.com>"
+license="GPL-3"
+homepage="http://www.cl.cam.ac.uk/~mgk25/jbigkit"
+distfiles="http://www.cl.cam.ac.uk/~mgk25/download/jbigkit-$version.tar.gz"
+checksum=de7106b6bfaf495d6865c7dd7ac6ca1381bd12e0d81405ea81e7f2167263d932
+
+do_build() {
+	CFLAGS+=-I${wrksrc}/libjbig make -e
+}
+
+do_install() {
+	# Install pbm tools
+	for tool in $(find pbmtools/ -executable -type f); do
+		vbin $tool
+	done
+	# Install man pages
+	for manp in pbmtools/*.{1,5}; do
+		vman $manp
+	done
+}
+
+jbigkit-devel_package() {
+	short_desc+=" - development files"
+	pkg_install() {
+		for lib in libjbig/*.a; do
+			vinstall $lib 644 usr/lib
+		done
+		for header in libjbig/*.h; do
+			vinstall $header 644 usr/include
+		done
+	}
+}


### PR DESCRIPTION
There is a little bug with the build system. I can build with `make` moving to the target directory while ./xbps-src cannot end a vanilla make command w/o errors.

```
cd libjbig && make -e
make[1]: Entering directory '/builddir/jbigkit-2.1/libjbig'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/builddir/jbigkit-2.1/libjbig'
cd pbmtools && make -e
make[1]: Entering directory '/builddir/jbigkit-2.1/pbmtools'
cc -O2 -W -Wno-unused-result      -c -o pbmtojbg.o pbmtojbg.c
pbmtojbg.c:11:18: fatal error: jbig.h: No such file or directory
 #include "jbig.h"
```

jbig.h is provided by jbigkit itself.