### PR TITLE
qtcreator: depend on qt5-*-devel and qt5-doc

### DIFF
--- a/srcpkgs/qtcreator/template
+++ b/srcpkgs/qtcreator/template
@@ -1,11 +1,16 @@
 # Template file for 'qtcreator'
 pkgname=qtcreator
 version=3.4.0
-revision=2
+revision=3
 wrksrc=qt-creator-opensource-src-${version}
 hostmakedepends="perl python pkg-config"
 makedepends="qt5-declarative-devel qt5-script-devel qt5-tools-devel"
-depends="${makedepends}"
+depends="qt5-connectivity-devel qt5-declarative-devel qt5-enginio-devel
+ qt5-location-devel qt5-multimedia-devel qt5-quick1-devel qt5-script-devel
+ qt5-sensors-devel qt5-serialport-devel qt5-svg-devel qt5-tools-devel
+ qt5-wayland-devel qt5-webchannel-devel qt5-webengine-devel qt5-webkit-devel
+ qt5-websockets-devel qt5-x11extras-devel qt5-xmlpatterns-devel
+ qt5-declarative-devel qt5-script-devel qt5-tools-devel qt5-doc qt5-plugin-sqlite"
 nocross=yes
 short_desc="A cross-platform IDE for Qt developers"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
@@ -15,7 +20,7 @@ distfiles="http://download.qt.io/official_releases/qtcreator/${version%.*}/${ver
 checksum=b80baf5be9b0421b3d951a8a0eb411a65cf008f4c753f5a80d205e90fa4fe112
 
 do_configure() {
-	qmake
+	MAKEFLAGS=${makejobs} qmake
 }
 do_install() {
 	make INSTALL_ROOT=${DESTDIR}/usr install


### PR DESCRIPTION
A developer using qtcreator will most probably want the majority of available qt-*-devel packages.
qt5-doc contains the *.qch help files and qt5-plugin-sqlite is required to access them.