### PR TITLE
nodejs: use shared http-parser by default

### DIFF
--- a/srcpkgs/nodejs/template
+++ b/srcpkgs/nodejs/template
@@ -1,7 +1,7 @@
 # Template file for 'nodejs'
 pkgname=nodejs
 version=0.12.4
-revision=1
+revision=2
 wrksrc=node-v${version}
 hostmakedepends="pkg-config python"
 makedepends="zlib-devel python-devel
@@ -19,8 +19,7 @@ build_options="ssl libuv http_parser"
 desc_option_libuv="Enable shared libuv"
 desc_option_http_parser="Enable shared http-parser"
 
-# shared http_parser broken
-build_options_default="ssl libuv"
+build_options_default="ssl libuv http_parser"
 
 do_configure() {
 	local _args


### PR DESCRIPTION
I fixed the ``http-parser-devel`` package, this build_option isn't broken anymore :space_invader: :space_invader: 