### PR TITLE
New package: fail2ban-0.8.14.

### DIFF
--- a/srcpkgs/fail2ban/files/fail2ban/run
+++ b/srcpkgs/fail2ban/files/fail2ban/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec fail2ban-server -f

--- a/srcpkgs/fail2ban/template
+++ b/srcpkgs/fail2ban/template
@@ -1,0 +1,84 @@
+# Template file for 'fail2ban'
+pkgname=fail2ban
+version=0.8.14
+revision=1
+noarch=yes
+build_style=python-module
+hostmakedepends="pkg-config python"
+depends="python"
+short_desc="Authentication failure monitor system"
+pycompile_dirs="/usr/share/fail2ban/"
+conf_files="/etc/fail2ban/action.d/apf.conf /etc/fail2ban/action.d/badips.conf \
+/etc/fail2ban/action.d/blocklist_de.conf /etc/fail2ban/action.d/bsd-ipfw.conf \
+/etc/fail2ban/action.d/complain.conf /etc/fail2ban/action.d/dshield.conf \
+/etc/fail2ban/action.d/dummy.conf /etc/fail2ban/action.d/firewallcmd-ipset.conf \
+/etc/fail2ban/action.d/firewallcmd-new.conf \
+/etc/fail2ban/action.d/hostsdeny.conf  /etc/fail2ban/action.d/ipfilter.conf \
+/etc/fail2ban/action.d/ipfw.conf \
+/etc/fail2ban/action.d/iptables-allports.conf \
+/etc/fail2ban/action.d/iptables-blocktype.conf \
+/etc/fail2ban/action.d/iptables.conf \
+/etc/fail2ban/action.d/iptables-ipset-proto4.conf \
+/etc/fail2ban/action.d/iptables-ipset-proto6-allports.conf \
+/etc/fail2ban/action.d/iptables-ipset-proto6.conf \
+/etc/fail2ban/action.d/iptables-multiport.conf \
+/etc/fail2ban/action.d/iptables-multiport-log.conf \
+/etc/fail2ban/action.d/iptables-new.conf \
+/etc/fail2ban/action.d/iptables-xt_recent-echo.conf \
+/etc/fail2ban/action.d/mail-buffered.conf \
+/etc/fail2ban/action.d/mail.conf /etc/fail2ban/action.d/mail-whois.conf \
+/etc/fail2ban/action.d/mail-whois-lines.conf \
+/etc/fail2ban/action.d/mynetwatchman.conf /etc/fail2ban/action.d/osx-afctl.conf \
+/etc/fail2ban/action.d/osx-ipfw.conf /etc/fail2ban/action.d/pf.conf \
+/etc/fail2ban/action.d/route.conf \
+/etc/fail2ban/action.d/sendmail-buffered.conf \
+/etc/fail2ban/action.d/sendmail-common.conf \
+/etc/fail2ban/action.d/sendmail.conf /etc/fail2ban/action.d/sendmail-whois.conf \
+/etc/fail2ban/action.d/sendmail-whois-lines.conf \
+/etc/fail2ban/action.d/shorewall.conf /etc/fail2ban/action.d/ufw.conf \
+/etc/fail2ban/fail2ban.conf /etc/fail2ban/filter.d/3proxy.conf \
+/etc/fail2ban/filter.d/apache-auth.conf \
+/etc/fail2ban/filter.d/apache-badbots.conf \
+/etc/fail2ban/filter.d/apache-common.conf \
+/etc/fail2ban/filter.d/apache-modsecurity.conf \
+/etc/fail2ban/filter.d/apache-nohome.conf \
+/etc/fail2ban/filter.d/apache-noscript.conf \
+/etc/fail2ban/filter.d/apache-overflows.conf /etc/fail2ban/filter.d/assp.conf \
+/etc/fail2ban/filter.d/asterisk.conf /etc/fail2ban/filter.d/common.conf \
+/etc/fail2ban/filter.d/courierlogin.conf \
+/etc/fail2ban/filter.d/couriersmtp.conf \
+/etc/fail2ban/filter.d/cyrus-imap.conf /etc/fail2ban/filter.d/dovecot.conf \
+/etc/fail2ban/filter.d/dropbear.conf /etc/fail2ban/filter.d/ejabberd-auth.conf \
+/etc/fail2ban/filter.d/exim-common.conf /etc/fail2ban/filter.d/exim.conf \
+/etc/fail2ban/filter.d/exim-spam.conf /etc/fail2ban/filter.d/freeswitch.conf \
+/etc/fail2ban/filter.d/groupoffice.conf /etc/fail2ban/filter.d/gssftpd.conf \
+/etc/fail2ban/filter.d/horde.conf /etc/fail2ban/filter.d/lighttpd-auth.conf \
+/etc/fail2ban/filter.d/mysqld-auth.conf /etc/fail2ban/filter.d/nagios.conf \
+/etc/fail2ban/filter.d/named-refused.conf \
+/etc/fail2ban/filter.d/nginx-http-auth.conf /etc/fail2ban/filter.d/nsd.conf \
+/etc/fail2ban/filter.d/openwebmail.conf /etc/fail2ban/filter.d/pam-generic.conf \
+/etc/fail2ban/filter.d/perdition.conf /etc/fail2ban/filter.d/php-url-fopen.conf \
+/etc/fail2ban/filter.d/postfix.conf /etc/fail2ban/filter.d/postfix-sasl.conf \
+/etc/fail2ban/filter.d/proftpd.conf /etc/fail2ban/filter.d/pure-ftpd.conf \
+/etc/fail2ban/filter.d/qmail.conf /etc/fail2ban/filter.d/recidive.conf \
+/etc/fail2ban/filter.d/roundcube-auth.conf \
+/etc/fail2ban/filter.d/selinux-common.conf \
+/etc/fail2ban/filter.d/selinux-ssh.conf \
+/etc/fail2ban/filter.d/sendmail-auth.conf \
+/etc/fail2ban/filter.d/sendmail-reject.conf \
+/etc/fail2ban/filter.d/sieve.conf /etc/fail2ban/filter.d/sogo-auth.conf \
+/etc/fail2ban/filter.d/solid-pop3d.conf /etc/fail2ban/filter.d/squid.conf \
+/etc/fail2ban/filter.d/sshd.conf /etc/fail2ban/filter.d/sshd-ddos.conf \
+/etc/fail2ban/filter.d/suhosin.conf /etc/fail2ban/filter.d/uwimap-auth.conf \
+/etc/fail2ban/filter.d/vsftpd.conf /etc/fail2ban/filter.d/webmin-auth.conf \
+/etc/fail2ban/filter.d/wuftpd.conf /etc/fail2ban/filter.d/xinetd-fail.conf \
+/etc/fail2ban/jail.conf"
+maintainer="necrophcodr <necrophcodr@necrophcodr.me>"
+license="GPL-2"
+homepage="http://fail2ban.org/"
+distfiles="https://github.com/fail2ban/fail2ban/archive/0.8.14.tar.gz"
+checksum=2d579d9f403eb95064781ffb28aca2b258ca55d7a2ba056a8fa2b3e6b79721f2
+
+post_install() {
+	vsv fail2ban
+}


### PR DESCRIPTION
This provides the current stable version of fail2ban, with no batteries included.

Critiques and comments, lets have 'em!