### PR TITLE
beets: depends on python-setuptools

### DIFF
--- a/srcpkgs/beets/template
+++ b/srcpkgs/beets/template
@@ -1,11 +1,11 @@
 # Template file for 'beets'
 pkgname=beets
 version=1.3.13
-revision=2
+revision=3
 noarch=yes
 build_style="python-module"
 hostmakedepends="python-setuptools"
-depends="mutagen python-enum34 python-munkres python-musicbrainzngs python-Unidecode python-yaml python-jellyfish"
+depends="mutagen python-enum34 python-munkres python-musicbrainzngs python-Unidecode python-yaml python-jellyfish python-setuptools"
 pycompile_module="beets beetsplug"
 short_desc="Media library management system for obsessive-compulsive music geeks"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"


### PR DESCRIPTION
ImportError: No module named pkg_resources