### PR TITLE
gdb: Make python detection work in cross builds

### DIFF
--- a/srcpkgs/gdb/template
+++ b/srcpkgs/gdb/template
@@ -1,7 +1,7 @@
 # Template file for 'gdb'
 pkgname=gdb
 version=7.9.1
-revision=3
+revision=4
 patch_args="-Np1"
 build_style=gnu-configure
 configure_args="--disable-werror --disable-nls --with-system-readline
@@ -16,6 +16,10 @@ license="GPL-3"
 distfiles="${GNU_SITE}/$pkgname/$pkgname-$version.tar.xz"
 checksum=cd9c543a411a05b2b647dd38936034b68c2b5d6f10e0d51dc168c166c973ba40
 
+if [ "${CROSS_BUILD}" ]; then
+	# Make python2.7 detection work in cross builds
+	CFLAGS+=" -I${XBPS_CROSS_BASE}/usr/include/python2.7"
+fi
 # Package build options
 build_options="gdbserver static python"
 desc_option_gdbserver="Enable support for building GDB server"


### PR DESCRIPTION
gdb/configure doesn't find .../python2.7/Python.h without this.

Configure also tells it doesn't find expat, so perhaps `makedepends+=" expat-devel"`?