### PR TITLE
widelands: unbreak musl build

### DIFF
--- a/srcpkgs/widelands/patches/fix-execinfo.patch
+++ b/srcpkgs/widelands/patches/fix-execinfo.patch
@@ -1,0 +1,30 @@
+Disable execinfo.h and backtrace() for musl
+
+--- src/backtrace.cc	2015-06-01 10:36:22.655599851 +0200
++++ src/backtrace.cc	2015-06-01 10:35:04.179600083 +0200
+@@ -22,15 +22,17 @@
+ #ifndef _WIN32
+ #ifndef __APPLE__
+ #include <cstdlib>
+-
++#ifdef	__GLIBC__
+ #include <execinfo.h>
+ #endif
+ #endif
++#endif
+ 
+ std::string get_backtrace() {
+ 	std::string result("Backtrace:\n");
+ #ifndef _WIN32
+ #ifndef __APPLE__
++#ifdef	__GLIBC__
+ #define BACKTRACE_STACKSIZE 24
+ 
+ 	void * stack[BACKTRACE_STACKSIZE];
+@@ -43,5 +45,6 @@
+ 	free(list);
+ #endif
+ #endif
++#endif
+ 	return result;
+ }

--- a/srcpkgs/widelands/patches/fix_nl_msg_cat_cntr.patch
+++ b/srcpkgs/widelands/patches/fix_nl_msg_cat_cntr.patch
@@ -1,0 +1,18 @@
+--- src/i18n.cc	2014-02-22 10:06:51.000000000 +0100
++++ src/i18n.cc	2015-06-01 10:44:01.035598493 +0200
+@@ -192,6 +192,7 @@
+ #endif
+ 
+ #ifdef __linux__
++#ifdef __GLIBC__
+ 	char * res = nullptr;
+ 	char const * encoding[] = {"", ".utf-8", "@euro", ".UTF-8"};
+ 	std::size_t found = alt_str.find(',', 0);
+@@ -236,6 +237,7 @@
+ 	/* Finally make changes known.  */
+ 	++_nl_msg_cat_cntr;
+ #endif
++#endif
+ 
+ 	SETLOCALE(LC_ALL, ""); //  call to libintl
+ 

--- a/srcpkgs/widelands/template
+++ b/srcpkgs/widelands/template
@@ -1,7 +1,7 @@
 # Template file for 'widelands'
 pkgname=widelands
 version=18
-revision=2
+revision=3
 wrksrc=${pkgname}-build${version}-src
 build_style=cmake
 configure_args="


### PR DESCRIPTION
+ execinfo.h missing and no backtrace() in musl libc
+ `extern int _nl_msg_cat_cntr;` reference doesn't work (hidden in libintl.so?)
