### PR TITLE
cubietruck-uboot: fix cubietruck.bootcmd

### DIFF
--- a/srcpkgs/cubietruck-uboot/files/cubietruck.bootcmd
+++ b/srcpkgs/cubietruck-uboot/files/cubietruck.bootcmd
@@ -1,9 +1,4 @@
 setenv bootargs console=tty1 root=/dev/mmcblk0p2 rootwait fb0_framebuffer_num=4 sunxi_fb_mem_reserve=64 hdmi.audio=EDID:0 disp.screen0_output_mode=EDID:1280x720p60 panic=10 consoleblank=0
-# Old method
 fatload mmc 0 0x43000000 script.bin || ext2load mmc 0 0x43000000 boot/script.bin
-fatload mmc 0 0x48000000 uImage || ext2load mmc 0 0x48000000 uImage boot/uImage
-bootm 0x48000000
-# New method (one partition)
-ext4load mmc 0 0x43000000 boot/script.bin
-ext4load mmc 0 0x48000000 boot/zImage
+fatload mmc 0 0x48000000 zImage || ext2load mmc 0 0x48000000 boot/zImage
 bootz 0x48000000

--- a/srcpkgs/cubietruck-uboot/template
+++ b/srcpkgs/cubietruck-uboot/template
@@ -1,7 +1,7 @@
 # Template file for 'cubietruck-uboot'
 pkgname=cubietruck-uboot
 version=2015.04
-revision=1
+revision=2
 wrksrc="u-boot-${version}"
 hostmakedepends="sunxi-tools uboot-mkimage"
 short_desc="Cubietruck U-Boot files for SD booting"


### PR DESCRIPTION
- The cubietruck-kernel is compressed, thus we load zImage and do bootz