### PR TITLE
buildbot: terser IRC messages

### DIFF
--- a/srcpkgs/buildbot/patches/terse-irc.patch
+++ b/srcpkgs/buildbot/patches/terse-irc.patch
@@ -1,0 +1,38 @@
+--- buildbot/status/words.py.orig
++++ buildbot/status/words.py
+@@ -439,9 +439,9 @@
+         self.send(r)
+ 
+     results_descriptions = {
+-        SUCCESS: ("Success", 'GREEN'),
+-        WARNINGS: ("Warnings", 'YELLOW'),
+-        FAILURE: ("Failure", 'RED'),
++        SUCCESS: ("OK", 'GREEN'),
++        WARNINGS: ("Warn", 'YELLOW'),
++        FAILURE: ("Fail", 'RED'),
+         EXCEPTION: ("Exception", 'PURPLE'),
+         RETRY: ("Retry", 'AQUA_LIGHT'),
+     }
+@@ -466,19 +466,18 @@
+         results = self.getResultsDescriptionAndColor(build.getResults())
+         if self.reportBuild(builder_name, buildnum):
+             if self.useRevisions:
+-                r = "build containing revision(s) [%s] on %s is complete: %s" % \
++                r = "%s/%s: %s" % \
+                     (buildrevs, builder_name, results[0])
+             else:
+                 r = "build #%d of %s is complete: %s" % \
+                     (buildnum, builder_name, results[0])
+ 
+-            r += ' [%s]' % maybeColorize(" ".join(build.getText()), results[1], self.useColors)
+             buildurl = self.bot.status.getURLForThing(build)
+             if buildurl:
+-                r += "  Build details are at %s" % buildurl
++                r += ": %s" % buildurl
+ 
+             if self.bot.showBlameList and build.getResults() != SUCCESS and len(build.changes) != 0:
+-                r += '  blamelist: ' + ', '.join(list(set([c.who for c in build.changes])))
++                r += '  blame: ' + ', '.join(list(set([c.who for c in build.changes])))
+ 
+             self.send(r)
+ 

--- a/srcpkgs/buildbot/template
+++ b/srcpkgs/buildbot/template
@@ -1,7 +1,7 @@
 # Template file for 'buildbot'
 pkgname=buildbot
 version=0.8.12
-revision=1
+revision=2
 noarch=yes
 build_style=python-module
 hostmakedepends="python"


### PR DESCRIPTION
Yeah, it sucks to patch buildbot...

Example output:

Success:
```
ec76dbe/x86_64-musl_builder OK: http://build.voidlinux.eu/builders/x86_64-musl_builder/builds/227
```

Failure:

```
76d2ec6/x86_64_builder Fail: http://build.voidlinux.eu/builders/x86_64_builder/builds/12260 blame: Juan RP <xtraeme@voidlinux.eu>
```