### PR TITLE
kbd: consistent backspace and delete for i386 maps

### DIFF
--- a/srcpkgs/kbd/patches/kbd-2.0.2-backspace-1.patch
+++ b/srcpkgs/kbd/patches/kbd-2.0.2-backspace-1.patch
@@ -1,0 +1,232 @@
+Submitted By: Matt Burgess
+Date: 2008-12-06
+Initial Package Version: 1.15
+Upstream Status: Not submitted, possibly incomplete
+Description: Makes Backspace and Delete keys consistent in all i386 keymaps.
+Makes the Backspace key send character code 127, and Delete send a well known
+escape sequence. Obsoletes the /etc/kbd/bs-sends-del file for i386.
+
+Original patch for 1.12 by Alexander Patrakov.
+Updated for 1.13 (drop ru.map, the change is upstream, and add ru_win.map,
+ru-cp1251.map) by Ken Moffat <ken at linuxfromscratch dot org>.
+Re-diffed against 1.15 by Matt Burgess <matthew at linuxfromscratch.org>.
+
+--- data/keymaps/i386/dvorak/dvorak-l.map	2008-06-20 12:36:01.000000000 +0100
++++ data/keymaps/i386/dvorak/dvorak-l.map	2008-12-03 22:27:55.000000000 +0000
+@@ -43,7 +43,7 @@
+ 		keycode  11 = three		numbersign
+ 		keycode  12 = two		at
+ 		keycode  13 = one		exclam
+-		keycode  14 = BackSpace		Delete
++		keycode  14 = Delete		Delete
+ ! --------------------------------------------------------------------------
+ ! Row 3
+ ! --------------------------------------------------------------------------
+--- data/keymaps/i386/dvorak/dvorak-r.map	2008-06-20 12:36:01.000000000 +0100
++++ data/keymaps/i386/dvorak/dvorak-r.map	2008-12-03 22:28:13.000000000 +0000
+@@ -43,7 +43,7 @@
+ 		keycode  11 = slash		question
+ 		keycode  12 = bracketleft	braceleft
+ 		keycode  13 = bracketright	braceright
+-		keycode  14 = BackSpace		Delete
++		keycode  14 = Delete		Delete
+ ! --------------------------------------------------------------------------
+ ! Row 3
+ ! --------------------------------------------------------------------------
+--- data/keymaps/i386/fgGIod/tr_f-latin5.map	2008-10-23 20:03:58.000000000 +0100
++++ data/keymaps/i386/fgGIod/tr_f-latin5.map	2008-12-03 22:40:32.000000000 +0000
+@@ -51,7 +51,7 @@
+ 	alt     keycode  12 = Meta_minus      
+ keycode  13 = minus            underscore      
+ 	alt     keycode  13 = Meta_equal      
+-keycode  14 = BackSpace           Delete          
++keycode  14 = Delete           Delete          
+ 	alt     keycode  14 = Meta_Delete     
+ keycode  15 = Tab              Meta_Tab             
+ 	alt     keycode  15 = Meta_Tab        
+--- data/keymaps/i386/qwerty/lt.l4.map	2008-10-23 20:03:59.000000000 +0100
++++ data/keymaps/i386/qwerty/lt.l4.map	2008-12-03 22:42:14.000000000 +0000
+@@ -205,7 +205,7 @@
+ #	edit this if you want the key above <Enter> to delete symbols above
+ # cursor, not before.
+ keycode  14 = \
+-	      BackSpace	       BackSpace	BackSpace	 BackSpace  \
++	      Delete	       Delete		Delete		 Delete	     \
+ 	      Delete	       Delete		Delete		 Delete	     \
+ 	      Meta_BackSpace   Meta_BackSpace	Meta_BackSpace Meta_BackSpace \
+ 	      Meta_Delete      Meta_Delete	Meta_Delete	 Meta_Delete  
+@@ -506,7 +506,7 @@
+ 
+ # Edit this if you want strict VT100 emulation.
+ string F111 = "\033[3$"
+-keycode 111 = Delete	       F111		Delete		 F111	   \
++keycode 111 = Remove	       F111		Remove		 F111	   \
+ 	      Remove	       Remove		Remove		 Remove	    \
+ 	      Meta_Delete      Meta_Delete	Meta_Delete	 Meta_Delete \
+ 	      Boot	       Boot		Boot		 Boot
+--- data/keymaps/i386/qwerty/lt.map	2008-10-23 20:03:59.000000000 +0100
++++ data/keymaps/i386/qwerty/lt.map	2008-12-03 22:42:58.000000000 +0000
+@@ -204,7 +204,7 @@
+ #	edit this if you want the key above <Enter> to delete symbols above
+ # cursor, not before.
+ keycode  14 = \
+-	      BackSpace	       BackSpace	BackSpace	 BackSpace  \
++	      Delete	       Delete		Delete		 Delete	     \
+ 	      Delete	       Delete		Delete		 Delete	     \
+ 	      Meta_BackSpace   Meta_BackSpace	Meta_BackSpace Meta_BackSpace \
+ 	      Meta_Delete      Meta_Delete	Meta_Delete	 Meta_Delete  
+@@ -505,7 +505,7 @@
+ 
+ # Edit this if you want strict VT100 emulation.
+ string F111 = "\033[3$"
+-keycode 111 = Delete	       F111		Delete		 F111	   \
++keycode 111 = Remove	       F111		Remove		 F111	   \
+ 	      Remove	       Remove		Remove		 Remove	    \
+ 	      Meta_Delete      Meta_Delete	Meta_Delete	 Meta_Delete \
+ 	      Boot	       Boot		Boot		 Boot
+--- data/keymaps/i386/qwerty/no-latin1.map	2008-06-20 12:36:00.000000000 +0100
++++ data/keymaps/i386/qwerty/no-latin1.map	2008-12-03 22:44:25.000000000 +0000
+@@ -3,7 +3,7 @@
+ # Send comments to Kjetil T. Homme <kjetilho@ifi.uio.no>
+ include "linux-with-alt-and-altgr"
+ 	plain keycode  83 = KP_Comma
+-	plain keycode 111 = Delete		# "Remove" originally, weird...
++	plain keycode 111 = Remove
+ strings as usual
+ 
+ 	keycode   1 = Escape
+--- data/keymaps/i386/qwerty/ru1.map	2008-10-23 20:03:59.000000000 +0100
++++ data/keymaps/i386/qwerty/ru1.map	2008-12-03 22:45:32.000000000 +0000
+@@ -143,8 +143,8 @@
+ 
+ # The keycode "0xFF" is too dangerous for many programs (including emacs).
+ # So let it be bracket instead of Hard Sign.
+-# altgr		keycode  27 = 	+0xDF
+-# altgr	shift 	keycode  27 = 	+0xFF
++altgr		keycode  27 = 	+0xDF
++altgr	shift 	keycode  27 = 	+0xFF
+ 	control	keycode  27 =	Control_bracketright
+ altgr	control	keycode  27 =	Control_bracketright
+ 	alt	keycode  27 =	Meta_bracketright
+--- data/keymaps/i386/qwerty/ru2.map	2008-10-23 20:03:59.000000000 +0100
++++ data/keymaps/i386/qwerty/ru2.map	2008-12-03 22:46:15.000000000 +0000
+@@ -46,7 +46,7 @@
+ 	alt	keycode  12 =	Meta_minus
+ 		keycode  13 =	equal	plus		equal	plus
+ 	alt	keycode  13 =	Meta_equal
+-		keycode  14 =	BackSpace BackSpace	BackSpace BackSpace
++		keycode  14 =	Delete Delete	Delete Delete
+ 	alt	keycode  14 =	Meta_Delete
+ 		keycode  15 =	Tab	Tab		Tab	Tab	
+ 	alt	keycode  15 =	Meta_Tab	
+--- data/keymaps/i386/qwerty/ru-cp1251.map	2008-10-23 20:03:59.000000000 +0100
++++ data/keymaps/i386/qwerty/ru-cp1251.map	2008-12-03 22:47:12.000000000 +0000
+@@ -39,7 +39,7 @@
+ 	alt	keycode  12 =	Meta_minus
+ 		keycode  13 =	equal	plus		equal	plus
+ 	alt	keycode  13 =	Meta_equal
+-		keycode  14 =	BackSpace
++		keycode  14 =	Delete
+ 	alt	keycode  14 =	Meta_Delete
+ 		keycode  15 =	Tab
+ 	alt	keycode  15 =	Meta_Tab	
+--- data/keymaps/i386/qwerty/ru-ms.map	2008-10-23 20:03:59.000000000 +0100
++++ data/keymaps/i386/qwerty/ru-ms.map	2008-12-03 22:48:10.000000000 +0000
+@@ -89,8 +89,8 @@
+ altgr	alt     keycode  13 =    Meta_equal
+ 	shift alt keycode  13 = 	Meta_plus
+ altgr	shift alt keycode  13 = 	Meta_plus
+-		keycode  14 = 	BackSpace  BackSpace  BackSpace  BackSpace
+-#		keycode  14 = 	Delete  Delete  Delete  Delete
++#		keycode  14 = 	BackSpace  BackSpace  BackSpace  BackSpace
++		keycode  14 = 	Delete  Delete  Delete  Delete
+ 	alt	keycode  14 =	Meta_Delete
+ altgr	alt     keycode  14 = 	Meta_Delete
+ 		keycode  15 =	Tab	Tab		Tab	Tab	
+--- data/keymaps/i386/qwerty/ru_win.map	2008-10-23 20:03:59.000000000 +0100
++++ data/keymaps/i386/qwerty/ru_win.map	2008-12-03 22:49:17.000000000 +0000
+@@ -42,7 +42,7 @@
+ 	alt	keycode  12 =	Meta_minus
+ 		keycode  13 =	equal	plus		equal	plus
+ 	alt	keycode  13 =	Meta_equal
+-		keycode  14 =	BackSpace BackSpace	BackSpace BackSpace
++		keycode  14 =	Delete Delete	Delete Delete
+ 	alt	keycode  14 =	Meta_Delete
+ 		keycode  15 =	Tab	Tab		Tab	Tab	
+ 	alt	keycode  15 =	Meta_Tab	
+--- data/keymaps/i386/qwerty/se-ir209.map	2008-10-23 20:03:59.000000000 +0100
++++ data/keymaps/i386/qwerty/se-ir209.map	2008-12-03 22:50:18.000000000 +0000
+@@ -345,7 +345,7 @@
+ 	keycode 109 = Next	Scroll_Forward
+ 	keycode 110 = Insert
+ 
+-	keycode 111 = Delete		# "Remove" originally, weird...
++	keycode 111 = Remove
+ control alt	keycode 111 = Boot
+ control altgr	keycode 111 = Boot
+ 
+--- data/keymaps/i386/qwerty/se-lat6.map	2008-10-23 20:03:59.000000000 +0100
++++ data/keymaps/i386/qwerty/se-lat6.map	2008-12-03 22:50:44.000000000 +0000
+@@ -374,6 +374,6 @@
+ 	keycode 109 = Next	Scroll_Forward
+ 	keycode 110 = Insert
+ 
+-	keycode 111 = Delete		# "Remove" originally, weird...
++	keycode 111 = Remove
+ control alt	keycode 111 = Boot
+ control altgr	keycode 111 = Boot
+--- data/keymaps/i386/qwerty/tr_q-latin5.map	2008-10-23 20:03:59.000000000 +0100
++++ data/keymaps/i386/qwerty/tr_q-latin5.map	2008-12-03 22:52:09.000000000 +0000
+@@ -49,7 +49,7 @@
+ 	alt     keycode  12 = Meta_minus
+ keycode  13 = minus            underscore
+ 	alt     keycode  13 = Meta_equal
+-keycode  14 = BackSpace           Delete
++keycode  14 = Delete           Delete
+ 	alt     keycode  14 = Meta_Delete
+ keycode  15 = Tab              Meta_Tab
+ 	alt     keycode  15 = Meta_Tab
+--- data/keymaps/i386/qwerty/ua.map	2008-10-23 20:03:59.000000000 +0100
++++ data/keymaps/i386/qwerty/ua.map	2008-12-03 22:52:52.000000000 +0000
+@@ -249,7 +249,7 @@
+ 	shift ctrll ctrlr keycode  13 = plus
+ 	alt ctrll ctrlr keycode  13 = Meta_equal
+ 	shift alt ctrll ctrlr keycode  13 = Meta_plus
+-keycode  14 = BackSpace           Delete          
++keycode  14 = Delete           Delete          
+ 	control	keycode  14 = BackSpace       
+ 	alt	keycode  14 = Meta_Delete     
+ 	ctrlr	keycode  14 = BackSpace
+--- data/keymaps/i386/qwerty/ua-utf.map	2008-10-23 20:03:59.000000000 +0100
++++ data/keymaps/i386/qwerty/ua-utf.map	2008-12-03 22:53:36.000000000 +0000
+@@ -250,7 +250,7 @@
+ 	shift ctrll ctrlr keycode  13 = plus
+ 	alt ctrll ctrlr keycode  13 = Meta_equal
+ 	shift alt ctrll ctrlr keycode  13 = Meta_plus
+-keycode  14 = BackSpace           Delete          
++keycode  14 = Delete           Delete          
+ 	control	keycode  14 = BackSpace       
+ 	alt	keycode  14 = Meta_Delete     
+ 	ctrlr	keycode  14 = BackSpace
+--- data/keymaps/i386/qwerty/ua-utf-ws.map	2008-10-23 20:03:59.000000000 +0100
++++ data/keymaps/i386/qwerty/ua-utf-ws.map	2008-12-03 22:54:06.000000000 +0000
+@@ -260,7 +260,7 @@
+ 	shift ctrll ctrlr keycode  13 = plus
+ 	alt ctrll ctrlr keycode  13 = Meta_equal
+ 	shift alt ctrll ctrlr keycode  13 = Meta_plus
+-keycode  14 = BackSpace           Delete          
++keycode  14 = Delete           Delete          
+ 	control	keycode  14 = BackSpace       
+ 	alt	keycode  14 = Meta_Delete     
+ 	ctrlr	keycode  14 = BackSpace
+--- data/keymaps/i386/qwerty/ua-ws.map	2008-10-23 20:03:59.000000000 +0100
++++ data/keymaps/i386/qwerty/ua-ws.map	2008-12-03 22:54:23.000000000 +0000
+@@ -260,7 +260,7 @@
+ 	shift ctrll ctrlr keycode  13 = plus
+ 	alt ctrll ctrlr keycode  13 = Meta_equal
+ 	shift alt ctrll ctrlr keycode  13 = Meta_plus
+-keycode  14 = BackSpace           Delete          
++keycode  14 = Delete           Delete          
+ 	control	keycode  14 = BackSpace       
+ 	alt	keycode  14 = Meta_Delete     
+ 	ctrlr	keycode  14 = BackSpace

--- a/srcpkgs/kbd/template
+++ b/srcpkgs/kbd/template
@@ -1,7 +1,7 @@
 # Template file for 'kbd'
 pkgname=kbd
 version=2.0.2
-revision=4
+revision=5
 build_pie=yes
 build_style=gnu-configure
 configure_args="--datadir=/usr/share/kbd --localedir=/usr/share/kbd/locale"


### PR DESCRIPTION
Imported from LFS (http://www.linuxfromscratch.org/lfs/view/development/chapter06/kbd.html)
The behaviour of the Backspace and Delete keys is not consistent across the keymaps in
the kbd package. This patch fixes the issue for i386 keymaps.