### PR TITLE
diffutils: revive po/Makefile

### DIFF
--- a/srcpkgs/diffutils/template
+++ b/srcpkgs/diffutils/template
@@ -1,7 +1,7 @@
 # Template file for 'diffutils'
 pkgname=diffutils
 version=3.3
-revision=6
+revision=7
 bootstrap=yes
 build_pie=yes
 build_style=gnu-configure

--- a/srcpkgs/diffutils/template
+++ b/srcpkgs/diffutils/template
@@ -12,3 +12,10 @@ homepage="http://www.gnu.org/software/diffutils"
 license="GPL-3"
 distfiles="${GNU_SITE}/$pkgname/$pkgname-$version.tar.xz"
 checksum=a25e89a8ab65fded1731e4186be1bb25cda967834b6df973599cdcd5abdfc19c
+
+post_configure() {
+	# Since autoreconf is not run, @mkdir_p@ remains undefined
+	# in po/Makefile. Patch it.
+	sed -e "s;mkdir_p = @mkdir_p@;mkdir_p = \${MKDIR_P};" \
+		-i ${wrksrc}/po/Makefile
+}


### PR DESCRIPTION
Since autoreconf is not run, mkdir_p remains undefined (@mkdir_p@).
Patch it to get the translations installed.