### PR TITLE
qt5: unbreak musl

### DIFF
--- a/srcpkgs/qt5/files/resolv_compat.h
+++ b/srcpkgs/qt5/files/resolv_compat.h
@@ -1,0 +1,29 @@
+#if !defined(__GLIBC__)
+/***************************************************************************
+ * resolv_compat.h
+ *
+ * Mimick GLIBC's res_ninit() and res_nclose() for musl libc
+ * Note: res_init() is actually deprecated according to
+ * http://docs.oracle.com/cd/E36784_01/html/E36875/res-nclose-3resolv.html
+ **************************************************************************/
+#include <string.h>
+
+static inline int res_ninit(res_state statp)
+{
+	int rc = res_init();
+	if (statp != &_res) {
+		memcpy(statp, &_res, sizeof(*statp));
+	}
+	return rc;
+}
+
+static inline int res_nclose(res_state statp)
+{
+	if (!statp)
+		return -1;
+	if (statp != &_res) {
+		memset(statp, 0, sizeof(*statp));
+	}
+	return 0;
+}
+#endif

--- a/srcpkgs/qt5/patches/qt-musl-mallinfo.patch
+++ b/srcpkgs/qt5/patches/qt-musl-mallinfo.patch
@@ -1,0 +1,13 @@
+In musl libc there is no struct mallinfo and no function mallinf()
+
+--- qtwebengine/src/3rdparty/chromium/content/child/content_child_helpers.cc	2015-06-05 04:52:18.502230985 +0200
++++ qtwebengine/src/3rdparty/chromium/content/child/content_child_helpers.cc	2015-06-05 04:52:06.712231020 +0200
+@@ -15,7 +15,7 @@
+
+ namespace content {
+
+-#if defined(OS_LINUX) || defined(OS_ANDROID)
++#if (defined(OS_LINUX) && defined(__GLIBC__)) || defined(OS_ANDROID)
+ size_t GetMemoryUsageKB() {
+   struct mallinfo minfo = mallinfo();
+   uint64_t mem_usage =

--- a/srcpkgs/qt5/patches/qt-musl-pthread_getattr_np.patch
+++ b/srcpkgs/qt5/patches/qt-musl-pthread_getattr_np.patch
@@ -1,0 +1,13 @@
+The musl libc also has pthread_getattr_np()
+
+--- qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/ThreadState.cpp	2015-02-17 05:58:05.000000000 +0100
++++ qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/ThreadState.cpp	2015-06-05 02:29:15.253256411 +0200
+@@ -54,7 +54,7 @@
+
+ static void* getStackStart()
+ {
+-#if defined(__GLIBC__) || OS(ANDROID)
++#if defined(__GLIBC__) || OS(ANDROID) || OS(LINUX_MUSL)
+     pthread_attr_t attr;
+     if (!pthread_getattr_np(pthread_self(), &attr)) {
+         void* base;

--- a/srcpkgs/qt5/patches/qt-musl-resolve.patch
+++ b/srcpkgs/qt5/patches/qt-musl-resolve.patch
@@ -1,0 +1,29 @@
+The musl resolver does not define res_ninit() and res_nclose() functions
+like glibc does. A wrapper for musl to mimick GLIBC's function should do
+the trick.
+
+--- qtwebengine/src/3rdparty/chromium/net/base/dns_reloader.cc	2015-06-03 12:34:26.979892244 +0200
++++ qtwebengine/src/3rdparty/chromium/net/base/dns_reloader.cc	2015-06-03 12:32:07.091899808 +0200
+@@ -8,6 +8,9 @@
+     !defined(OS_ANDROID)
+
+ #include <resolv.h>
++#if defined(OS_LINUX) && !defined(__GLIBC__)
++#include "net/dns/resolv_compat.h"
++#endif
+
+ #include "base/basictypes.h"
+ #include "base/lazy_instance.h"
+--- qtwebengine/src/3rdparty/chromium/net/dns/dns_config_service_posix.cc	2015-02-17 05:58:45.000000000 +0100
++++ qtwebengine/src/3rdparty/chromium/net/dns/dns_config_service_posix.cc	2015-06-04 22:22:01.104300355 +0200
+@@ -21,6 +21,10 @@
+ #include "net/dns/notify_watcher_mac.h"
+ #include "net/dns/serial_worker.h"
+
++#if defined(OS_LINUX) && !defined(__GLIBC__)
++#include "net/dns/resolv_compat.h"
++#endif
++
+ #if defined(OS_MACOSX) && !defined(OS_IOS)
+ #include "net/dns/dns_config_watcher_mac.h"
+ #endif

--- a/srcpkgs/qt5/patches/qt-musl-rtld_deepbind.patch
+++ b/srcpkgs/qt5/patches/qt-musl-rtld_deepbind.patch
@@ -1,0 +1,18 @@
+--- qtwebengine/src/3rdparty/chromium/third_party/libjingle/source/talk/base/latebindingsymboltable.cc	2015-02-17 05:58:22.000000000 +0100
++++ qtwebengine/src/3rdparty/chromium/third_party/libjingle/source/talk/base/latebindingsymboltable.cc	2015-06-05 01:29:43.582266992 +0200
+@@ -118,6 +118,7 @@
+                    // versions of the same library to not explode.
+                    RTLD_NOW|RTLD_LOCAL
+ #ifdef LINUX
++#ifdef __GLIBC__
+                    // RTLD_DEEPBIND makes symbol dependencies in the
+                    // newly-loaded tree prefer to resolve to definitions within
+                    // that tree (the default on OS X). This is necessary for
+@@ -125,6 +126,7 @@
+                    // library to not explode.
+                    |RTLD_DEEPBIND
+ #endif
++#endif
+                    );  // NOLINT
+ #else
+ #error Not implemented

--- a/srcpkgs/qt5/patches/qt-musl-siginfo_t.patch
+++ b/srcpkgs/qt5/patches/qt-musl-siginfo_t.patch
@@ -1,0 +1,18 @@
+There's a subtle difference in the internal name of siginfo_t fields
+between glibc and musl. The structure itself is equivalent, so it
+should suffice to add a macro to rename the field.
+
+--- qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/trap.cc	2015-02-17 05:57:43.000000000 +0100
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/trap.cc	2015-06-03 08:20:25.032716427 +0200
+@@ -22,6 +22,11 @@
+ #include "sandbox/linux/services/android_ucontext.h"
+ #endif
+
++// musl libc defines siginfo_t __si_fields instead of _sifields
++#if !defined(__GLIBC__)
++#define _sifields __si_fields
++#endif
++
+ namespace {
+
+ const int kCapacityIncrement = 20;

--- a/srcpkgs/qt5/patches/qt-musl-sys_errno_h.patch
+++ b/srcpkgs/qt5/patches/qt-musl-sys_errno_h.patch
@@ -1,0 +1,13 @@
+Fix a warning issued by musl libc headers
+
+--- qtwebengine/src/3rdparty/chromium/base/file_util_posix.cc	2015-02-17 05:57:34.000000000 +0100
++++ qtwebengine/src/3rdparty/chromium/base/file_util_posix.cc	2015-06-05 12:20:48.831848404 +0200
+@@ -12,7 +12,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <sys/errno.h>
++#include <errno.h>
+ #include <sys/mman.h>
+ #include <sys/param.h>
+ #include <sys/stat.h>

--- a/srcpkgs/qt5/template
+++ b/srcpkgs/qt5/template
@@ -1,7 +1,7 @@
 # Template file for 'qt5'
 pkgname=qt5
 version=5.4.1
-revision=4
+revision=5
 wrksrc="qt-everywhere-opensource-src-${version}"
 homepage="http://qt.io/"
 short_desc="A cross-platform application and UI framework (QT5)"
@@ -24,13 +24,23 @@ makedepends="
  nss-devel libcap-devel libxkbcommon-devel wayland-devel"
 depends="qtchooser"
 
-case "$XBPS_TARGET_MACHINE" in
-	*-musl) broken="http://build.voidlinux.eu/builders/x86_64-musl_builder/builds/723/steps/shell_3/logs/stdio";;
-esac
-
 pre_configure() {
 	sed -i "s|-O2|${CXXFLAGS}|" qtbase/mkspecs/common/{g++,gcc}-base.conf
 	sed -i "/^QMAKE_LFLAGS\s/s|+=|+= ${LDFLAGS}|g" qtbase/mkspecs/common/gcc-base.conf
+
+	# Compatibility functions res_ninit() and res_nclose() for musl libc
+	cp ${FILESDIR}/resolv_compat.h ${wrksrc}/qtwebengine/src/3rdparty/chromium/net/dns
+	case "$XBPS_TARGET_MACHINE" in
+	*-musl)
+		# Patch .../linx/*/config.{h,asm} to define HAVE_SYSCTL 0
+		local config chromium=${wrksrc}/qtwebengine/src/3rdparty/chromium
+		for config in $(find ${chromium}/third_party/ffmpeg/chromium/config -name "config\.*" | grep linux); do
+			sed -i ${config} -e "s;HAVE_SYSCTL 1;HAVE_SYSCTL 0;"
+		done
+		# Define WTF_OS_LINUX_MUSL to 1 to activate the patch qt-musl-pthread_getattr_np.patch
+		sed -i ${chromium}/third_party/WebKit/Source/platform/heap/ThreadState.cpp \
+			-e "/namespace WebCore/i #define WTF_OS_LINUX_MUSL 1"
+	esac
 }
 do_configure() {
 	export LD_LIBRARY_PATH="${wrksrc}/qtbase/lib:${wrksrc}/qttools/lib:${LD_LIBRARY_PATH}"


### PR DESCRIPTION
It built locally on musl, but untested yet. Specificially the `resolv_compat.h` code may be doing something wrong. You get the idea, anyway.

