### PR TITLE
monkey: add musl-compilation support.

### DIFF
--- a/srcpkgs/monkey/template
+++ b/srcpkgs/monkey/template
@@ -1,14 +1,14 @@
 # Template file for 'monkey'
 pkgname=monkey
 version=1.5.6
-revision=3
+revision=4
 build_style=configure
 makedepends="mbedtls-devel"
 configure_args+="--prefix=/usr --plugdir=/usr/share/monkey/plugins "
 configure_args+="--sysconfdir=/etc/monkey/ --enable-plugins=mbedtls "
 configure_args+="--datadir=/srv/httpd --mandir=/usr/share/man "
 configure_args+="--pidfile=/var/run/monkey.pid --logdir=/var/log/monkey "
-configure_args+="--malloc-libc"
+configure_args+="--malloc-libc "
 short_desc="Cross-arch embeddable lightweight HTTP server"
 maintainer="necrophcodr <necrophcodr@necrophcodr.me>"
 license="APL-2.0"
@@ -36,6 +36,11 @@ conf_files="
 system_accounts="httpd"
 httpd_descr="Monkey HTTP server"
 httpd_homedir="/srv/httpd"
+
+case $XBPS_TARGET_MACHINE in
+	*-musl)
+		configure_args+="--musl-mode --no-backtrace " ;;
+esac
 
 post_install() {
 	vmkdir usr/share/monkey/htdocs


### PR DESCRIPTION
This fixes monkey not building with musl.

Additionally, as can easily be seen in the commit, it also disables the backtrace feature for the musl build of monkey. Likely this won't be a major issue, but it is simply due to the fact that `src/mk_utils.c` will include a header only provided by glibc-devel ( `/usr/include/execinfo.h` ), which is not available on musl-platforms.

Unlikely to be an issue, but worth mentioning. Other than that, it should be good to go.