### PR TITLE
libXxf86vm: unbreak musl cross compilation

### DIFF
--- a/srcpkgs/libXxf86vm/template
+++ b/srcpkgs/libXxf86vm/template
@@ -1,8 +1,9 @@
 # Template build file for 'libXxf86vm'.
 pkgname=libXxf86vm
 version=1.1.4
-revision=1
+revision=2
 build_style=gnu-configure
+configure_args="--enable-malloc0returnsnull"
 hostmakedepends="pkg-config"
 makedepends="xf86vidmodeproto libXext-devel"
 short_desc="Library for the XFree86-VidMode X extension"


### PR DESCRIPTION
This is similar to issue #1399 - when cross-compiling, you can't test the behavior of malloc(0)