### PR TITLE
gnome-*: add build option 'gir'

### DIFF
--- a/srcpkgs/gnome-bluetooth/template
+++ b/srcpkgs/gnome-bluetooth/template
@@ -1,11 +1,11 @@
 # Template file for 'gnome-bluetooth'
 pkgname=gnome-bluetooth
 version=3.16.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --disable-desktop-update
  --disable-schemas-compile --disable-icon-update"
-hostmakedepends="pkg-config intltool itstool gnome-doc-utils gobject-introspection glib-devel"
+hostmakedepends="pkg-config intltool itstool gnome-doc-utils $(vopt_if gir gobject-introspection) glib-devel"
 makedepends="libXi-devel gtk+3-devel libnotify-devel dconf-devel
  gvfs-devel bluez eudev-libudev-devel"
 depends="bluez>=5 dconf>=0.20 gvfs>=1.20 hicolor-icon-theme desktop-file-utils"
@@ -16,14 +16,21 @@ license="GPL-2, LGPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=3feb202d6780a53bc4a570eab5b0179f9351b32c1d3f28151ac2d222453ae08b
 
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi
+
 gnome-bluetooth-devel_package() {
 	depends="glib-devel gtk+3-devel ${sourcepkg}>=${version}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
-		vmove usr/share/gir-1.0
 		vmove usr/share/gtk-doc
 		vmove "usr/lib/*.so"
+		if [ -n "$build_option_gir" ]; then
+			vmove usr/share/gir-1.0
+		fi
 	}
 }

--- a/srcpkgs/gnome-boxes/template
+++ b/srcpkgs/gnome-boxes/template
@@ -1,11 +1,11 @@
 # Template file for 'gnome-boxes'
 pkgname=gnome-boxes
 version=3.16.2
-revision=1
+revision=2
 # XXX ovirt support.
 build_style=gnu-configure
 configure_args="--enable-smartcard"
-hostmakedepends="pkg-config intltool itstool gobject-introspection"
+hostmakedepends="pkg-config intltool itstool $(vopt_if gir gobject-introspection)"
 makedepends="clutter-gtk-devel gtk+3-devel gtk-vnc-devel libuuid-devel
  libvirt-glib-devel libxml2-devel libgudev-devel libosinfo-devel
  tracker-devel spice-gtk-devel spice-protocol vala-devel
@@ -18,3 +18,8 @@ homepage="https://live.gnome.org/Boxes"
 license="LGPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=f5fecb1ba0769e2a3dbec31e6149fffbcbd59946e4dbab31fb3ec28a16e41995
+
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi

--- a/srcpkgs/gnome-clocks/template
+++ b/srcpkgs/gnome-clocks/template
@@ -1,9 +1,9 @@
 # Template file for 'gnome-clocks'
 pkgname=gnome-clocks
 version=3.16.1
-revision=1
+revision=2
 build_style=gnu-configure
-hostmakedepends="pkg-config intltool itstool gobject-introspection"
+hostmakedepends="pkg-config intltool itstool $(vopt_if gir gobject-introspection)"
 makedepends="glib-devel vala-devel gnome-desktop-devel
  libgweather-devel libcanberra-devel libnotify-devel gsound-devel
  geocode-glib-devel geoclue2 desktop-file-utils hicolor-icon-theme"
@@ -14,3 +14,8 @@ homepage="https://live.gnome.org/GnomeClocks"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=1804bac40d95044d43d6c04762dd2a0785f8783b38d9393290c31face083f3cc
+
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi

--- a/srcpkgs/gnome-contacts/template
+++ b/srcpkgs/gnome-contacts/template
@@ -1,9 +1,9 @@
 # Template file for 'gnome-contacts'
 pkgname=gnome-contacts
 version=3.16.2
-revision=1
+revision=2
 build_style=gnu-configure
-hostmakedepends="pkg-config intltool gobject-introspection"
+hostmakedepends="pkg-config intltool $(vopt_if gir gobject-introspection)"
 makedepends="vala-devel telepathy-glib-devel
  gnome-desktop-devel folks-devel libnotify-devel
  cheese-devel libchamplain-devel geocode-glib-devel"
@@ -14,3 +14,8 @@ homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=fb625a40fe915d866625a7d688c9a3b454d198c9474ce2efc3979f2b0d1687e7
+
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi

--- a/srcpkgs/gnome-documents/template
+++ b/srcpkgs/gnome-documents/template
@@ -1,10 +1,10 @@
 # Template file for 'gnome-documents'
 pkgname=gnome-documents
 version=3.16.2
-revision=1
+revision=2
 lib32disabled=yes
 build_style=gnu-configure
-hostmakedepends="pkg-config intltool itstool docbook-xsl gobject-introspection"
+hostmakedepends="pkg-config intltool itstool docbook-xsl $(vopt_if gir gobject-introspection)"
 makedepends="
  clutter-gtk-devel gnome-desktop-devel libzapojit-devel
  gnome-online-accounts-devel libgdata-devel tracker-devel
@@ -17,3 +17,8 @@ homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=ba7230f0f7bd83932e03b1c06c6b67a46f9bc2dd2a93d0193c402d60323ff4a3
+
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi

--- a/srcpkgs/gnome-initial-setup/template
+++ b/srcpkgs/gnome-initial-setup/template
@@ -1,9 +1,9 @@
 # Template file for 'gnome-initial-setup'.
 pkgname=gnome-initial-setup
 version=3.16.3
-revision=1
+revision=2
 build_style=gnu-configure
-hostmakedepends="pkg-config intltool gobject-introspection"
+hostmakedepends="pkg-config intltool $(vopt_if gir gobject-introspection)"
 makedepends="NetworkManager-devel accountsservice-devel glib-devel
  gnome-desktop-devel cheese-devel libgweather-devel webkit2gtk-devel
  gnome-online-accounts-devel gdm-devel libpwquality-devel
@@ -16,3 +16,8 @@ homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=9c424fd6ccc9c6e17b6352a39f6a0e8080294978ad15b24e67b53b3714ab1dfa
+
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi

--- a/srcpkgs/gnome-maps/template
+++ b/srcpkgs/gnome-maps/template
@@ -1,9 +1,9 @@
 # Template file for 'gnome-maps'
 pkgname=gnome-maps
 version=3.16.2
-revision=1
+revision=2
 build_style=gnu-configure
-hostmakedepends="pkg-config intltool gobject-introspection glib-devel"
+hostmakedepends="pkg-config intltool glib-devel $(vopt_if gir gobject-introspection)"
 makedepends="
  gjs-devel gnome-desktop-devel geocode-glib-devel geoclue2
  libgee08-devel folks-devel libchamplain-devel"
@@ -14,3 +14,8 @@ homepage="http://live.gnome.org/Design/Apps/Maps"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=a7d791e4fb2dc3674232edf5c6d6112274869524db458695fc9fece49df07c96
+
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi

--- a/srcpkgs/gnome-music/template
+++ b/srcpkgs/gnome-music/template
@@ -1,11 +1,11 @@
 # Template file for 'gnome-music'
 pkgname=gnome-music
 version=3.16.1
-revision=1
+revision=2
 lib32disabled=yes
 build_style=gnu-configure
 configure_args="PYTHON=python3.4"
-hostmakedepends="pkg-config intltool itstool gobject-introspection glib-devel"
+hostmakedepends="pkg-config intltool itstool glib-devel $(vopt_if gir gobject-introspection)"
 makedepends="python3.4-devel python-gobject-devel python3.4-dbus
  grilo-devel gnome-desktop-devel libmediaart2-devel"
 depends="python3.4-gobject>=3.14 python3.4-dbus desktop-file-utils"
@@ -15,3 +15,8 @@ homepage="http://live.gnome.org/Apps/Music"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=116945d87fbac6aea2aedfa8e6a98bef720675916a0a6e9ae21aa83d450ad2df
+
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi

--- a/srcpkgs/gnome-online-accounts/template
+++ b/srcpkgs/gnome-online-accounts/template
@@ -1,14 +1,14 @@
 # Template file for 'gnome-online-accounts'
 pkgname=gnome-online-accounts
 version=3.16.3
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="
  --enable-google --enable-kerberos --enable-flickr --enable-telepathy
  --enable-facebook --disable-static --enable-exchange  --enable-imap-smtp
  --enable-owncloud --enable-windows-live --disable-twitter --enable-yahoo"
-hostmakedepends="pkg-config intltool libxslt docbook-xsl gobject-introspection
- glib-devel"
+hostmakedepends="pkg-config intltool libxslt docbook-xsl glib-devel
+ $(vopt_if gir gobject-introspection)"
 makedepends="libsoup-gnome-devel webkit2gtk-devel json-glib-devel libnotify-devel
  rest-devel gcr-devel libsecret-devel mit-krb5-devel dbus-glib-devel telepathy-glib-devel"
 depends="hicolor-icon-theme"
@@ -19,6 +19,11 @@ license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=a0648e4d595f5c63f85c03bf65a2cf1204e8615aba242c50c15aa4c9696a0ca0
 
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi
+
 gnome-online-accounts-devel_package() {
 	depends="glib-devel gtk+3-devel ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
@@ -27,6 +32,8 @@ gnome-online-accounts-devel_package() {
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
 		vmove usr/lib/goa-1.0
-		vmove usr/share/gir-1.0
+		if [ -n "$build_option_gir" ]; then
+			vmove usr/share/gir-1.0
+		fi
 	}
 }

--- a/srcpkgs/gnome-online-miners/template
+++ b/srcpkgs/gnome-online-miners/template
@@ -1,11 +1,11 @@
 # Template file for 'gnome-online-miners'
 pkgname=gnome-online-miners
 version=3.14.3
-revision=1
+revision=2
 lib32disabled=yes
 build_style=gnu-configure
 configure_args="--disable-static"
-hostmakedepends="pkg-config intltool libxslt docbook-xsl gobject-introspection"
+hostmakedepends="pkg-config intltool libxslt docbook-xsl $(vopt_if gir gobject-introspection)"
 makedepends="libzapojit-devel libgdata-devel grilo-devel
  tracker-devel gfbgraph-devel libmediaart-devel gnome-online-accounts-devel"
 depends="libzapojit>=0.0.3_3"
@@ -15,3 +15,8 @@ homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=907f0c1d2f4fcb762be9e3992d05bcc39d292d9c1246c2aca2b293b04c59ba7d
+
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi

--- a/srcpkgs/gnome-photos/template
+++ b/srcpkgs/gnome-photos/template
@@ -1,10 +1,10 @@
 # Template file for 'gnome-photos'
 pkgname=gnome-photos
 version=3.16.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-schemas-compile"
-hostmakedepends="pkg-config intltool itstool gnome-doc-utils gobject-introspection"
+hostmakedepends="pkg-config intltool itstool gnome-doc-utils $(vopt_if gir gobject-introspection)"
 makedepends="
  gtk+3-devel babl-devel gegl3-devel exempi-devel lcms2-devel gfbgraph-devel
  tracker-devel libexif-devel librsvg-devel grilo-devel
@@ -16,3 +16,8 @@ homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=9eb6a08a1d198f174f006b1c4e60a7db4f2e05cce7776e3f989470638cda2e20
+
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi

--- a/srcpkgs/gnome-shell/template
+++ b/srcpkgs/gnome-shell/template
@@ -1,12 +1,12 @@
 # Template file for 'gnome-shell'
 pkgname=gnome-shell
 version=3.16.2
-revision=1
+revision=2
 build_options="systemd"
 build_style=gnu-configure
 configure_args="--disable-schemas-compile $(vopt_enable systemd)"
 hostmakedepends="
- pkg-config intltool gnome-doc-utils gobject-introspection python3.4"
+ pkg-config intltool gnome-doc-utils $(vopt_if gir gobject-introspection) python3.4"
 makedepends="
  evolution-data-server gnome-desktop-devel
  json-glib-devel startup-notification-devel network-manager-applet-devel
@@ -23,3 +23,8 @@ homepage="http://live.gnome.org/GnomeShell"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=90b7aeac7673f05f0bf7de39444ac458900c943fa8fd22e5374c047aa54d1838
+
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi

--- a/srcpkgs/gnome-sound-recorder/template
+++ b/srcpkgs/gnome-sound-recorder/template
@@ -1,11 +1,11 @@
 # Template file for 'gnome-sound-recorder'
 pkgname=gnome-sound-recorder
 version=3.16.0
-revision=1
+revision=2
 lib32disabled=yes
 build_style=gnu-configure
 configure_args="--disable-schemas-compile"
-hostmakedepends="pkg-config intltool itstool glib-devel gobject-introspection"
+hostmakedepends="pkg-config intltool itstool glib-devel $(vopt_if gir gobject-introspection)"
 makedepends="gtk+3-devel gsettings-desktop-schemas-devel gjs-devel gst-plugins-base1"
 depends="desktop-file-utils gjs>=1.40 gsettings-desktop-schemas>=3.14 gst-plugins-base1"
 short_desc="GNOME sound recorder application"
@@ -14,3 +14,8 @@ homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=9af4935a8007810f750b40039a77cc762c260cb554339c1fc13e6ee52f6a1c04
+
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi

--- a/srcpkgs/gnome-weather/template
+++ b/srcpkgs/gnome-weather/template
@@ -1,11 +1,12 @@
 # Template file for 'gnome-weather'
 pkgname=gnome-weather
 version=3.16.2.1
-revision=1
+revision=2
 lib32disabled=yes
 build_style=gnu-configure
 configure_args="--disable-schemas-compile"
-hostmakedepends="pkg-config intltool itstool gnome-doc-utils gobject-introspection glib-devel"
+hostmakedepends="pkg-config intltool itstool gnome-doc-utils glib-devel
+ $(vopt_if gir gobject-introspection)"
 makedepends="gtk+3-devel gjs-devel libgweather-devel"
 depends="desktop-file-utils"
 short_desc="Access current weather conditions and forecasts for GNOME"
@@ -14,3 +15,8 @@ homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*.*}/$pkgname-$version.tar.xz"
 checksum=0fe481d4be192ca32cb401f3f4b74feb0f1ea3241f23dc51ec1949874836e355
+
+build_options="gir"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi


### PR DESCRIPTION

+ This should allow more gnome-* packages to be cross compiled
+ Some will still fail due to prerequisites not cross compilable