### PR TITLE
mame: testing musl fix on travis

### DIFF
--- a/srcpkgs/mame/patches/musl-sched.patch
+++ b/srcpkgs/mame/patches/musl-sched.patch
@@ -1,10 +1,15 @@
---- src/emu/emucore.h	2015-06-06 15:32:17.639326661 +0200
-+++ src/emu/emucore.h	2015-06-06 15:32:02.649327471 +0200
-@@ -19,6 +19,7 @@
- #include <string.h>
- #include <stdlib.h>
- #include <stdarg.h>
-+#include <sched.h>
+The musl libc header /usr/include/sched.h fails with the string.h
+memory functions redefined as macros, thus enable the mem tracking
+only if __GLIBC__ is defined as well.
+
+--- src/lib/util/corealloc.h	2015-06-06 19:27:52.467562344 +0200
++++ src/lib/util/corealloc.h	2015-06-06 19:30:09.602554928 +0200
+@@ -84,7 +84,7 @@
+ //  ADDDITIONAL MACROS
+ //**************************************************************************
  
- // some cleanups for Solaris for things defined in stdlib.h
- #if defined(__sun__) && defined(__svr4__)
+-#ifndef NO_MEM_TRACKING
++#if !defined(NO_MEM_TRACKING) && defined(__GLIBC__)
+ // re-route classic malloc-style allocations
+ #undef malloc
+ #undef calloc

--- a/srcpkgs/mame/template
+++ b/srcpkgs/mame/template
@@ -1,7 +1,7 @@
 # Template file for 'mame'
 pkgname=mame
 version=0162
-revision=3
+revision=4
 wrksrc="mame-${version}s"
 homepage="http://mamedev.org"
 distfiles="https://github.com/mamedev/$pkgname/releases/download/${pkgname}${version}/${pkgname}${version}s.zip"
@@ -31,9 +31,6 @@ do_build() {
 		# Doesn't work yet because of qt (which can't be cross compiled ?)
 		opts+=" CROSS_BUILD=1 OVERRIDE_CC=${CC} OVERRIDE_CXX=${CXX} OVERRIDE_LD=${CC}"
 	fi
-	case "$XBPS_TARGET_MACHINE" in
-		*-musl) opts+=" NO_MEM_TRACKING=1" ;;
-	esac
 	make ${opts} ${makejobs}
 }
 do_install() {


### PR DESCRIPTION
Here's what a companion developer on mamedev list said regarding this topic:

> We should just drop defining free and malloc as macros in corealloc.h.
> Instead, we should on a regular basis scan the source for uses of free
> and malloc.

The patch entirely disables mem tracking for non-`__GLIBC__` now.