### PR TITLE
gnome-desktop: add build option 'gir'

### DIFF
--- a/srcpkgs/gnome-desktop/template
+++ b/srcpkgs/gnome-desktop/template
@@ -1,10 +1,10 @@
 # Template file for 'gnome-desktop'
 pkgname=gnome-desktop
 version=3.16.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-gnome-distributor=void"
-hostmakedepends="pkg-config intltool itstool gnome-doc-utils gobject-introspection"
+hostmakedepends="pkg-config intltool itstool gnome-doc-utils $(vopt_if gir gobject-introspection)"
 makedepends="libxkbfile-devel gtk+3-devel gsettings-desktop-schemas-devel
  xkeyboard-config iso-codes"
 depends="gsettings-desktop-schemas>=3.14 xkeyboard-config iso-codes"
@@ -15,6 +15,11 @@ homepage="http://www.gnome.org"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=3a8f196b46eb9dbd3ba2afb8fb5fef6a8825539d449a02181311242e22227bd0
 
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi
+
 gnome-desktop-devel_package() {
 	depends="libxkbfile-devel gsettings-desktop-schemas-devel>=3.12
 		gtk+3-devel ${sourcepkg}>=${version}_${revision}"
@@ -22,7 +27,9 @@ gnome-desktop-devel_package() {
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
-		vmove usr/share/gir-1.0
+		if [ -n "$build_option_gir" ]; then
+			vmove usr/share/gir-1.0
+		fi
 		vmove usr/share/gtk-doc
 		vmove "usr/lib/*.so"
 	}


### PR DESCRIPTION
Like in other packages disable gobject-introspection for cross builds.