### PR TITLE
gnome-keyring: fix build on musl

### DIFF
--- a/srcpkgs/gnome-keyring/patches/sys-select-h.patch
+++ b/srcpkgs/gnome-keyring/patches/sys-select-h.patch
@@ -1,0 +1,12 @@
+Add include of sys/select.h for FD_ISSET definition
+
+--- pkcs11/rpc-layer/gkm-rpc-daemon-standalone.c	2015-06-01 08:19:06.507624249 +0200
++++ pkcs11/rpc-layer/gkm-rpc-daemon-standalone.c	2015-06-01 08:19:45.070624135 +0200
+@@ -31,6 +31,7 @@
+ #include <unistd.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <sys/select.h>
+ 
+ #include <dlfcn.h>
+ #include <pthread.h>

--- a/srcpkgs/gnome-keyring/template
+++ b/srcpkgs/gnome-keyring/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-keyring'
 pkgname=gnome-keyring
 version=3.14.0
-revision=1
+revision=2
 lib32disabled=yes
 build_style=gnu-configure
 configure_args="--with-pam-dir=/usr/lib/security --disable-schemas-compile"
@@ -13,6 +13,6 @@ depends="libcap-progs dconf>=0.18 gcr>=3.12"
 short_desc="GNOME password and secret manager"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
-license="GPL, LGPL"
+license="GPL-2, LGPL-2.1"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=c7059516cc47192e8bc5f1095e8e57cd3388825a4584ea8ad67a97763b7c9040


### PR DESCRIPTION
To get evolution compiled with musl libc, this patch is required as well, because evolution depends on gnome-keyring for authenticating with servers.
Then the evolution-data-server pr #1703 is required and finally evolution #1704 should build.

The result can be previewed when installing `evolution` from `--repository=http://muslrepo.voidlinux.de/current` which has all required packages.