### PR TITLE
edbrowse: update to 3.5.4.

### DIFF
--- a/srcpkgs/edbrowse/patches/0001-glob-fixes.patch
+++ b/srcpkgs/edbrowse/patches/0001-glob-fixes.patch
@@ -1,0 +1,155 @@
+# We were using glob() to do tilde-expansion on filenames, but it caused
+# a couple problems, one of which is that the package won't build
+# under musl.  Fix submitted by Karl Dahlke post-release, and modified
+# by Chris Brannon so that it would apply against 3.5.4 sources.
+# This goes away with the next release.
+diff --git src/messages.c src/messages.c
+index 755b153..3dc2aac 100644
+--- src/messages.c
++++ src/messages.c
+@@ -412,7 +412,7 @@ static const char *englishMessages[] = {
+ 	"cannot read the contents of %s",
+ 	"cannot access %s",
+ 	"$%s is not defined",
+-	0,
++	"~%s is not defined",
+ 	0,
+ 	0,
+ 	0,
+@@ -1075,7 +1075,7 @@ static const char *frenchMessages[] = {
+ 	"impossible de lire le contenu de %s",
+ 	"impossible d'accéder à %s",
+ 	"$%s n'est pas définie",
+-	0,
++	"~%s n'est pas définie",
+ 	0,
+ 	0,
+ 	0,
+@@ -1738,7 +1738,7 @@ static const char *brazilianPortugueseMessages[] = {
+ 	"impossível ler o conteúdo do %s",
+ 	"impossível acessar %s",
+ 	"$%s não definida",
+-	0,
++	"~%s não definida",
+ 	0,
+ 	0,
+ 	0,
+@@ -2401,7 +2401,7 @@ static const char *polishMessages[] = {
+ 	"nie można wczytać zawartości %s",
+ 	"nie można odczytać %s",
+ 	"$%s nie jest ustawiona",
+-	0,
++	"~%s nie jest ustawiona",
+ 	0,
+ 	0,
+ 	0,
+@@ -3064,7 +3064,7 @@ static const char *germanMessages[] = {
+ 	"kann Inhalt von %s nicht lesen",
+ 	"kann auf %s nicht zugreifen",
+ 	"$%s ungültige",
+-	0,
++	"~%s ungültige",
+ 	0,
+ 	0,
+ 	0,
+diff --git src/messages.h src/messages.h
+index 62652a8..4ae61bc 100644
+--- src/messages.h
++++ src/messages.h
+@@ -412,7 +412,7 @@ enum {
+ 	MSG_NoRead2,
+ 	MSG_NoAccess,
+ 	MSG_NoEnvVar,
+-	MSG_NotUsed415,
++	MSG_NoTilde,
+ 	MSG_NotUsed416,
+ 	MSG_NotUsed417,
+ 	MSG_NotUsed418,
+diff --git src/stringfile.c src/stringfile.c
+index ecc2cfc..195912c 100644
+--- src/stringfile.c
++++ src/stringfile.c
+@@ -15,6 +15,7 @@
+ #include <glob.h>
+ #include <dirent.h>
+ #include <netdb.h>
++#include <pwd.h>
+ 
+ /*********************************************************************
+ Allocate and manage memory.
+@@ -1144,22 +1145,62 @@ bool sortedDirList(const char *dir, struct lineMap **map_p, int *count_p)
+ static bool envExpand(const char *line, const char **expanded)
+ {
+ 	const char *s;
+-	const char *v;
+ 	char *t;
+-	bool inbrace;
++	const char *v;		/* result of getenv call */
++	bool inbrace;		/* ${foo} */
++	struct passwd *pw;
++	const char *udir;	/* user directory */
+ 	int l;
+ 	static char varline[ABSPATH];
+ 	char var1[40];
+ 
+ /* quick check */
+-	if (!strchr(line, '$')) {
++	if (line[0] != '~' && !strchr(line, '$')) {
+ 		*expanded = line;
+ 		return true;
+ 	}
+ 
+ /* ok, need to crunch along */
+ 	t = varline;
+-	for (s = line; *s; ++s) {
++	s = line;
++
++	if (line[0] != '~')
++		goto dollars;
++
++	l = 0;
++	for (s = line + 1; isalnum(*s) || *s == '_'; ++s)
++		++l;
++	if (l >= sizeof(var1) || isdigit(line[1]) || *s && *s != '/') {
++/* invalid syntax, put things back */
++		s = line;
++		goto dollars;
++	}
++
++	udir = 0;
++	strncpy(var1, line + 1, l);
++	var1[l] = 0;
++	if (l) {
++		pw = getpwnam(var1);
++		if (!pw) {
++			setError(MSG_NoTilde, var1);
++			return false;
++		}
++		if (pw->pw_dir && *pw->pw_dir)
++			udir = pw->pw_dir;
++	} else
++		udir = home;
++	if (!udir) {
++		s = line;
++		goto dollars;
++	}
++	l = strlen(udir);
++	if (l >= sizeof(varline))
++		goto longline;
++	strcpy(varline, udir);
++	t = varline + l;
++
++dollars:
++	for (; *s; ++s) {
+ 		if (t - varline == ABSPATH - 1) {
+ longline:
+ 			setError(MSG_ShellLineLong);
+@@ -1235,7 +1276,7 @@ bool envFile(const char *line, const char **expanded)
+ 		return false;
+ 
+ /* expanded the environment variables, if any, now time to glob */
+-	flags = (GLOB_NOSORT | GLOB_TILDE_CHECK);
++	flags = GLOB_NOSORT;
+ 	rc = glob(varline, flags, NULL, &g);
+ 
+ 	if (rc == GLOB_NOMATCH) {

--- a/srcpkgs/edbrowse/template
+++ b/srcpkgs/edbrowse/template
@@ -1,15 +1,15 @@
 # Template file for 'edbrowse'
 pkgname=edbrowse
-version=3.5.3
-revision=3
+version=3.5.4
+revision=1
 hostmakedepends="unzip pkg-config"
 makedepends="mozjs24-devel libressl-devel pcre-devel libcurl-devel readline-devel"
 short_desc="Line-oriented text editor and web browser similar to ed(1)"
 maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
 license="GPL-3"
-homepage="http://the-brannons.com/edbrowse/"
-distfiles="http://the-brannons.com/${pkgname}/${pkgname}-${version}.zip"
-checksum=fae06a147a9661fe446e47b1ba68cd680e5eb0b5e71fae1fb6952d8c646835d5
+homepage="http://edbrowse.org/"
+distfiles="http://edbrowse.org/${pkgname}-${version}.zip"
+checksum=9b8ef8c8b83a207f59999e9117b1f1f09ca498ccd08811782dd4d42081679225
 
 do_build() {
 	make ${makejobs} -C src	JS_CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/mozjs-24"


### PR DESCRIPTION
This also contains a patch from upstream, so that edbrowse will
build under musl.  This will go away with the next release.