### PR TITLE
qemu: patch to fix Venom vulnerability (CVE-2015-3456)

### DIFF
--- a/srcpkgs/qemu/patches/qemu-2.3.0-security-fdc.patch
+++ b/srcpkgs/qemu/patches/qemu-2.3.0-security-fdc.patch
@@ -1,0 +1,61 @@
+This is a security patch addressing the Venom security issue (CVE-2015-3456)
+Patch pulled from qemu's git repository:
+http://git.qemu.org/?p=qemu.git;a=commitdiff;h=e907746266721f305d67bc0718795fedee2e824c
+
+--- hw/block/fdc.c
++++ hw/block/fdc.c
+@@ -1497,7 +1497,7 @@ static uint32_t fdctrl_read_data(FDCtrl *fdctrl)
+ {
+     FDrive *cur_drv;
+     uint32_t retval = 0;
+-    int pos;
++    uint32_t pos;
+ 
+     cur_drv = get_cur_drv(fdctrl);
+     fdctrl->dsr &= ~FD_DSR_PWRDOWN;
+@@ -1506,8 +1506,8 @@ static uint32_t fdctrl_read_data(FDCtrl *fdctrl)
+         return 0;
+     }
+     pos = fdctrl->data_pos;
++    pos %= FD_SECTOR_LEN;
+     if (fdctrl->msr & FD_MSR_NONDMA) {
+-        pos %= FD_SECTOR_LEN;
+         if (pos == 0) {
+             if (fdctrl->data_pos != 0)
+                 if (!fdctrl_seek_to_next_sect(fdctrl, cur_drv)) {
+@@ -1852,10 +1852,13 @@ static void fdctrl_handle_option(FDCtrl *fdctrl, int direction)
+ static void fdctrl_handle_drive_specification_command(FDCtrl *fdctrl, int direction)
+ {
+     FDrive *cur_drv = get_cur_drv(fdctrl);
++    uint32_t pos;
+ 
+-    if (fdctrl->fifo[fdctrl->data_pos - 1] & 0x80) {
++    pos = fdctrl->data_pos - 1;
++    pos %= FD_SECTOR_LEN;
++    if (fdctrl->fifo[pos] & 0x80) {
+         /* Command parameters done */
+-        if (fdctrl->fifo[fdctrl->data_pos - 1] & 0x40) {
++        if (fdctrl->fifo[pos] & 0x40) {
+             fdctrl->fifo[0] = fdctrl->fifo[1];
+             fdctrl->fifo[2] = 0;
+             fdctrl->fifo[3] = 0;
+@@ -1955,7 +1958,7 @@ static uint8_t command_to_handler[256];
+ static void fdctrl_write_data(FDCtrl *fdctrl, uint32_t value)
+ {
+     FDrive *cur_drv;
+-    int pos;
++    uint32_t pos;
+ 
+     /* Reset mode */
+     if (!(fdctrl->dor & FD_DOR_nRESET)) {
+@@ -2004,7 +2007,9 @@ static void fdctrl_write_data(FDCtrl *fdctrl, uint32_t value)
+     }
+ 
+     FLOPPY_DPRINTF("%s: %02x\n", __func__, value);
+-    fdctrl->fifo[fdctrl->data_pos++] = value;
++    pos = fdctrl->data_pos++;
++    pos %= FD_SECTOR_LEN;
++    fdctrl->fifo[pos] = value;
+     if (fdctrl->data_pos == fdctrl->data_len) {
+         /* We now have all parameters
+          * and will be able to treat the command

--- a/srcpkgs/qemu/template
+++ b/srcpkgs/qemu/template
@@ -1,7 +1,7 @@
 # Template file for 'qemu'
 pkgname=qemu
 version=2.3.0
-revision=1
+revision=2
 short_desc="Open Source Processor Emulator"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://qemu.org"


### PR DESCRIPTION
The qemu git repository contains a patch to address the Venom vulnerability.
This patch applies the upstream changes to hw/block/fdc.c