### PR TITLE
epson-inkjet-printer-escpr: update to 1.4.5.

### DIFF
--- a/srcpkgs/epson-inkjet-printer-escpr/template
+++ b/srcpkgs/epson-inkjet-printer-escpr/template
@@ -1,6 +1,6 @@
 # Template file for 'epson-inkject-printer-escpr'
 pkgname=epson-inkjet-printer-escpr
-version=1.4.3
+version=1.4.5
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --with-cupsppddir=/usr/share/ppd --with-cupsfilterdir=/usr/lib/cups/filter"
@@ -10,5 +10,5 @@ short_desc="Epson Inkjet Printer Driver (ESC/P-R)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX"
-distfiles="http://pkgs.fedoraproject.org/repo/pkgs/${pkgname}/${pkgname}-${version}-1lsb3.2.tar.gz/b58b448a1f47498537d06a2baf9310c2/${pkgname}-${version}-1lsb3.2.tar.gz"
-checksum=f97f23293494f0c3ef9d1a171484fc1825387268bb248e004235564f786a1498
+distfiles="https://download3.ebz.epson.net/dsc/f/03/00/03/52/19/465c03d0ac4d2a6408d82b65b7178441a2dffb9c/epson-inkjet-printer-escpr-1.4.5-1lsb3.2.tar.gz"
+checksum=90766deb4c5ca97def703a7bf91a0b0cb312ec9aaa769e036fb05fee2083b580


### PR DESCRIPTION
had to change the download link to epson directly. i'm not a lawyer, maybe someone has a look at the license stuff at http://download.ebz.epson.net/dsc/du/02/DriverDownloadInfo.do?LG2=EN&CN2=&DSCMI=35219&DSCCHK=01a2288d3ec549615b1491db99fd832d75b73aac# before merging.