### PR TITLE
chroot-util-linux: disable programs that use pam

### DIFF
--- a/srcpkgs/chroot-util-linux/template
+++ b/srcpkgs/chroot-util-linux/template
@@ -1,7 +1,7 @@
 # Template file for 'chroot-util-linux'
 pkgname=chroot-util-linux
 version=2.24.1
-revision=3
+revision=4
 wrksrc="${pkgname/chroot-/}-${version}"
 bootstrap=yes
 conflicts="util-linux>=0"
@@ -12,6 +12,8 @@ configure_args="--without-ncurses --without-udev --disable-libuuid
 --disable-libblkid --disable-libmount --disable-mount --disable-losetup
 --disable-fsck --disable-partx --disable-uuidd --disable-mountpoint
 --disable-fallocate --disable-unshare --disable-nls --disable-wall
+--disable-chfn-chsh-password --disable-su --disable-sulogin
+--disable-login --disable-runuser
  scanf_cv_alloc_modifier=as"
 short_desc="Miscellaneous linux utilities -- for xbps-src use"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"


### PR DESCRIPTION
If the host has ``pam-devel`` installed, bootstrapping fails because chroot-util-linux builds programs that rely on pam. This PR disables those programs explicitly.