### PR TITLE
darktable: enable on musl

### DIFF
--- a/srcpkgs/darktable/patches/0001-musl.patch
+++ b/srcpkgs/darktable/patches/0001-musl.patch
@@ -1,0 +1,61 @@
+From 60c3edbc4ccb15680c0305e787bd236933c85bad Mon Sep 17 00:00:00 2001
+From: lemmi <lemmi@nerd2nerd.org>
+Date: Tue, 12 May 2015 08:40:56 +0200
+Subject: [PATCH] musl
+
+
+diff --git src/control/jobs/control_jobs.c src/control/jobs/control_jobs.c
+index ea61eb1..28ec5ea 100644
+--- src/control/jobs/control_jobs.c
++++ src/control/jobs/control_jobs.c
+@@ -941,7 +941,7 @@ static int32_t dt_control_export_job_run(dt_job_t *job)
+   const __attribute__((__unused__)) int num_threads = 1;
+ #if !defined(__SUNOS__) && !defined(__NetBSD__) && !defined(__WIN32__)
+ #pragma omp parallel default(none) private(imgid)                                                            \
+-    shared(control, fraction, w, h, stderr, mformat, mstorage, t, sdata, job, progress, darktable, settings) \
++    shared(control, fraction, w, h, mformat, mstorage, t, sdata, job, progress, darktable, settings) \
+         num_threads(num_threads) if(num_threads > 1)
+ #else
+ #pragma omp parallel private(imgid) shared(control, fraction, w, h, mformat, mstorage, t, sdata, job,        \
+@@ -993,7 +993,6 @@ static int32_t dt_control_export_job_run(dt_job_t *job)
+         if(!g_file_test(imgfilename, G_FILE_TEST_IS_REGULAR))
+         {
+           dt_control_log(_("image `%s' is currently unavailable"), image->filename);
+-          fprintf(stderr, "image `%s' is currently unavailable", imgfilename);
+           // dt_image_remove(imgid);
+           dt_image_cache_read_release(darktable.image_cache, image);
+         }
+diff --git src/develop/blend.c src/develop/blend.c
+index b39afde..e327634 100644
+--- src/develop/blend.c
++++ src/develop/blend.c
+@@ -2276,7 +2276,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
+ 
+ #ifdef _OPENMP
+ #if !defined(__SUNOS__) && !defined(__NetBSD__) && !defined(__WIN32__)
+-#pragma omp parallel for default(none) shared(i, roi_out, o, mask, blend, d, stderr)
++#pragma omp parallel for default(none) shared(i, roi_out, o, mask, blend, d)
+ #else
+ #pragma omp parallel for shared(i, roi_out, o, mask, blend, d)
+ #endif
+@@ -2327,7 +2327,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
+     {
+ #ifdef _OPENMP
+ #if !defined(__SUNOS__) && !defined(__WIN32__)
+-#pragma omp parallel for default(none) shared(roi_out, mask, stderr)
++#pragma omp parallel for default(none) shared(roi_out, mask)
+ #else
+ #pragma omp parallel for shared(roi_out, mask)
+ #endif
+@@ -2342,7 +2342,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
+ /* now apply blending with per-pixel opacity value as defined in mask */
+ #ifdef _OPENMP
+ #if !defined(__SUNOS__) && !defined(__WIN32__)
+-#pragma omp parallel for default(none) shared(i, roi_out, o, mask, blend, stderr)
++#pragma omp parallel for default(none) shared(i, roi_out, o, mask, blend)
+ #else
+ #pragma omp parallel for shared(i, roi_out, o, mask, blend)
+ #endif
+-- 
+2.4.0
+

--- a/srcpkgs/darktable/template
+++ b/srcpkgs/darktable/template
@@ -1,7 +1,7 @@
 # Template file for 'darktable'
 pkgname=darktable
 version=1.6.6
-revision=1
+revision=2
 build_style=cmake
 #this makes sure to use -march=generic and -msse3
 configure_args="-DBINARY_PACKAGE_BUILD=ON"
@@ -15,8 +15,8 @@ makedepends="gtk+-devel glib-devel exiv2-devel lcms2-devel
 	 libwebp-devel libsoup-devel lensfun-devel sqlite-devel librsvg-devel
 	 lua-devel json-glib-devel libgomp-devel colord-devel
 	 libopenjpeg-devel libopenexr-devel libgraphicsmagick-devel
-	 SDL-devel libsecret-devel"
-only_for_archs="i686 x86_64"  # too much SSE2 stuff all over
+	 SDL-devel libsecret-devel glu-devel"
+only_for_archs="i686 x86_64 x86_64-musl"  # too much SSE2 stuff all over
 
 distfiles="https://github.com/darktable-org/darktable/releases/download/release-${version}/darktable-${version}.tar.xz"
 checksum=f85e4b8219677eba34f5a41e1a0784cc6ec06576326a99f04e460a4f41fd21a5


### PR DESCRIPTION
the patch removes unused stderr from the openmp pragma. 
musl defines stderr as (stderr). somehow this is not a valid identifier anymore.
