### PR TITLE
linux4.0: make sure $hdrdest dirs exist

### DIFF
--- a/srcpkgs/linux4.0/template
+++ b/srcpkgs/linux4.0/template
@@ -50,9 +50,9 @@ do_configure() {
 			;;
 	esac
 
-        if [ "$CROSS_BUILD" ]; then
-                _args="CROSS_COMPILE=${XBPS_CROSS_TRIPLET}-"
-        fi
+	if [ "$CROSS_BUILD" ]; then
+		_args="CROSS_COMPILE=${XBPS_CROSS_TRIPLET}-"
+	fi
 
 	if [ -f ${FILESDIR}/${arch}-dotconfig-custom ]; then
 		msg_normal "Detected a custom .config file for your arch, using it.\n"
@@ -78,9 +78,9 @@ do_build() {
 		x86_64*) _args="bzImage modules"; arch=x86_64;;
 		armv7*) _args="zImage modules dtbs"; arch=arm;;
 	esac
-        if [ "$CROSS_BUILD" ]; then
-                _cross="CROSS_COMPILE=${XBPS_CROSS_TRIPLET}-"
-        fi
+	if [ "$CROSS_BUILD" ]; then
+		_cross="CROSS_COMPILE=${XBPS_CROSS_TRIPLET}-"
+	fi
 
 	make ARCH=$arch ${_cross} ${makejobs} prepare
 	make ARCH=$arch ${_cross} ${makejobs} ${_args}
@@ -151,9 +151,11 @@ do_install() {
 	mkdir -p ${hdrdest}/arch/${arch}/kernel
 	cp arch/x86/Makefile ${hdrdest}/arch/${arch}
 	if [ "$arch" = "i386" ]; then
+		mkdir -p ${hdrdest}/arch/x86
 		cp arch/x86/Makefile_32.cpu ${hdrdest}/arch/x86
 	fi
 	if [ "$arch" = "i386" -o "$arch" = "x86_64" ]; then
+		mkdir -p ${hdrdest}/arch/x86/kernel
 		cp arch/x86/kernel/asm-offsets.s ${hdrdest}/arch/x86/kernel
 	fi
 


### PR DESCRIPTION
Build failed in x86_64-musl masterdir when running `./xbps-src -m /tmp/musl -N pkg base-system`