### PR TITLE
libvirt: add libvirt group

### DIFF
--- a/srcpkgs/libvirt/template
+++ b/srcpkgs/libvirt/template
@@ -1,7 +1,7 @@
 # Template file for 'libvirt'
 pkgname=libvirt
 version=1.2.16
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--without-hal --with-storage-lvm --with-qemu-user=nobody
  --disable-static
@@ -75,6 +75,8 @@ make_dirs="
  /var/lib/libvirt/dnsmasq 0755 root root
  /var/libvirt/boot 0755 root root
  /var/cache/libvirt/qemu 0755 root root"
+
+system_groups="libvirt"
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
/usr/share/polkit-1/rules.d/50-libvirt.rules:

```
// Allow any user in the 'libvirt' group to connect to system libvirtd
// without entering a password.

polkit.addRule(function(action, subject) {
    if (action.id == "org.libvirt.unix.manage" &&
        subject.isInGroup("libvirt")) {
        return polkit.Result.YES;
    }
});
```