### PR TITLE
libenet: update to 1.3.13

### DIFF
--- a/srcpkgs/libenet/template
+++ b/srcpkgs/libenet/template
@@ -1,7 +1,7 @@
 # Template file for 'enet'
 pkgname=libenet
-version=1.3.12
-revision=2
+version=1.3.13
+revision=1
 build_style=gnu-configure
 short_desc="Reliable UDP networking library"
 maintainer="necrophcodr <necrophcodr@necrophcodr.me>"
@@ -9,7 +9,7 @@ license="MIT"
 homepage="http://enet.bespin.org"
 distfiles="http://enet.bespin.org/download/enet-${version}.tar.gz"
 wrksrc="enet-${version}"
-checksum=a5851cbd0dde2ddb47bca487a61976825159cb508ece3b1e34605420ac7e1d0b
+checksum=e36072021faa28731b08c15b1c3b5b91b911baf5f6abcc7fe4a6d425abada35c
 
 libenet-devel_package() {
 	depends="libenet>=${version}_${revision}"
@@ -19,6 +19,5 @@ libenet-devel_package() {
 		vmove "usr/lib/*.a"
 		vmove usr/lib/pkgconfig
 		vmove usr/include
-	}	
+	}
 }
-


### PR DESCRIPTION
This commit simply updates libenet from 1.3.12 to 1.3.13.  No major changes happened there.