### PR TITLE
New Package: CuteMarkEd-0.11.0

### DIFF
--- a/srcpkgs/CuteMarkEd/template
+++ b/srcpkgs/CuteMarkEd/template
@@ -1,0 +1,27 @@
+# Template file for 'CuteMarkEd'
+pkgname=CuteMarkEd
+version=v0.11.0
+revision=1
+wrksrc="${pkgname}-${version#?}"
+hostmakedepends="pkg-config qt-qmake"
+makedepends="qt5-devel qt5-tools-devel qt5-webkit-devel discount-devel hunspell-devel"
+depends="desktop-file-utils"
+short_desc="A Markdown editor with live HTML preview"
+maintainer="Logen K <logen@sudotask.com>"
+license="GPL-2"
+homepage="http://cloose.github.io/CuteMarkEd/"
+distfiles="https://github.com/cloose/${pkgname}/archive/${version}.tar.gz"
+checksum=c6396d3807417ffe63fcbe3e84a8c1dc7d38bd7f5dada0c75de4f374318831a5
+
+do_configure() {
+	qmake QMAKE_CFLAGS="${CFLAGS}" QMAKE_CXXFLAGS="${CXXFLAGS}" QMAKE_LFLAGS="${LDFLAGS}" QMAKE_STRIP=""
+}
+
+do_build() {
+	make ${makejobs}
+}
+
+do_install() {
+	make INSTALL_ROOT=${DESTDIR} install
+}
+

--- a/srcpkgs/cutemarked/template
+++ b/srcpkgs/cutemarked/template
@@ -3,6 +3,7 @@ pkgname=cutemarked
 version=v0.11.0
 revision=1
 wrksrc="CuteMarkEd-${version#?}"
+nocross=yes
 hostmakedepends="pkg-config qt-qmake"
 makedepends="qt5-devel qt5-tools-devel qt5-webkit-devel discount-devel hunspell-devel"
 depends="desktop-file-utils"

--- a/srcpkgs/cutemarked/template
+++ b/srcpkgs/cutemarked/template
@@ -1,8 +1,8 @@
-# Template file for 'CuteMarkEd'
-pkgname=CuteMarkEd
+# Template file for 'cutemarked'
+pkgname=cutemarked
 version=v0.11.0
 revision=1
-wrksrc="${pkgname}-${version#?}"
+wrksrc="CuteMarkEd-${version#?}"
 hostmakedepends="pkg-config qt-qmake"
 makedepends="qt5-devel qt5-tools-devel qt5-webkit-devel discount-devel hunspell-devel"
 depends="desktop-file-utils"


### PR DESCRIPTION
closes #1401 

I want to point out line 5.

I did a "#?" to get rid of the "v" in the version string.  Is this fine?  Or is another way prefered to drop the first letter from the version string? 