### PR TITLE
vopt_enable: check for excess parameters

### DIFF
--- a/common/environment/setup/options.sh
+++ b/common/environment/setup/options.sh
@@ -16,6 +16,9 @@ vopt_with() {
 
 vopt_enable() {
     local opt="$1" flag="${2:-$1}"
+    if [ "$#" -gt "2" ]; then
+        msg_error "vopt_enable $opt: $(($# - 2)) excess parameter(s)\n"
+    fi
     vopt_if "$1" "--enable-${flag}" "--disable-${flag}"
 }
 


### PR DESCRIPTION
I'm don't know if there is an easy way to obtain the function name for the msg_error.
The hint should suffice to detect erroneous use of `vopt_enable` as in #1862.