### PR TITLE
libgnomekbd: add build option 'gir'

### DIFF
--- a/srcpkgs/libgnomekbd/template
+++ b/srcpkgs/libgnomekbd/template
@@ -1,10 +1,10 @@
 # Template file for 'libgnomekbd'
 pkgname=libgnomekbd
 version=3.6.0
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--disable-static"
-hostmakedepends="pkg-config intltool gobject-introspection glib-devel"
+hostmakedepends="pkg-config intltool $(vopt_if gir gobject-introspection) glib-devel"
 makedepends="libxml2-devel gtk+3-devel libxklavier-devel"
 depends="desktop-file-utils"
 short_desc="Gnome keyboard configuration library"
@@ -14,6 +14,12 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 distfiles="${GNOME_SITE}/$pkgname/3.6/$pkgname-$version.tar.xz"
 checksum=c41ea5b0f64da470925ba09f9f1b46b26b82d4e433e594b2c71eab3da8856a09
 
+LDFLAGS="-L${XBPS_CROSS_BASE}/usr/lib"
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi
+
 libgnomekbd-devel_package() {
 	depends="libxml2-devel gtk+3-devel>=3.6.0_2 libxklavier-devel ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" -- development files"
@@ -21,6 +27,8 @@ libgnomekbd-devel_package() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
-		vmove usr/share/gir-1.0
+		if [ -n "$build_option_gir" ]; then
+			vmove usr/share/gir-1.0
+		fi
 	}
 }


### PR DESCRIPTION
Also fix cross building by setting LDFLAGS to the appropriate
${XBPS_CROSS_BASE}/usr/lib