### PR TITLE
evolution-data-server: revbump, patch + hook to build with musl

### DIFF
--- a/common/environment/configure/autoconf_cache/musl-linux
+++ b/common/environment/configure/autoconf_cache/musl-linux
@@ -4,3 +4,5 @@ gt_cv_func_gnugettext1_libc=yes
 gt_cv_func_gnugettext2_libc=yes
 gt_cv_func_gnugettext3_libc=yes
 ac_cv_sys_file_offset_bits=64
+# Force detection of musl's iconv
+ac_cv_libiconv_utf8=yes

--- a/srcpkgs/evolution-data-server/patches/iconv_10646.patch
+++ b/srcpkgs/evolution-data-server/patches/iconv_10646.patch
@@ -1,0 +1,14 @@
+Add a definition for ICONV_10646 in case it's missing
+
+--- camel/camel-iconv.h	2014-03-24 10:07:52.000000000 +0100
++++ camel/camel-iconv.h	2015-06-01 08:41:44.271620227 +0200
+@@ -28,6 +28,9 @@
+ #include <sys/types.h>
+ #include <iconv.h>
+ #include <glib.h>
++#ifndef ICONV_10646
++#define ICONV_10646 "iso-10646"
++#endif
+ 
+ G_BEGIN_DECLS
+ 

--- a/srcpkgs/evolution-data-server/template
+++ b/srcpkgs/evolution-data-server/template
@@ -1,7 +1,7 @@
 # Template file for 'evolution-data-server'
 pkgname=evolution-data-server
 version=3.12.11
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-openldap --disable-uoa
  --with-krb5=/usr --with-nspr-includes=/usr/include/nspr


### PR DESCRIPTION
The evolution-data-server configure script doesn't trust musl iconv() implementation.
Tell it to assume it's good by setting `ac_cv_libiconv_utf8=hopefully`
A missing macro `ICONV_10646` is conditionally defined in camel/camel-inconv.h to `iso-10646`, which I hope is right for musl's iconv as well.
