### PR TITLE
mediainfo: combine -gui package

### DIFF
--- a/srcpkgs/mediainfo-gui
+++ b/srcpkgs/mediainfo-gui
@@ -1,1 +1,0 @@
-mediainfo

--- a/srcpkgs/mediainfo/template
+++ b/srcpkgs/mediainfo/template
@@ -2,7 +2,7 @@
 
 pkgname=mediainfo
 version=0.7.73
-revision=1
+revision=2
 short_desc="Display technical and tag data for video and audio files"
 homepage="http://mediaarea.net/MediaInfo"
 maintainer="Georg Schabel <gescha@posteo.de>"
@@ -11,35 +11,42 @@ license="BSD"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}_${version}.tar.gz"
 checksum=1fde5b2972d923f7f87c2b2e738e8a086603243770961b077cf558f9836e612e
 
-build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
 makedepends="libmediainfo-devel zlib-devel
  wxGTK-devel wxWidgets-devel"
+depends="desktop-file-utils hicolor-icon-theme"
 create_wrksrc=yes
-build_wrksrc="MediaInfo/Project/GNU/CLI"
+_gnudir="MediaInfo/Project/GNU"
 
-pre_configure() {
-	autoreconf -fi
+do_configure() {
+	for d in CLI GUI; do
+		cd $wrksrc/$_gnudir/$d
+		autoreconf -fi
+		./configure --prefix=/usr
+	done
+}
+
+do_build() {
+	for d in CLI GUI; do
+		cd $wrksrc/$_gnudir/$d
+		make ${makejobs}
+	done
+}
+
+do_install() {
+	for d in CLI GUI; do
+		cd $wrksrc/$_gnudir/$d
+		make DESTDIR="${DESTDIR}" install
+	done
 }
 
 post_install() {
 	vlicense ${wrksrc}/MediaInfo/License.html
-}
 
-mediainfo-gui_package() {
-	short_desc+=" - GUI version"
-	depends="mediainfo>=${version}_${revision} desktop-file-utils hicolor-icon-theme"
-	pkg_install(){
-		cd ${wrksrc}/MediaInfo/Project/GNU/GUI
-		autoreconf -fi
-		./configure --prefix=/usr
-		make DESTDIR="${DESTDIR}" install
-
-		vmkdir usr/share/icons/hicolor/scalable/apps
-		vinstall ${wrksrc}/MediaInfo/Source/Resource/Image/MediaInfo.svg 644 \
-			usr/share/icons/hicolor/scalable/apps mediainfo.svg
-		vinstall ${wrksrc}/MediaInfo/Source/Resource/Image/MediaInfo.png 644 \
-			usr/share/pixmaps mediainfo-gui.png
-		vinstall mediainfo-gui.desktop 644 usr/share/applications
-	}
+	vmkdir usr/share/icons/hicolor/scalable/apps
+	vinstall ${wrksrc}/MediaInfo/Source/Resource/Image/MediaInfo.svg 644 \
+		usr/share/icons/hicolor/scalable/apps mediainfo.svg
+	vinstall ${wrksrc}/MediaInfo/Source/Resource/Image/MediaInfo.png 644 \
+		usr/share/pixmaps mediainfo-gui.png
+	vinstall ${wrksrc}/$_gnudir/GUI/mediainfo-gui.desktop 644 usr/share/applications
 }

--- a/srcpkgs/mediainfo/template
+++ b/srcpkgs/mediainfo/template
@@ -17,12 +17,13 @@ makedepends="libmediainfo-devel zlib-devel
 depends="desktop-file-utils hicolor-icon-theme"
 create_wrksrc=yes
 _gnudir="MediaInfo/Project/GNU"
+replaces="mediainfo-gui>=0"
 
 do_configure() {
 	for d in CLI GUI; do
 		cd $wrksrc/$_gnudir/$d
 		autoreconf -fi
-		./configure --prefix=/usr
+		./configure ${configure_args}
 	done
 }
 


### PR DESCRIPTION
I tried a workaround to keep the -gui package with setting a variable in -gui_package and then check for it in do_{build,install}. Didn't work, thus combined them.