### PR TITLE
New package: gtkspell3

### DIFF
--- a/srcpkgs/gtkspell3-devel
+++ b/srcpkgs/gtkspell3-devel
@@ -1,0 +1,1 @@
+gtkspell3

--- a/srcpkgs/gtkspell3/template
+++ b/srcpkgs/gtkspell3/template
@@ -1,0 +1,35 @@
+# Template file for 'gtkspell3'
+pkgname=gtkspell3
+version=3.0.7
+revision=1
+build_options="gir"
+build_style=gnu-configure
+configure_args="--disable-silent-rules"
+hostmakedepends="$(vopt_if gir 'gobject-introspection vala') intltool pkg-config"
+makedepends="enchant-devel gtk+3-devel"
+short_desc="Highlighting and replacement of misspelled words"
+maintainer="beefcurtains <beefcurtains@voidlinux.eu>"
+license="GPL-2"
+homepage="http://${pkgname}.sourceforge.net/"
+distfiles="${SOURCEFORGE_SITE}/${pkgname::-1}/${version}/${pkgname}-${version}.tar.gz"
+checksum=13f2e6d3e2554cc24253ef592074b28c117db33b7a4465c98c69a3e0a4fa3cc2
+
+# Enable gir and vala for non-cross builds
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default="gir"
+fi
+
+gtkspell3-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		if [ "$build_option_gir" ]; then
+			vmove usr/share/gir-1.0
+			vmove usr/share/vala
+		fi
+	}
+}


### PR DESCRIPTION
This builds gtkspell 3.0.7 for GTK+3 only. The API is incompatible with 2.x versions, packages using that API can continue using the existing gtkspell packages.

With this package, it should be possible to build gnome applications (e.g. evolution) with spell check support.