### PR TITLE
abduco: fix building

### DIFF
--- a/srcpkgs/abduco/template
+++ b/srcpkgs/abduco/template
@@ -1,7 +1,7 @@
 # Template file for 'abduco'
 pkgname=abduco
 version=0.4
-revision=1
+revision=2
 build_pie=yes
 build_style=gnu-makefile
 short_desc="Session management in a clean and simple way"
@@ -10,6 +10,10 @@ license="ISC"
 homepage="http://www.brain-dump.org/projects/abduco/"
 distfiles="http://www.brain-dump.org/projects/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=bda3729df116ce41f9a087188d71d934da2693ffb1ebcf33b803055eb478bcbb
+
+do_build() {
+	make CC="$CC"
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
From failing build:
```
abduco build options:
CFLAGS   = -mtune=generic -O2 -pipe -fstack-protector-strong -D_FORTIFY_SOURCE=2    -specs=/void-packages/common/environment/configure/gccspecs/hardened-cc1
LDFLAGS  = -Wl,--as-needed -Wl,-z,relro  -specs=/void-packages/common/environment/configure/gccspecs/hardened-ld
```

To:
```
abduco build options:
CFLAGS   = -mtune=generic -O2 -pipe -fstack-protector-strong -D_FORTIFY_SOURCE=2    -specs=/void-packages/common/environment/configure/gccspecs/hardened-cc1 -std=c99 -pedanti
c -Wall -I. -DVERSION="0.4" -DNDEBUG -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700
LDFLAGS  =   -Wl,--as-needed -Wl,-z,relro  -specs=/void-packages/common/environment/configure/gccspecs/hardened-ld -lc -lutil
```