### PR TITLE
qtcreator: Add missing dependency

### DIFF
--- a/srcpkgs/qtcreator/template
+++ b/srcpkgs/qtcreator/template
@@ -1,15 +1,15 @@
 # Template file for 'qtcreator'
 pkgname=qtcreator
 version=3.4.0
-revision=3
+revision=4
 wrksrc=qt-creator-opensource-src-${version}
 hostmakedepends="perl python pkg-config"
 makedepends="qt5-declarative-devel qt5-script-devel qt5-tools-devel"
 depends="qt5-connectivity-devel qt5-declarative-devel qt5-enginio-devel
- qt5-location-devel qt5-multimedia-devel qt5-quick1-devel qt5-script-devel
- qt5-sensors-devel qt5-serialport-devel qt5-svg-devel qt5-tools-devel
- qt5-wayland-devel qt5-webchannel-devel qt5-webengine-devel qt5-webkit-devel
- qt5-websockets-devel qt5-x11extras-devel qt5-xmlpatterns-devel
+ qt5-location-devel qt5-multimedia-devel qt5-quick1-devel qt5-quickcontrols
+ qt5-script-devel qt5-sensors-devel qt5-serialport-devel qt5-svg-devel
+ qt5-tools-devel qt5-wayland-devel qt5-webchannel-devel qt5-webengine-devel
+ qt5-webkit-devel qt5-websockets-devel qt5-x11extras-devel qt5-xmlpatterns-devel
  qt5-declarative-devel qt5-script-devel qt5-tools-devel qt5-doc qt5-plugin-sqlite"
 nocross=yes
 short_desc="A cross-platform IDE for Qt developers"


### PR DESCRIPTION
Also qt5-quickcontrols is required for qtcreator. Without it qtcreator
won't display the Welcome screen lists of sessions and projects.