### PR TITLE
gnome-menus: add build option 'gir'

### DIFF
--- a/srcpkgs/gnome-menus/template
+++ b/srcpkgs/gnome-menus/template
@@ -1,10 +1,10 @@
 # Template file for 'gnome-menus'
 pkgname=gnome-menus
 version=3.10.1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-static"
-hostmakedepends="pkg-config intltool gobject-introspection"
+hostmakedepends="pkg-config intltool $(vopt_if gir gobject-introspection)"
 makedepends="libglib-devel"
 short_desc="GNOME menu specifications"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -13,13 +13,20 @@ license="GPL-2, LGPL-2.1"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=46950aba274c1ad58234374fa9b235258650737307f3bc396af48eb983668a71
 
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi
+
 gnome-menus-devel_package() {
 	depends="glib-devel gnome-menus>=${version}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
-		vmove usr/share/gir-1.0
 		vmove "usr/lib/*.so"
+		if [ -n "$build_option_gir" ]; then
+			vmove usr/share/gir-1.0
+		fi
 	}
 }


### PR DESCRIPTION
This fixes cross compiling