### PR TITLE
mesa-demos: exclude broken eglut/opengl code

### DIFF
--- a/srcpkgs/mesa-demos/template
+++ b/srcpkgs/mesa-demos/template
@@ -1,9 +1,9 @@
 # Template build file for 'MesaLib'.
 pkgname=mesa-demos
 version=8.2.0
-revision=6
+revision=7
 build_style=gnu-configure
-hostmakedepends="pkg-config"
+hostmakedepends="automake libtool pkg-config"
 makedepends="libXext-devel MesaLib-devel glu-devel glew-devel freetype-devel libfreeglut-devel"
 short_desc="Mesa 3D demos and tools"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -11,6 +11,14 @@ homepage="http://www.mesa3d.org"
 license="MIT"
 distfiles="ftp://ftp.freedesktop.org/pub/mesa/demos/$version/$pkgname-$version.tar.bz2"
 checksum=e4bfecb5816ddd4b7b37c1bc876b63f1f7f06fda5879221a9774d0952f90ba92
+
+# eglut + opengl stuff is broken with Mesa-10.6.0
+pre_configure() {
+	sed -i ${wrksrc}/src/egl/Makefile.am \
+		-e "/	eglut/d" \
+		-e "/	opengl/d"
+	autoreconf -fi
+}
 
 glxinfo_package() {
 	short_desc="Tool to diagnose problems with 3D acceleration setup"


### PR DESCRIPTION
The mesa-demos code including EGL/eglext.h expects some interfaces
which no longer exist in Mesa-10.6.0. Disable that code.

Closes #1871