### PR TITLE
socat: unbreak musl builds for arm*, i686

### DIFF
--- a/common/environment/configure/autoconf_cache/arm-common
+++ b/common/environment/configure/autoconf_cache/arm-common
@@ -170,7 +170,6 @@ slrn_cv_va_val_copy=${slrn_cv_va_val_copy=yes}
 sc_cv_sys_crdly_shift=9
 sc_cv_sys_csize_shift=4
 sc_cv_sys_tabdly_shift=11
-sc_cv_termios_ispeed=yes
 sc_cv_type_dev_basic='8 /* unsigned long long */'
 sc_cv_type_gidt_basic='4 /* unsigned int */'
 sc_cv_type_longlong=yes
@@ -205,8 +204,6 @@ sc_cv_type_uint32=yes
 sc_cv_type_uint64=yes
 sc_cv_type_uint8=yes
 sc_cv_typeof_struct_cmsghdr_cmsg_len='4 /* unsigned int */'
-ac_cv_ispeed_offset=${ac_cv_ispeed_offset=13}
-sc_cv_termios_ispeed=${sc_cv_termios_ispeed=yes}
 
 # ssh
 ac_cv_have_space_d_name_in_struct_dirent=${ac_cv_dirent_have_space_d_name=yes}

--- a/common/environment/configure/autoconf_cache/common-glibc
+++ b/common/environment/configure/autoconf_cache/common-glibc
@@ -69,3 +69,7 @@ ac_cv_func___va_copy=${ac_cv_func___va_copy=yes}
 
 # Xorg
 xorg_cv_malloc0_returns_null=${xorg_cv_malloc0_returns_null=yes}
+
+# socat
+ac_cv_ispeed_offset=${ac_cv_ispeed_offset=13}
+sc_cv_termios_ispeed=${sc_cv_termios_ispeed=yes}

--- a/common/environment/configure/autoconf_cache/ix86-common
+++ b/common/environment/configure/autoconf_cache/ix86-common
@@ -168,7 +168,6 @@ rsync_cv_REPLACE_INET_ATON=${rsync_cv_REPLACE_INET_ATON=no}
 samba_cv_HAVE_GETTIMEOFDAY_TZ=${samba_cv_HAVE_GETTIMEOFDAY_TZ=yes}
 
 # socat
-sc_cv_termios_ispeed=yes
 sc_cv_type_dev_basic='8 /* unsigned long long */'
 sc_cv_type_gidt_basic='4 /* unsigned int */'
 sc_cv_type_longlong=yes

--- a/srcpkgs/socat/template
+++ b/srcpkgs/socat/template
@@ -1,7 +1,7 @@
 # Template file for 'socat'
 pkgname=socat
 version=1.7.3.0
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="--disable-libwrap --enable-fips
  ac_cv_have_z_modifier=yes sc_cv_sys_crdly_shift=9


### PR DESCRIPTION
musl's termios doesn't have c_ispeed.