### PR TITLE
gnome-disk-utility: add parted as a dependency

### DIFF
--- a/srcpkgs/gnome-disk-utility/template
+++ b/srcpkgs/gnome-disk-utility/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-disk-utility'
 pkgname=gnome-disk-utility
 version=3.14.0
-revision=2
+revision=3
 lib32disabled=yes
 build_style=gnu-configure
 configure_args="--disable-static $(vopt_enable gir introspection)
@@ -11,7 +11,7 @@ hostmakedepends="pkg-config intltool gnome-doc-utils
 makedepends="liblzma-devel gtk+3-devel libcanberra-devel udisks2-devel
  libdvdread-devel libsecret-devel libpwquality-devel libnotify-devel
  gnome-settings-daemon-devel $(vopt_if systemd systemd-devel)"
-depends="hicolor-icon-theme desktop-file-utils"
+depends="hicolor-icon-theme desktop-file-utils parted"
 short_desc="GNOME libraries and applications for dealing with storage devices"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"


### PR DESCRIPTION
parted is required to format or alter partitions.
https://bugs.archlinux.org/task/41446
https://lists.alioth.debian.org/pipermail/pkg-utopia-maintainers/2014-October/017093.html