### PR TITLE
wine: added staging patchset

### DIFF
--- a/srcpkgs/wine/template
+++ b/srcpkgs/wine/template
@@ -1,7 +1,7 @@
 # Template file for 'wine'
 pkgname=wine
 version=1.7.42
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--without-gstreamer"
 short_desc="Run Microsoft Windows applications"
@@ -27,6 +27,22 @@ makedepends="gettext-devel lcms2-devel zlib-devel ncurses-devel
 depends="libXi libXinerama libXcomposite libXcursor libOSMesa
  desktop-file-utils hicolor-icon-theme liberation-fonts-ttf"
 
+build_options="staging"
+desc_option_staging="Enable wine-staging patchset"
+build_options_default="staging"
+
+if [ ${build_option_staging} ]; then
+	hostmakedepends+=" automake"
+	makedepends+=" pulseaudio-devel"
+	distfiles+=" https://github.com/wine-compholio/${pkgname}-staging/archive/v${version}.tar.gz"
+	checksum+=" 71dc4b0063446347769234075e7b76e5214a54eccee445a72cb7467bd0a85b3d"
+
+	post_extract() {
+		cd ${XBPS_BUILDDIR}/${pkgname}-staging-${version}/patches/
+		DESTDIR="$wrksrc" ./patchinstall.sh --all
+	}
+fi
+
 post_install() {
 	# Font aliasing settings for Win32 applications
 	install -d ${DESTDIR}/etc/fonts/conf.{avail,d}
@@ -48,7 +64,7 @@ wine-devel_package() {
 	short_desc+=" - development files"
 	replaces="wine-unstable-devel>=0"
 	pkg_install() {
-        	vmove usr/include
+		vmove usr/include
 		vmove "usr/lib/*.so"
 	}
 }


### PR DESCRIPTION
This adds staging patches comprehending pulseaudio driver, NPAPI compatibility (needed by pipelight) and other patches. It's currently employed by the default distribution of wine in fedora.