### PR TITLE
xbps-src: unified ccache directory

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -536,7 +536,10 @@ else
     export PATH="$MYPATH"
     if [ -n "$XBPS_CCACHE" ]; then
         CCACHEPATH="/usr/lib/ccache/bin"
-        export CCACHE_DIR="$XBPS_HOSTDIR/ccache-${XBPS_CROSS_BUILD:-${XBPS_MACHINE}}"
+        export CCACHE_DIR="$XBPS_HOSTDIR/ccache"
+        # Avoid not using cached files just due to compiler mtime
+        # changes when e.g. bootstrapping
+        export CCACHE_COMPILERCHECK=content
         export PATH="$CCACHEPATH:$PATH"
         mkdir -p $CCACHE_DIR
     fi


### PR DESCRIPTION
- I turns out that ccache is very well capable of recognizing different
  compilers and using only files stored to the cache by each compiler.
- To avoid large parts of a cache becoming useless just because a compiler
  was rebuilt during some (bootstrap) stage, rely on the contents of
  the compiler binary for identification instead of mtime + size.