### PR TITLE
ebtables: include patch from Alpine to fix *-musl

### DIFF
--- a/srcpkgs/ebtables/patches/musl-fixes.patch
+++ b/srcpkgs/ebtables/patches/musl-fixes.patch
@@ -1,0 +1,141 @@
+This patch was made by Natanael Copa of the Alpine Linux project.
+http://git.alpinelinux.org/cgit/aports/commit/?id=0f5076024a9700644ac9d542d2ca643fa38e77da
+
+--- Makefile.orig
++++ Makefile
+@@ -17,7 +17,7 @@
+ SYSCONFIGDIR:=/etc/sysconfig
+ DESTDIR:=
+ 
+-CFLAGS:=-Wall -Wunused -Werror
++CFLAGS:=-Wall -Wunused
+ CFLAGS_SH_LIB:=-fPIC -O3
+ CC:=gcc
+ 
+--- extensions/ebt_among.c.orig
++++ extensions/ebt_among.c
+@@ -12,14 +12,14 @@
+ #include <getopt.h>
+ #include <ctype.h>
+ #include <unistd.h>
+-#include "../include/ebtables_u.h"
++#include <sys/mman.h>
++#include <sys/stat.h>
++#include <fcntl.h>
+ #include <netinet/ether.h>
++#include "../include/ebtables_u.h"
+ #include "../include/ethernetdb.h"
+ #include <linux/if_ether.h>
+ #include <linux/netfilter_bridge/ebt_among.h>
+-#include <sys/mman.h>
+-#include <sys/stat.h>
+-#include <fcntl.h>
+ 
+ #define AMONG_DST '1'
+ #define AMONG_SRC '2'
+--- extensions/ebt_arpreply.c.orig
++++ extensions/ebt_arpreply.c
+@@ -11,8 +11,8 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <getopt.h>
+-#include "../include/ebtables_u.h"
+ #include <netinet/ether.h>
++#include "../include/ebtables_u.h"
+ #include <linux/netfilter_bridge/ebt_arpreply.h>
+ 
+ static int mac_supplied;
+--- extensions/ebt_ip6.c.orig
++++ extensions/ebt_ip6.c
+@@ -53,8 +53,8 @@
+ 
+ struct icmpv6_names {
+ 	const char *name;
+-	u_int8_t type;
+-	u_int8_t code_min, code_max;
++	uint8_t type;
++	uint8_t code_min, code_max;
+ };
+ 
+ static const struct icmpv6_names icmpv6_codes[] = {
+--- extensions/ebt_limit.c.orig
++++ extensions/ebt_limit.c
+@@ -59,11 +59,11 @@
+ "                                default %u\n", EBT_LIMIT_BURST);
+ }
+ 
+-static int parse_rate(const char *rate, u_int32_t *val)
++static int parse_rate(const char *rate, uint32_t *val)
+ {
+ 	const char *delim;
+-	u_int32_t r;
+-	u_int32_t mult = 1;  /* Seconds by default. */
++	uint32_t r;
++	uint32_t mult = 1;  /* Seconds by default. */
+ 
+ 	delim = strchr(rate, '/');
+ 	if (delim) {
+@@ -151,7 +151,7 @@
+ struct rates
+ {
+ 	const char *name;
+-	u_int32_t mult;
++	uint32_t mult;
+ };
+ 
+ static struct rates g_rates[] =
+@@ -162,7 +162,7 @@
+ 	{ "sec", EBT_LIMIT_SCALE }
+ };
+ 
+-static void print_rate(u_int32_t period)
++static void print_rate(uint32_t period)
+ {
+ 	unsigned int i;
+ 
+--- extensions/ebt_nat.c.orig
++++ extensions/ebt_nat.c
+@@ -10,8 +10,8 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <getopt.h>
+-#include "../include/ebtables_u.h"
+ #include <netinet/ether.h>
++#include "../include/ebtables_u.h"
+ #include <linux/netfilter_bridge/ebt_nat.h>
+ 
+ static int to_source_supplied, to_dest_supplied;
+--- include/ethernetdb.h.orig
++++ include/ethernetdb.h
+@@ -30,6 +30,10 @@
+ #define	_PATH_ETHERTYPES	"/etc/ethertypes"
+ #endif				/* _PATH_ETHERTYPES */
+ 
++#ifndef __THROW
++#define __THROW
++#endif
++
+ struct ethertypeent {
+ 	char *e_name;		/* Official ethernet type name.  */
+ 	char **e_aliases;	/* Alias list.  */
+--- useful_functions.c.orig
++++ useful_functions.c
+@@ -22,8 +22,7 @@
+  * along with this program; if not, write to the Free Software
+  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+  */
+-#include "include/ebtables_u.h"
+-#include "include/ethernetdb.h"
++#define _GNU_SOURCE
+ #include <stdio.h>
+ #include <netinet/ether.h>
+ #include <string.h>
+@@ -33,6 +32,8 @@
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <arpa/inet.h>
++#include "include/ebtables_u.h"
++#include "include/ethernetdb.h"
+ 
+ const unsigned char mac_type_unicast[ETH_ALEN] =   {0,0,0,0,0,0};
+ const unsigned char msk_type_unicast[ETH_ALEN] =   {1,0,0,0,0,0};

--- a/srcpkgs/ebtables/template
+++ b/srcpkgs/ebtables/template
@@ -2,28 +2,31 @@
 pkgname=ebtables
 version=2.0.10.4
 _version=${version%.*}-${version##*.}
-revision=2
+revision=3
 build_style=gnu-makefile
+conf_files="/etc/ebtables.conf"
 short_desc="Filtering tool for a Linux-based bridging firewall"
-maintainer="Enno Boland <eb@s01.de>"
+maintainer="beefcurtains <beefcurtains@users.noreply.github.com>"
 license="GPL-2"
 homepage="http://ebtables.netfilter.org/"
 depends="perl"
 distfiles="http://ftp.netfilter.org/pub/ebtables/${pkgname}-v${_version}.tar.gz"
 checksum=dc6f7b484f207dc712bfca81645f45120cb6aee3380e77a1771e9c34a9a4455d
 wrksrc=${pkgname}-v${_version}
-make_build_args="CFLAGS+=-Wno-error=unused-but-set-variable"
 make_install_args="
- LIBDIR=/usr/lib \
  MANDIR=/usr/share/man \
- BINDIR=/usr/sbin \
+ BINDIR=/usr/bin \
  INITDIR=/etc/rc.d \
  SYSCONFIGDIR=/etc
 "
 broken_as_needed=yes
 
+pre_build() {
+	rm include/linux/if_ether.h
+}
+
 post_install() {
 	rm -r $DESTDIR/etc/rc.d $DESTDIR/etc/ebtables-config
-	touch /etc/ebtables.conf
+	touch $DESTDIR/etc/ebtables.conf
 	vsv ebtables
 }


### PR DESCRIPTION
[Original source](http://git.alpinelinux.org/cgit/aports/commit/main/ebtables/musl-fixes.patch?id=0f5076024a9700644ac9d542d2ca643fa38e77da). Thanks to Natanael Copa.