### PR TITLE
Node add build options

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2041,3 +2041,4 @@ libkasten2core.so.2 okteta-4.14.2_1
 libkasten2controllers.so.2 okteta-4.14.2_1
 libkasten2okteta1gui.so.1 okteta-4.14.2_1
 libkasten2okteta1core.so.1 okteta-4.14.2_1
+libhttp_parser.so.2.5.0 http-parser-2.5.0_1

--- a/srcpkgs/http-parser-devel
+++ b/srcpkgs/http-parser-devel
@@ -1,0 +1,1 @@
+http-parser

--- a/srcpkgs/http-parser/patches/fix-destdir.diff
+++ b/srcpkgs/http-parser/patches/fix-destdir.diff
@@ -1,0 +1,36 @@
+--- Makefile.orig	2015-05-12 09:32:01.346321752 +0200
++++ Makefile	2015-05-12 09:33:29.063315187 +0200
+@@ -43,7 +43,7 @@
+ LDFLAGS_LIB = $(LDFLAGS) -shared
+ 
+ INSTALL ?= install
+-PREFIX ?= $(DESTDIR)/usr/local
++PREFIX ?= /usr/local
+ LIBDIR = $(PREFIX)/lib
+ INCLUDEDIR = $(PREFIX)/include
+ 
+@@ -112,18 +112,18 @@
+ 
+ install: library
+ 	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
+-	$(INSTALL) -D $(SONAME) $(LIBDIR)/$(SONAME)
+-	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.so
++	$(INSTALL) -D $(SONAME) $(DESTDIR)/$(LIBDIR)/$(SONAME)
++	ln -s $(DESTDIR)/$(LIBDIR)/$(SONAME) $(DESTDIR)/$(LIBDIR)/libhttp_parser.so
+ 
+ install-strip: library
+ 	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
+-	$(INSTALL) -D -s $(SONAME) $(LIBDIR)/$(SONAME)
+-	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.so
++	$(INSTALL) -D -s $(SONAME) $(DESTDIR)/$(LIBDIR)/$(SONAME)
++	ln -s $(DESTDIR)/$(LIBDIR)/$(SONAME) $(DESTDIR)/$(LIBDIR)/libhttp_parser.so
+ 
+ uninstall:
+ 	rm $(INCLUDEDIR)/http_parser.h
+-	rm $(LIBDIR)/$(SONAME)
+-	rm $(LIBDIR)/libhttp_parser.so
++	rm $(DESTDIR)/$(LIBDIR)/$(SONAME)
++	rm $(DESTDIR)/$(LIBDIR)/libhttp_parser.so
+ 
+ clean:
+ 	rm -f *.o *.a tags test test_fast test_g \

--- a/srcpkgs/http-parser/template
+++ b/srcpkgs/http-parser/template
@@ -1,0 +1,27 @@
+# Template file for 'http-parser'
+pkgname=http-parser
+version=2.5.0
+revision=1
+build_style=gnu-makefile
+short_desc="HTTP request/response parser for c"
+maintainer="Enno Boland <gottox@voidlinux.eu>"
+license="GPL-3"
+homepage="https://github.com/joyent/http-parser"
+distfiles="$homepage/archive/v${version}.tar.gz"
+checksum=e3b4ba58f4e6ee5fbec781df020e5cb74c3a799a07f059e1e125127a0b801481
+make_build_target=library
+
+pre_install() {
+	vmkdir usr/lib/pkgconfig
+	vmkdir usr/include
+}
+
+http-parser-devel_package() {
+	depends="$sourcepkg>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/iojs/template
+++ b/srcpkgs/iojs/template
@@ -1,19 +1,27 @@
 # Template file for 'iojs'
 pkgname=iojs
-version=1.6.2
+version=2.1.0
 revision=1
 wrksrc=iojs-v${version}
 hostmakedepends="pkg-config python"
-makedepends="libressl-devel zlib-devel python-devel libuv-devel"
+makedepends="zlib-devel python-devel
+ $(vopt_if ssl libressl-devel) $(vopt_if libuv libuv-devel)
+ $(vopt_if http_parser http-parser-devel)"
 depends="python"
 short_desc="Evented I/O for V8 javascript"
-maintainer="Enno Boland <eb@s01.de>"
+maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="MIT"
 homepage="http://iojs.org/"
 distfiles="${homepage}/dist/v${version}/${pkgname}-v${version}.tar.gz"
-checksum=ea537c47a46a15fdae0eab884a7c8f947905bd0cadc3b0d3ca4dbc51fe4afb5f
+checksum=f10473944dc0e4a7bd2d57efc65d7c2a1d1991852c2d7b3cb6a0fa81b3fed26c
 provides="nodejs-0.12.1_1"
 conflicts="nodejs>=0"
+build_options="ssl libuv http_parser"
+desc_option_libuv="Enable shared libuv"
+desc_option_http_parser="Enable shared http-parser"
+# broken with libressl, use bundled openssl instead
+# linking error with http_parser, use bundled instead
+build_options_default="libuv"
 
 do_configure() {
 	local _args
@@ -25,16 +33,20 @@ do_configure() {
 			*) msg_error "$pkgver: cannot be cross compiled for ${XBPS_TARGET_MACHINE}\n" ;;
 		esac
 	fi
-	./configure --prefix=/usr --openssl-use-sys --shared-zlib --shared-libuv ${_args}
+	./configure --prefix=/usr --shared-zlib \
+		$(vopt_if http_parser --shared-http-parser) \
+		$(vopt_if ssl --shared-openssl) \
+		$(vopt_if libuv --shared-libuv) ${_args}
 }
 do_build() {
 	if [ "$CROSS_BUILD" ]; then
-		make LD="$CXX" ${makejobs} PORTABLE=1 V=1
+		make LD="$CXX" LDFLAGS+=-ldl ${makejobs} PORTABLE=1 V=1
 	else
-		make LD="$CXX" ${makejobs} V=1
+		make LD="$CXX" LDFLAGS+=-ldl ${makejobs} V=1
 	fi
 }
 do_install() {
-	make LD="$CXX" DESTDIR="$DESTDIR" install
+	make LD="$CXX" LDFLAGS+=-ldl DESTDIR="$DESTDIR" install
 	vlicense LICENSE
+	rm -r $DESTDIR/usr/include
 }

--- a/srcpkgs/nodejs/template
+++ b/srcpkgs/nodejs/template
@@ -4,7 +4,9 @@ version=0.12.3
 revision=1
 wrksrc=node-v${version}
 hostmakedepends="pkg-config python"
-makedepends="libressl-devel zlib-devel python-devel libuv-devel"
+makedepends="zlib-devel python-devel
+ $(vopt_if ssl libressl-devel) $(vopt_if libuv libuv-devel)
+ $(vopt_if http_parser http-parser-devel)"
 depends="python"
 short_desc="Evented I/O for V8 javascript"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -12,6 +14,12 @@ license="MIT"
 homepage="http://nodejs.org/"
 distfiles="${homepage}/dist/v${version}/node-v${version}.tar.gz"
 checksum=e65d83c6f2c874e28f65c5e192ac0acd2bbb52bfcf9d77e33442d6765a3eb9da
+build_options="ssl libuv http_parser"
+desc_option_libuv="Enable shared libuv"
+desc_option_http_parser="Enable shared http-parser"
+
+# shared http_parser broken
+build_options_default="ssl libuv"
 
 do_configure() {
 	local _args
@@ -23,7 +31,10 @@ do_configure() {
 			*) msg_error "$pkgver: cannot be cross compiled for ${XBPS_TARGET_MACHINE}\n" ;;
 		esac
 	fi
-	./configure --prefix=/usr --openssl-use-sys --shared-zlib --shared-libuv ${_args}
+	./configure --prefix=/usr --shared-zlib \
+		$(vopt_if http_parser --shared-http-parser) \
+		$(vopt_if ssl  --openssl-use-sys) \
+		$(vopt_if libuv --shared-libuv) ${_args}
 }
 do_build() {
 	if [ "$CROSS_BUILD" ]; then


### PR DESCRIPTION
Node.js and io.js now support build options to enable/disable shared dependencies. As the node/iojs dependencies happily break APIs every now and then this makes maintainance easier.