### PR TITLE
New package: libopenraw-0.0.9

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2051,3 +2051,5 @@ libcodeblocks.so.0 codeblocks-13.12_1
 liblept.so.4 leptonica-1.72_1
 libtesseract.so.3 tesseract-ocr-3.02.02_1
 libffmpegthumbnailer.so.4 ffmpegthumbnailer-2.0.10_1
+libopenraw.so.1 libopenraw-0.0.9_1
+libopenrawgnome.so.1 libopenraw-0.0.9_1

--- a/srcpkgs/libopenraw-devel
+++ b/srcpkgs/libopenraw-devel
@@ -1,0 +1,1 @@
+libopenraw

--- a/srcpkgs/libopenraw/template
+++ b/srcpkgs/libopenraw/template
@@ -1,0 +1,37 @@
+# Template file for 'libopenraw'
+pkgname=libopenraw
+version=0.0.9
+revision=1
+build_style=gnu-configure
+configure_args="--with-boost=${XBPS_CROSS_BASE}/usr"
+hostmakedepends="pkg-config curl"
+makedepends="glib-devel gdk-pixbuf-devel boost-devel libxml2-devel libjpeg-turbo-devel"
+triggers="gtk-pixbuf-loaders"
+short_desc="Library for camera RAW files decoding"
+maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
+license="GPL-3"
+homepage="http://${pkgname}.freedesktop.org/wiki/"
+distfiles="http://${pkgname}.freedesktop.org/download/${pkgname}-${version}.tar.bz2"
+checksum=49fd1adf0a0228c7a17a79bf98d8d03664195feae1e50f4ddd1b20162626e18f
+
+LDFLAGS="-L${XBPS_CROSS_BASE}/usr/lib"
+post_configure() {
+	# Fix local posix_{open,close} name clash with unistd.h
+	sed -e "s;posix_open;s_posix_open;g" \
+		-e "s;posix_close;s_posix_close;g" \
+		-i ${wrksrc}/lib/io/posix_io.c
+}
+post_install() {
+	# Remove gdk-pixbuf static lib
+	rm ${DESTDIR}/usr/lib/gdk-pixbuf-*/*/loaders/libopenraw_pixbuf.a
+}
+libopenraw-devel_package() {
+	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
+	description=" - development files"
+	pkg_install() {
+		vmove "usr/lib/*.so"
+		vmove "usr/lib/*.a"
+		vmove usr/lib/pkgconfig
+		vmove usr/include
+	}
+}


### PR DESCRIPTION
With this and ffmpegthumbnailer the tumbler package can be completed.
Why the cross builds don't find boost escapes me. Perhaps because the package doesn't recognize `--with-libtool-sysroot`?