### PR TITLE
Binutils

### DIFF
--- a/srcpkgs/binutils/template
+++ b/srcpkgs/binutils/template
@@ -7,7 +7,7 @@ short_desc="GNU binary utilities"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnu.org/software/binutils/"
 license="GPL-3"
-distfiles="http://ftp.gnu.org/gnu/$pkgname/$pkgname-$version.tar.gz"
+distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d
 
 if [ "$CHROOT_READY" ]; then

--- a/srcpkgs/binutils/template
+++ b/srcpkgs/binutils/template
@@ -1,7 +1,7 @@
 # Template file for 'binutils'
 pkgname=binutils
 version=2.25
-revision=2
+revision=3
 bootstrap=yes
 short_desc="GNU binary utilities"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -18,7 +18,7 @@ makedepends+=" zlib-devel"
 pre_configure() {
 	sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure
 	# Drop bashism!
-	sed -e 's,source,\.,g' -i ld/scripttempl/elf.sc
+	sed -e 's,source,\.,g' -i ld/scripttempl/elf32msp430.sc
 }
 do_configure() {
 	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then


### PR DESCRIPTION
A quick grep points out the bashism is removed from the wrong file. This PR corrects both that and an xlint warning (use $GNU_SITE).