### PR TITLE
xorg-server: fix cross arm*-musl builds

### DIFF
--- a/srcpkgs/xorg-server/patches/musl-io.patch
+++ b/srcpkgs/xorg-server/patches/musl-io.patch
@@ -1,0 +1,11 @@
+--- hw/xfree86/common/compiler.h	2015-06-05 17:19:40.000000000 +0200
++++ hw/xfree86/common/compiler.h	2015-06-20 11:07:13.548555711 +0200
+@@ -758,7 +758,7 @@
+     return xf86ReadMmio32Le((void *) ioBase, port);
+ }
+ 
+-#elif defined(__arm__) && defined(__linux__)
++#elif defined(__arm__) && defined(__linux__) && defined(__GLIBC__)
+ 
+ /* for Linux on ARM, we use the LIBC inx/outx routines */
+ /* note that the appropriate setup via "ioperm" needs to be done */

--- a/srcpkgs/xorg-server/template
+++ b/srcpkgs/xorg-server/template
@@ -1,7 +1,7 @@
 # Template build file for 'xorg-server'.
 pkgname=xorg-server
 version=1.17.2
-revision=1
+revision=2
 build_pie=yes
 build_style=gnu-configure
 configure_args="--enable-ipv6 --enable-record --enable-xorg
@@ -69,7 +69,7 @@ post_install() {
 	vinstall ${FILESDIR}/30-nvidia-drm-outputclass.conf 644 usr/share/X11/xorg.conf.d
 	vinstall ${FILESDIR}/Xwrapper.config 644 etc/X11
 
-	vinstall COPYING 644 usr/share/licenses/${pkgname}
+	vlicense COPYING
 
 	chmod 4755 ${DESTDIR}/usr/libexec/Xorg.wrap
 


### PR DESCRIPTION
In musl libc sys/io.h does not define in/out functions