### PR TITLE
New package: dunelegacy-0.96.3

### DIFF
--- a/srcpkgs/dunelegacy/template
+++ b/srcpkgs/dunelegacy/template
@@ -1,0 +1,19 @@
+# Template file for 'dunelegacy'
+pkgname=dunelegacy
+version=0.96.3
+revision=1
+build_style=gnu-configure
+configure_args="--disable-sdltest"
+makedepends="SDL_mixer-devel"
+short_desc="Modern Dune II reimplementation"
+maintainer="beefcurtains <beefcurtains@voidlinux.eu>"
+license="GPL-2"
+homepage="http://${pkgname}.sourceforge.net/website/"
+distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}/${version}/${pkgname}-${version}-src.tar.bz2"
+checksum=677159c174d9f9e8eb20e5e5cec997decf8e5a7091dc1583dc23fe340c5f6222
+
+post_install() {
+	vinstall dunelegacy.desktop 644 usr/share/applications
+	vinstall dunelegacy.png 644 usr/share/icons/hicolor/48x48/apps
+	vinstall dunelegacy.svg 644 usr/share/icons/hicolor/scalable/apps
+}


### PR DESCRIPTION
Data files can be found [over here](https://github.com/katlogic/dunelegacy/tree/115a5723176092966cef4fe1729abb2c1cb56cd5/data) ([download](https://github.com/katlogic/dunelegacy/archive/115a5723176092966cef4fe1729abb2c1cb56cd5.tar.gz)). Copy the ``PAK`` files to ``~/.config/dunelegacy/data``.