### PR TITLE
mopidy: update to 1.0.4

### DIFF
--- a/srcpkgs/mopidy/template
+++ b/srcpkgs/mopidy/template
@@ -1,6 +1,6 @@
 # Template file for 'mopidy'
 pkgname=mopidy
-version=1.0.3
+version=1.0.4
 revision=1
 build_style=python-module
 short_desc="An extensible music server in python"
@@ -8,7 +8,7 @@ maintainer="allan <mail@may.mooo.com>"
 license="Apache-2.0"
 homepage="http://www.mopidy.com"
 distfiles="${PYPI_SITE}/M/Mopidy/Mopidy-${version}.tar.gz"
-checksum=171af12c671e5634d66e7bb21aa6b558b30b86610e312eaa81d1cff4afd13e0c
+checksum=906b665a237c691368afb99c06f59648c2fc78b21fb473ba25f3b5dc67922cc6
 noarch=yes
 pycompile_module=mopidy
 hostmakedepends="python-setuptools"


### PR DESCRIPTION
1.0.4 fixes inability to stream (at least) mp3 over HTTP - https://discuss.mopidy.com/t/mopidy-not-playing-anything-since-last-apt-get-upgrade/704/8