### PR TITLE
libgweather: fix cross building

### DIFF
--- a/srcpkgs/libgweather/template
+++ b/srcpkgs/libgweather/template
@@ -1,10 +1,10 @@
 # Template file for 'libgweather'
 pkgname=libgweather
 version=3.16.1
-revision=1
+revision=2
 build_style=gnu-configure
 build_options="gir"
-configure_args="$(vopt_enable gir '--enable-introspection --enable-vala' '--disable-introspection --disable-vala')
+configure_args="$(vopt_if gir '--enable-introspection --enable-vala' '--disable-introspection --disable-vala')
  --disable-schemas-compile --enable-locations-compression --with-zoneinfo-dir=/usr/share/zoneinfo"
 hostmakedepends="pkg-config intltool glib-devel $(vopt_if gir 'gobject-introspection vala-devel')"
 makedepends="libxml2-devel libsoup-gnome-devel gtk+3-devel geocode-glib-devel"


### PR DESCRIPTION
Fix a possible typo: $(vopt_enable ...) doesn't expect true/false parameters,
but $(vopt_if ...) does.