### PR TITLE
evolution: revbump + hook to build with musl

### DIFF
--- a/srcpkgs/evolution/template
+++ b/srcpkgs/evolution/template
@@ -1,19 +1,19 @@
 # Template file for 'evolution'
 pkgname=evolution
 version=3.12.11
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-pst-import --with-openldap --disable-bogofilter
  --with-krb5=/usr --disable-schemas-compile --disable-static --disable-spamassassin
  --disable-text-highlight --disable-gtkspell"
-hostmakedepends="pkg-config intltool itstool gnome-doc-utils gobject-introspection"
+hostmakedepends="pkg-config intltool itstool gnome-doc-utils gobject-introspection gnome-icon-theme"
 makedepends="
  libgdata-devel webkitgtk-devel evolution-data-server-devel
  GConf-devel clutter-gtk-devel libcanberra-devel
  gtkhtml-devel libsoup-gnome-devel gnome-desktop-devel
  libnotify-devel gstreamer1-devel libgweather-devel
  NetworkManager-devel enchant-devel iso-codes"
-depends="gtkhtml>=4.6 hicolor-icon-theme desktop-file-utils iso-codes"
+depends="gtkhtml>=4.6 gnome-keyring gnome-icon-theme hicolor-icon-theme desktop-file-utils iso-codes"
 short_desc="Integrated mail, addressbook and calendaring for GNOME"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"


### PR DESCRIPTION
Similar to evolution-data-server also evolution is not happy with musl iconv()
Convince configure to go ahead and write a default iconv-detect.h

Also add gnome-icon-theme to hostdepends and depends, as configure wants either gnome-icon-theme or adwaita-icon-theme installed.

The dependency on gnome-keyring is required for authentication with servers.