### PR TITLE
llvm: fix cross-compilation under musl

### DIFF
--- a/srcpkgs/llvm/files/patches/cfe/cfe-001-fix-stdint.patch
+++ b/srcpkgs/llvm/files/patches/cfe/cfe-001-fix-stdint.patch
@@ -1,0 +1,29 @@
+diff --git lib/Headers/stdint.h lib/Headers/stdint.h
+index 0303db9..8ca28df 100644
+--- lib/Headers/stdint.h
++++ lib/Headers/stdint.h
+@@ -22,8 +22,6 @@
+  *
+ \*===----------------------------------------------------------------------===*/
+ 
+-#ifndef __CLANG_STDINT_H
+-#define __CLANG_STDINT_H
+ 
+ /* If we're hosted, fall back to the system's stdint.h, which might have
+  * additional definitions.
+@@ -72,6 +70,8 @@
+ # endif
+ 
+ #else
++#ifndef __CLANG_STDINT_H
++#define __CLANG_STDINT_H
+ 
+ /* C99 7.18.1.1 Exact-width integer types.
+  * C99 7.18.1.2 Minimum-width integer types.
+@@ -703,5 +703,5 @@ typedef __UINTMAX_TYPE__ uintmax_t;
+ #define INTMAX_C(v)   __INTN_C(__INTMAX_WIDTH__, v)
+ #define UINTMAX_C(v) __UINTN_C(__INTMAX_WIDTH__, v)
+ 
+-#endif /* __STDC_HOSTED__ */
+ #endif /* __CLANG_STDINT_H */
++#endif /* __STDC_HOSTED__ */

--- a/srcpkgs/llvm/files/patches/cfe/cfe-002-default-runtime-compiler-rt.patch
+++ b/srcpkgs/llvm/files/patches/cfe/cfe-002-default-runtime-compiler-rt.patch
@@ -1,0 +1,27 @@
+diff --git lib/Driver/ToolChains.cpp lib/Driver/ToolChains.cpp
+index f789fd5..07fc182 100644
+--- lib/Driver/ToolChains.cpp
++++ lib/Driver/ToolChains.cpp
+@@ -3385,6 +3385,10 @@ void Linux::AddClangCXXStdlibIncludeArgs(const ArgList &DriverArgs,
+   }
+ }
+ 
++ToolChain::RuntimeLibType Linux::GetDefaultRuntimeLibType() const {
++  return ToolChain::RLT_CompilerRT;
++}
++
+ bool Linux::isPIEDefault() const {
+   return getSanitizerArgs().requiresPIE();
+ }
+diff --git lib/Driver/ToolChains.h lib/Driver/ToolChains.h
+index 47fb10d..88aee51 100644
+--- lib/Driver/ToolChains.h
++++ lib/Driver/ToolChains.h
+@@ -640,6 +640,7 @@ public:
+   void
+   AddClangCXXStdlibIncludeArgs(const llvm::opt::ArgList &DriverArgs,
+                                llvm::opt::ArgStringList &CC1Args) const override;
++  RuntimeLibType GetDefaultRuntimeLibType() const override;
+   bool isPIEDefault() const override;
+ 
+   std::string Linker;

--- a/srcpkgs/llvm/files/patches/cfe/cfe-003-fix-unwind-chain-inclusion.patch
+++ b/srcpkgs/llvm/files/patches/cfe/cfe-003-fix-unwind-chain-inclusion.patch
@@ -1,0 +1,33 @@
+diff --git lib/Headers/unwind.h lib/Headers/unwind.h
+index 90aca16..ef96969 100644
+--- lib/Headers/unwind.h
++++ lib/Headers/unwind.h
+@@ -23,9 +23,6 @@
+ 
+ /* See "Data Definitions for libgcc_s" in the Linux Standard Base.*/
+ 
+-#ifndef __CLANG_UNWIND_H
+-#define __CLANG_UNWIND_H
+-
+ #if defined(__APPLE__) && __has_include_next(<unwind.h>)
+ /* Darwin (from 11.x on) provide an unwind.h. If that's available,
+  * use it. libunwind wraps some of its definitions in #ifdef _GNU_SOURCE,
+@@ -53,6 +50,9 @@
+ # endif
+ #else
+ 
++#ifndef __CLANG_UNWIND_H
++#define __CLANG_UNWIND_H
++
+ #include <stdint.h>
+ 
+ #ifdef __cplusplus
+@@ -277,6 +277,7 @@ _Unwind_Ptr _Unwind_GetTextRelBase(struct _Unwind_Context *);
+ }
+ #endif
+ 
++#endif /* __CLANG_UNWIND_H */
++
+ #endif
+ 
+-#endif /* __CLANG_UNWIND_H */

--- a/srcpkgs/llvm/files/patches/cfe/cfe-004-add-musl-triples.patch
+++ b/srcpkgs/llvm/files/patches/cfe/cfe-004-add-musl-triples.patch
@@ -1,0 +1,37 @@
+diff --git lib/Driver/ToolChains.cpp lib/Driver/ToolChains.cpp
+index 07fc182..232f99e 100644
+--- lib/Driver/ToolChains.cpp
++++ lib/Driver/ToolChains.cpp
+@@ -1296,7 +1296,10 @@ bool Generic_GCC::GCCInstallationDetector::getBiarchSibling(Multilib &M) const {
+   static const char *const ARMTriples[] = { "arm-linux-gnueabi",
+                                             "arm-linux-androideabi" };
+   static const char *const ARMHFTriples[] = { "arm-linux-gnueabihf",
+-                                              "armv7hl-redhat-linux-gnueabi" };
++                                              "armv7hl-redhat-linux-gnueabi",
++                                              "armv6-linux-musleabihf",
++                                              "armv7-linux-musleabihf",
++                                              "arm-linux-musleabihf" };
+   static const char *const ARMebLibDirs[] = { "/lib" };
+   static const char *const ARMebTriples[] = { "armeb-linux-gnueabi",
+                                               "armeb-linux-androideabi" };
+@@ -1308,7 +1311,8 @@ bool Generic_GCC::GCCInstallationDetector::getBiarchSibling(Multilib &M) const {
+     "x86_64-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-pc-linux-gnu",
+     "x86_64-redhat-linux6E", "x86_64-redhat-linux", "x86_64-suse-linux",
+     "x86_64-manbo-linux-gnu", "x86_64-linux-gnu", "x86_64-slackware-linux",
+-    "x86_64-linux-android", "x86_64-unknown-linux"
++    "x86_64-linux-android", "x86_64-linux-musl", "x86_64-pc-linux-musl",
++    "x86_64-unknown-linux"
+   };
+   static const char *const X32LibDirs[] = { "/libx32" };
+   static const char *const X86LibDirs[] = { "/lib32", "/lib" };
+@@ -1316,7 +1320,9 @@ bool Generic_GCC::GCCInstallationDetector::getBiarchSibling(Multilib &M) const {
+     "i686-linux-gnu", "i686-pc-linux-gnu", "i486-linux-gnu", "i386-linux-gnu",
+     "i386-redhat-linux6E", "i686-redhat-linux", "i586-redhat-linux",
+     "i386-redhat-linux", "i586-suse-linux", "i486-slackware-linux",
+-    "i686-montavista-linux", "i686-linux-android", "i586-linux-gnu"
++    "i686-montavista-linux", "i686-linux-android", "i586-linux-gnu",
++    "i486-linux-musl", "i486-pc-linux-musl",
++    "i686-linux-musl", "i686-pc-linux-musl"
+   };
+ 
+   static const char *const MIPSLibDirs[] = { "/lib" };

--- a/srcpkgs/llvm/files/patches/cfe/cfe-005-fix-dynamic-linker-paths.patch
+++ b/srcpkgs/llvm/files/patches/cfe/cfe-005-fix-dynamic-linker-paths.patch
@@ -1,0 +1,59 @@
+diff --git lib/Driver/Tools.cpp lib/Driver/Tools.cpp
+index 75eef9e..4f32678 100644
+--- lib/Driver/Tools.cpp
++++ lib/Driver/Tools.cpp
+@@ -7282,8 +7282,14 @@ static std::string getLinuxDynamicLinker(const ArgList &Args,
+       return "/system/bin/linker64";
+     else
+       return "/system/bin/linker";
+-  } else if (ToolChain.getArch() == llvm::Triple::x86 ||
+-             ToolChain.getArch() == llvm::Triple::sparc)
++  } else if (ToolChain.getArch() == llvm::Triple::x86) {
++    switch (ToolChain.getTriple().getEnvironment()) {
++    case llvm::Triple::Musl:
++      return "/lib/ld-musl-i386.so.1";
++    default:
++      return "/lib/ld-linux.so.2";
++    }
++  } else if (ToolChain.getArch() == llvm::Triple::sparc)
+     return "/lib/ld-linux.so.2";
+   else if (ToolChain.getArch() == llvm::Triple::aarch64)
+     return "/lib/ld-linux-aarch64.so.1";
+@@ -7291,10 +7297,17 @@ static std::string getLinuxDynamicLinker(const ArgList &Args,
+     return "/lib/ld-linux-aarch64_be.so.1";
+   else if (ToolChain.getArch() == llvm::Triple::arm ||
+            ToolChain.getArch() == llvm::Triple::thumb) {
+-    if (ToolChain.getTriple().getEnvironment() == llvm::Triple::GNUEABIHF)
+-      return "/lib/ld-linux-armhf.so.3";
+-    else
++    switch (ToolChain.getTriple().getEnvironment()) {
++    case llvm::Triple::Musl:
++    case llvm::Triple::MuslEABI:
++      return "/lib/ld-musl-arm.so.1";
++    case llvm::Triple::MuslEABIHF:
++      return "/lib/ld-musl-armhf.so.1";
++    case llvm::Triple::GNUEABIHF:
++      return "/lib/ld-linux-armhf.so.1";
++    default:
+       return "/lib/ld-linux.so.3";
++    }
+   } else if (ToolChain.getArch() == llvm::Triple::armeb ||
+              ToolChain.getArch() == llvm::Triple::thumbeb) {
+     if (ToolChain.getTriple().getEnvironment() == llvm::Triple::GNUEABIHF)
+@@ -7339,8 +7352,14 @@ static std::string getLinuxDynamicLinker(const ArgList &Args,
+   else if (ToolChain.getArch() == llvm::Triple::x86_64 &&
+            ToolChain.getTriple().getEnvironment() == llvm::Triple::GNUX32)
+     return "/libx32/ld-linux-x32.so.2";
+-  else
+-    return "/lib64/ld-linux-x86-64.so.2";
++  else {
++    switch (ToolChain.getTriple().getEnvironment()) {
++    case llvm::Triple::Musl:
++      return "/lib/ld-musl-x86_64.so.1";
++    default:
++      return "/lib64/ld-linux-x86-64.so.2";
++    }
++  }
+ }
+ 
+ static void AddRunTimeLibs(const ToolChain &TC, const Driver &D,

--- a/srcpkgs/llvm/files/patches/cfe/cfe-006-no-use-cxa-atexit.patch
+++ b/srcpkgs/llvm/files/patches/cfe/cfe-006-no-use-cxa-atexit.patch
@@ -1,0 +1,14 @@
+diff --git lib/Driver/Tools.cpp lib/Driver/Tools.cpp
+index 3e71522..5a5cba7 100644
+--- lib/Driver/Tools.cpp
++++ lib/Driver/Tools.cpp
+@@ -3978,7 +3978,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
+                     options::OPT_fno_use_cxa_atexit,
+                     !IsWindowsCygnus && !IsWindowsGNU &&
+                     getToolChain().getArch() != llvm::Triple::hexagon &&
+-                    getToolChain().getArch() != llvm::Triple::xcore) ||
++                    getToolChain().getArch() != llvm::Triple::xcore &&
++                    getToolChain().getTriple().getEnvironment() != llvm::Triple::Musl) ||
+       KernelOrKext)
+     CmdArgs.push_back("-fno-use-cxa-atexit");
+ 

--- a/srcpkgs/llvm/files/patches/cfe/cfe-007-musl-use-init-array.patch
+++ b/srcpkgs/llvm/files/patches/cfe/cfe-007-musl-use-init-array.patch
@@ -1,0 +1,14 @@
+diff --git lib/Driver/ToolChains.cpp lib/Driver/ToolChains.cpp
+index 7b15c54..3155ade 100644
+--- lib/Driver/ToolChains.cpp
++++ lib/Driver/ToolChains.cpp
+@@ -2088,7 +2088,8 @@ void Generic_ELF::addClangTargetOptions(const ArgList &DriverArgs,
+       getTriple().getArch() == llvm::Triple::aarch64_be ||
+       (getTriple().getOS() == llvm::Triple::Linux &&
+        (!V.isOlderThan(4, 7, 0) ||
+-        getTriple().getEnvironment() == llvm::Triple::Android));
++        getTriple().getEnvironment() == llvm::Triple::Android ||
++        getTriple().getEnvironment() == llvm::Triple::Musl));
+ 
+   if (DriverArgs.hasFlag(options::OPT_fuse_init_array,
+                          options::OPT_fno_use_init_array,

--- a/srcpkgs/llvm/files/patches/cfe/cfe-008-remove-lgcc-when-using-compiler-rt.patch
+++ b/srcpkgs/llvm/files/patches/cfe/cfe-008-remove-lgcc-when-using-compiler-rt.patch
@@ -1,0 +1,23 @@
+diff --git lib/Driver/Tools.cpp lib/Driver/Tools.cpp
+index 5a5cba7..701ac12 100644
+--- lib/Driver/Tools.cpp
++++ lib/Driver/Tools.cpp
+@@ -2157,12 +2157,12 @@ static void addClangRT(const ToolChain &TC, const ArgList &Args,
+                        ArgStringList &CmdArgs) {
+   CmdArgs.push_back(Args.MakeArgString(getCompilerRT(TC, "builtins")));
+ 
+-  if (!TC.getTriple().isOSWindows()) {
+-    // FIXME: why do we link against gcc when we are using compiler-rt?
+-    CmdArgs.push_back("-lgcc_s");
+-    if (TC.getDriver().CCCIsCXX())
+-      CmdArgs.push_back("-lgcc_eh");
+-  }
++  // if (!TC.getTriple().isOSWindows()) {
++  //   // FIXME: why do we link against gcc when we are using compiler-rt?
++  //   CmdArgs.push_back("-lgcc_s");
++  //   if (TC.getDriver().CCCIsCXX())
++  //     CmdArgs.push_back("-lgcc_eh");
++  // }
+ }
+ 
+ static void addProfileRT(const ToolChain &TC, const ArgList &Args,

--- a/srcpkgs/llvm/files/patches/compiler-rt/compiler-rt-002-musl-no-dlvsym.patch
+++ b/srcpkgs/llvm/files/patches/compiler-rt/compiler-rt-002-musl-no-dlvsym.patch
@@ -1,0 +1,13 @@
+diff --git lib/interception/interception_linux.cc lib/interception/interception_linux.cc
+index 6e908ac..7fcf2a6 100644
+--- lib/interception/interception_linux.cc
++++ lib/interception/interception_linux.cc
+@@ -24,7 +24,7 @@ bool GetRealFunctionAddress(const char *func_name, uptr *func_addr,
+   return real == wrapper;
+ }
+ 
+-#if !defined(__ANDROID__)  // android does not have dlvsym
++#if 0 // !defined(__ANDROID__)  // android does not have dlvsym
+ void *GetFuncAddrVer(const char *func_name, const char *ver) {
+   return dlvsym(RTLD_NEXT, func_name, ver);
+ }

--- a/srcpkgs/llvm/files/patches/compiler-rt/compiler-rt_musl_001-disable-sanitizers.patch
+++ b/srcpkgs/llvm/files/patches/compiler-rt/compiler-rt_musl_001-disable-sanitizers.patch
@@ -1,0 +1,25 @@
+diff --git lib/Makefile.mk lib/Makefile.mk
+index ed9690d..aacb2b1 100644
+--- lib/Makefile.mk
++++ lib/Makefile.mk
+@@ -10,13 +10,13 @@
+ SubDirs :=
+ 
+ # Add submodules.
+-SubDirs += asan
++# SubDirs += asan
+ SubDirs += builtins
+-SubDirs += dfsan
++# SubDirs += dfsan
+ SubDirs += interception
+-SubDirs += lsan
+-SubDirs += msan
++# SubDirs += lsan
++# SubDirs += msan
+ SubDirs += profile
+-SubDirs += sanitizer_common
+-SubDirs += tsan
+-SubDirs += ubsan
++# SubDirs += sanitizer_common
++# SubDirs += tsan
++# SubDirs += ubsan

--- a/srcpkgs/llvm/files/patches/llvm/llvm-001-fix-gcc-4.9.patch
+++ b/srcpkgs/llvm/files/patches/llvm/llvm-001-fix-gcc-4.9.patch
@@ -1,0 +1,26 @@
+diff --git include/llvm/IR/LegacyPassNameParser.h include/llvm/IR/LegacyPassNameParser.h
+index e2e4912..a07e3fd 100644
+--- include/llvm/IR/LegacyPassNameParser.h
++++ include/llvm/IR/LegacyPassNameParser.h
+@@ -95,6 +95,8 @@ private:
+   }
+ };
+ 
++EXTERN_TEMPLATE_INSTANTIATION(class cl::parser<const PassInfo *>);
++
+ ///===----------------------------------------------------------------------===//
+ /// FilteredPassNameParser class - Make use of the pass registration
+ /// mechanism to automatically add a command line argument to opt for
+diff --git lib/IR/Pass.cpp lib/IR/Pass.cpp
+index 91d86ae..00ce223 100644
+--- lib/IR/Pass.cpp
++++ lib/IR/Pass.cpp
+@@ -234,6 +234,8 @@ PassNameParser::~PassNameParser() {
+   // attempting to remove the registration listener is an error.
+ }
+ 
++TEMPLATE_INSTANTIATION(class cl::parser<const PassInfo *>);
++
+ //===----------------------------------------------------------------------===//
+ //   AnalysisUsage Class Implementation
+ //

--- a/srcpkgs/llvm/files/patches/llvm/llvm-002-musl-triple.patch
+++ b/srcpkgs/llvm/files/patches/llvm/llvm-002-musl-triple.patch
@@ -1,0 +1,75 @@
+diff --git include/llvm/ADT/Triple.h include/llvm/ADT/Triple.h
+index 8a68599..072623c 100644
+--- include/llvm/ADT/Triple.h
++++ include/llvm/ADT/Triple.h
+@@ -154,6 +154,10 @@ public:
+     EABIHF,
+     Android,
+ 
++    Musl,
++    MuslEABI,
++    MuslEABIHF,
++
+     MSVC,
+     Itanium,
+     Cygnus,
+diff --git lib/Support/Triple.cpp lib/Support/Triple.cpp
+index 0838e90..4be78e5 100644
+--- lib/Support/Triple.cpp
++++ lib/Support/Triple.cpp
+@@ -175,6 +175,9 @@ const char *Triple::getEnvironmentTypeName(EnvironmentType Kind) {
+   case CODE16: return "code16";
+   case EABI: return "eabi";
+   case EABIHF: return "eabihf";
++  case Musl: return "musl";
++  case MuslEABIHF: return "musleabihf";
++  case MuslEABI: return "musleabi";
+   case Android: return "android";
+   case MSVC: return "msvc";
+   case Itanium: return "itanium";
+@@ -375,6 +378,9 @@ static Triple::EnvironmentType parseEnvironment(StringRef EnvironmentName) {
+     .StartsWith("code16", Triple::CODE16)
+     .StartsWith("gnu", Triple::GNU)
+     .StartsWith("android", Triple::Android)
++    .StartsWith("musleabihf", Triple::MuslEABIHF)
++    .StartsWith("musleabi", Triple::MuslEABI)
++    .StartsWith("musl", Triple::Musl)
+     .StartsWith("msvc", Triple::MSVC)
+     .StartsWith("itanium", Triple::Itanium)
+     .StartsWith("cygnus", Triple::Cygnus)
+diff --git lib/Target/ARM/ARMSubtarget.h lib/Target/ARM/ARMSubtarget.h
+index dbacd4d..b330be5 100644
+--- lib/Target/ARM/ARMSubtarget.h
++++ lib/Target/ARM/ARMSubtarget.h
+@@ -369,8 +369,10 @@ public:
+   bool isTargetEHABICompatible() const {
+     return (TargetTriple.getEnvironment() == Triple::EABI ||
+             TargetTriple.getEnvironment() == Triple::GNUEABI ||
++            TargetTriple.getEnvironment() == Triple::MuslEABI ||
+             TargetTriple.getEnvironment() == Triple::EABIHF ||
+             TargetTriple.getEnvironment() == Triple::GNUEABIHF ||
++            TargetTriple.getEnvironment() == Triple::MuslEABIHF ||
+             TargetTriple.getEnvironment() == Triple::Android) &&
+            !isTargetDarwin() && !isTargetWindows();
+   }
+@@ -379,6 +381,7 @@ public:
+     // FIXME: this is invalid for WindowsCE
+     return TargetTriple.getEnvironment() == Triple::GNUEABIHF ||
+            TargetTriple.getEnvironment() == Triple::EABIHF ||
++           TargetTriple.getEnvironment() == Triple::MuslEABIHF ||
+            isTargetWindows();
+   }
+   bool isTargetAndroid() const {
+diff --git lib/Target/ARM/ARMTargetMachine.cpp lib/Target/ARM/ARMTargetMachine.cpp
+index 7a8181b..ce5ceb9 100644
+--- lib/Target/ARM/ARMTargetMachine.cpp
++++ lib/Target/ARM/ARMTargetMachine.cpp
+@@ -87,6 +87,8 @@ computeTargetABI(const Triple &TT, StringRef CPU,
+     case llvm::Triple::GNUEABIHF:
+     case llvm::Triple::EABIHF:
+     case llvm::Triple::EABI:
++    case llvm::Triple::MuslEABI:
++    case llvm::Triple::MuslEABIHF:
+       TargetABI = ARMBaseTargetMachine::ARM_ABI_AAPCS;
+       break;
+     case llvm::Triple::GNU:

--- a/srcpkgs/llvm/files/patches/llvm/llvm-003-musl.patch
+++ b/srcpkgs/llvm/files/patches/llvm/llvm-003-musl.patch
@@ -1,0 +1,80 @@
+diff --git include/llvm/Target/TargetLibraryInfo.h include/llvm/Target/TargetLibraryInfo.h
+index 46f87b9..41ac5fd 100644
+--- include/llvm/Target/TargetLibraryInfo.h
++++ include/llvm/Target/TargetLibraryInfo.h
+@@ -13,6 +13,15 @@
+ #include "llvm/ADT/DenseMap.h"
+ #include "llvm/Pass.h"
+ 
++#undef fopen64
++#undef fseeko64
++#undef fstat64
++#undef fstatvfs64
++#undef ftello64
++#undef lstat64
++#undef stat64
++#undef tmpfile64
++
+ namespace llvm {
+   class Triple;
+ 
+diff --git lib/Support/DynamicLibrary.cpp lib/Support/DynamicLibrary.cpp
+index d2b551e..4634a13 100644
+--- lib/Support/DynamicLibrary.cpp
++++ lib/Support/DynamicLibrary.cpp
+@@ -138,7 +138,7 @@ void* DynamicLibrary::SearchForAddressOfSymbol(const char *symbolName) {
+ 
+ // This macro returns the address of a well-known, explicit symbol
+ #define EXPLICIT_SYMBOL(SYM) \
+-   if (!strcmp(symbolName, #SYM)) return &SYM
++   if (!strcmp(symbolName, #SYM)) return (void *) &SYM
+ 
+ // On linux we have a weird situation. The stderr/out/in symbols are both
+ // macros and global variables because of standards requirements. So, we
+diff --git lib/Support/Unix/Signals.inc lib/Support/Unix/Signals.inc
+index e8f4643..8a320ef 100644
+--- lib/Support/Unix/Signals.inc
++++ lib/Support/Unix/Signals.inc
+@@ -416,7 +416,7 @@ static bool printSymbolizedStackTrace(void **StackTrace, int Depth, FILE *FD) {
+ // On glibc systems we have the 'backtrace' function, which works nicely, but
+ // doesn't demangle symbols.
+ void llvm::sys::PrintStackTrace(FILE *FD) {
+-#if defined(HAVE_BACKTRACE) && defined(ENABLE_BACKTRACES)
++#if defined(__GLIBC__) && defined(HAVE_BACKTRACE) && defined(ENABLE_BACKTRACES)
+   static void* StackTrace[256];
+   // Use backtrace() to output a backtrace on Linux systems with glibc.
+   int depth = backtrace(StackTrace,
+diff --git lib/Target/TargetLibraryInfo.cpp lib/Target/TargetLibraryInfo.cpp
+index c0abdbd..ed908f8 100644
+--- lib/Target/TargetLibraryInfo.cpp
++++ lib/Target/TargetLibraryInfo.cpp
+@@ -664,14 +664,15 @@ static void initialize(TargetLibraryInfo &TLI, const Triple &T,
+   }
+ 
+   // The following functions are available on at least Linux:
+-  if (!T.isOSLinux()) {
++  if (!T.isOSLinux())
++    TLI.setUnavailable(LibFunc::memalign);
++  if (1 /*!T.isGlibc()*/) {
+     TLI.setUnavailable(LibFunc::dunder_strdup);
+     TLI.setUnavailable(LibFunc::dunder_strtok_r);
+     TLI.setUnavailable(LibFunc::dunder_isoc99_scanf);
+     TLI.setUnavailable(LibFunc::dunder_isoc99_sscanf);
+     TLI.setUnavailable(LibFunc::under_IO_getc);
+     TLI.setUnavailable(LibFunc::under_IO_putc);
+-    TLI.setUnavailable(LibFunc::memalign);
+     TLI.setUnavailable(LibFunc::fopen64);
+     TLI.setUnavailable(LibFunc::fseeko64);
+     TLI.setUnavailable(LibFunc::fstat64);
+diff --git utils/unittest/googletest/src/gtest.cc utils/unittest/googletest/src/gtest.cc
+index bf850c6..9e9088c 100644
+--- utils/unittest/googletest/src/gtest.cc
++++ utils/unittest/googletest/src/gtest.cc
+@@ -120,6 +120,7 @@
+ 
+ #if GTEST_CAN_STREAM_RESULTS_
+ # include <arpa/inet.h>  // NOLINT
++# include <sys/socket.h>  // NOLINT
+ # include <netdb.h>  // NOLINT
+ #endif
+ 

--- a/srcpkgs/llvm/template
+++ b/srcpkgs/llvm/template
@@ -2,7 +2,7 @@
 pkgname=llvm
 version=3.6.0
 wrksrc="llvm-${version}.src"
-revision=1
+revision=2
 lib32disabled=yes
 configure_args="--disable-expensive-checks --disable-debug-runtime
  --enable-bindings=none --enable-optimized --enable-shared --enable-libffi
@@ -34,6 +34,25 @@ if [ -z "$CROSS_BUILD" ]; then
 fi
 
 post_extract() {
+	# patches
+	cd ${XBPS_BUILDDIR}/llvm-${version}.src
+	for i in ${FILESDIR}/patches/llvm/llvm-*.patch; do
+		patch -sNp0 -i ${i}
+	done
+
+	cd ${XBPS_BUILDDIR}/compiler-rt-${version}.src
+	for i in ${FILESDIR}/patches/compiler-rt/compiler-rt-*.patch; do
+		patch -sNp0 -i ${i}
+	done
+	case "$XBPS_TARGET_MACHINE" in
+		*-musl) patch -sNp0 -i "${FILESDIR}/patches/compiler-rt/compiler-rt_musl_001-disable-sanitizers.patch" ;;
+	esac
+
+	cd ${XBPS_BUILDDIR}/cfe-${version}.src
+	for i in ${FILESDIR}/patches/cfe/cfe-*.patch; do
+		patch -sNp0 -i ${i}
+	done
+
 	# Move clang files into the llvm source.
 	if [ -d ${XBPS_BUILDDIR}/cfe-${version}.src ]; then
 		mv ${XBPS_BUILDDIR}/cfe-${version}.src ${wrksrc}/tools/clang


### PR DESCRIPTION
This uses patches from Alpine Linux's LLVM package, with the Alpine-specific stuff removed: http://git.alpinelinux.org/cgit/aports/tree/testing/llvm