### PR TITLE
new package: argp-standalone

### DIFF
--- a/srcpkgs/argp-standalone/template
+++ b/srcpkgs/argp-standalone/template
@@ -1,0 +1,19 @@
+# Template file for 'argp-standalone'
+pkgname=argp-standalone
+version=1.3
+revision=1
+build_style=gnu-configure
+short_desc="Implementation of ARGP"
+maintainer="John Regan <john@jrjrtech.com>"
+homepage="https://www.freshports.org/devel/argp-standalone/"
+license="Public Domain"
+distfiles="http://www.lysator.liu.se/~nisse/misc/argp-standalone-${version}.tar.gz"
+checksum=dec79694da1319acd2238ce95df57f3680fea2482096e483323fddf3d818d8be
+
+CFLAGS="-fPIC"
+
+do_install() {
+	vinstall ${wrksrc}/libargp.a 644 usr/lib
+	vinstall ${wrksrc}/argp.h 644 usr/include
+}
+


### PR DESCRIPTION
This is an implementation of argp, for libc implementations that lack it (musl)