### PR TITLE
re2c: update to 0.14.3

### DIFF
--- a/srcpkgs/re2c/template
+++ b/srcpkgs/re2c/template
@@ -1,6 +1,6 @@
 # Template file for 're2c'
 pkgname=re2c
-version=0.14.2
+version=0.14.3
 revision=1
 build_style=gnu-configure
 hostmakedepends="bison"
@@ -8,8 +8,8 @@ short_desc="Tool for generating fast C-based recognizers"
 maintainer="beefcurtains <beefcurtains@users.noreply.github.com>"
 license="Public Domain"
 homepage="http://re2c.sourceforge.net/"
-distfiles="${SOURCEFORGE_SITE}/${pkgname}/${version}/${pkgname}-${version}.tar.gz"
-checksum=a702eb63977af4715555edb41eba3b47bbfdcdb44b566d146869a7db022f1c30
+distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}/${version}/${pkgname}-${version}.tar.gz"
+checksum=1c6806df599f3aef0804b576cfdf64bdba5ad590626dfca2d44e473460917e84
 
 pre_configure() {
 	if [ -n "$CROSS_BUILD" ]; then


### PR DESCRIPTION
Upstream changes:
- applied patch '# 27 re2c crashes reading files containing %{ %}' by Rui
- dropped distfiles for MSVC (they are broken anyway)