### PR TITLE
livestreamer: updated to 1.12.2

### DIFF
--- a/srcpkgs/livestreamer/template
+++ b/srcpkgs/livestreamer/template
@@ -1,6 +1,6 @@
 # Template file for 'livestreamer'
 pkgname=livestreamer
-version=1.12.1
+version=1.12.2
 revision=1
 build_style=python-module
 pycompile_module="livestreamer livestreamer_cli"
@@ -13,4 +13,4 @@ maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="BSD"
 homepage="http://livestreamer.tanuki.se"
 distfiles="https://github.com/chrippa/livestreamer/archive/v${version}.tar.gz"
-checksum=3255bc78adbdc233b9586d3b5348134ab5ae656580c9f2489d03068c369a0fb6
+checksum=4d6e2954abff198dce082f34a19a54dbf6fb95ca53567d92a661e527fe68e3ba


### PR DESCRIPTION
https://github.com/chrippa/livestreamer/releases new version released 4 days ago.