### PR TITLE
gnome-disk-utility: disable compile warnings

### DIFF
--- a/srcpkgs/gnome-disk-utility/template
+++ b/srcpkgs/gnome-disk-utility/template
@@ -1,10 +1,10 @@
 # Template file for 'gnome-disk-utility'
 pkgname=gnome-disk-utility
 version=3.16.2
-revision=1
+revision=2
 lib32disabled=yes
 build_style=gnu-configure
-configure_args="--disable-static $(vopt_enable gir introspection)
+configure_args="--disable-static --enable-compile-warnings=no $(vopt_enable gir introspection)
  $(vopt_enable systemd libsystemd-login)"
 hostmakedepends="pkg-config intltool gnome-doc-utils
  glib-devel $(vopt_if gir gobject-introspection)"


### PR DESCRIPTION
This makes gnome-disk-utility build with musl libc.