### PR TITLE
distcc: remove --no-fork option

### DIFF
--- a/srcpkgs/distcc/files/distccd/run
+++ b/srcpkgs/distcc/files/distccd/run
@@ -4,7 +4,6 @@ USER="nobody"
 OPTIONS="--no-detach"
 OPTIONS="$OPTIONS --daemon"
 OPTIONS="$OPTIONS --user $USER"
-OPTIONS="$OPTIONS --no-fork"
 ALLOW_FILE=/etc/distcc/clients.allow
 if [ -f "$ALLOW_FILE" ]; then
         ALLOW_OPTIONS=$(sed -e 's/#.*$//' -e '/^\s*$/d' -e 's/^/--allow /' < $ALLOW_FILE)

--- a/srcpkgs/distcc/template
+++ b/srcpkgs/distcc/template
@@ -1,7 +1,7 @@
 # Template file for 'distcc'
 pkgname=distcc
 version=3.2rc1
-revision=9
+revision=10
 build_options="systemd"
 build_style=gnu-configure
 configure_args="--disable-Werror --with-gtk"


### PR DESCRIPTION
With --no-fork distccd will only ever run one job at a time.