### PR TITLE
minicom: unbreak musl

### DIFF
--- a/srcpkgs/minicom/patches/musl-sys_param_h.patch
+++ b/srcpkgs/minicom/patches/musl-sys_param_h.patch
@@ -1,0 +1,12 @@
+MAXNAMLEN is defined in sys/param.h
+
+--- src/getsdir.c	2011-02-14 11:07:00.000000000 +0100
++++ src/getsdir.c	2015-06-22 02:47:36.263541750 +0200
+@@ -28,6 +28,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <sys/param.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <errno.h>

--- a/srcpkgs/minicom/patches/musl-vc_music.patch
+++ b/srcpkgs/minicom/patches/musl-vc_music.patch
@@ -1,0 +1,21 @@
+In musl libc __GLIBC__ is not defined, while it has the
+same required header files for VC_MUSIC to work.
+Just disable the additional __GLIBC__ shield.
+
+--- src/dial.c	2013-05-09 20:32:02.000000000 +0200
++++ src/dial.c	2015-06-22 02:44:34.768551564 +0200
+@@ -39,11 +39,9 @@
+ #include "intl.h"
+ 
+ #ifdef VC_MUSIC
+-#  if defined(__GLIBC__)
+-#    include <sys/ioctl.h>
+-#    include <sys/kd.h>
+-#    include <sys/time.h>
+-#  endif
++#include <sys/ioctl.h>
++#include <sys/kd.h>
++#include <sys/time.h>
+ #endif
+ 
+ enum { CURRENT_VERSION = 6 };

--- a/srcpkgs/minicom/template
+++ b/srcpkgs/minicom/template
@@ -1,12 +1,12 @@
 # Template file for 'minicom'
 pkgname=minicom
 version=2.7
-revision=2
+revision=3
 build_style=gnu-configure
 makedepends="ncurses-devel"
 short_desc="Menu driven communications program"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://alioth.debian.org/projects/minicom/"
-distfiles="https://www.alioth.debian.org/frs/download.php/latestfile/3/${pkgname}-${version}.tar.gz"
+distfiles="${DEBIAN_SITE}/main/m/${pkgname}/${pkgname}_${version}.orig.tar.gz"
 checksum=9ac3a663b82f4f5df64114b4792b9926b536c85f59de0f2d2b321c7626a904f4


### PR DESCRIPTION
Here xlint wanted me to use $DEBIAN_SITE while the original download was on a `alioth.debian.org`, not `ftp.debian.org`.

I switched to $DEBIAN_SITE's corresponding minicom-2.7-orig.tar.gz file to silence xlint :)