### PR TITLE
apr: add missing make dependency expat-devel

### DIFF
--- a/srcpkgs/apr/template
+++ b/srcpkgs/apr/template
@@ -1,10 +1,10 @@
 # Template file for 'apr'
 pkgname=apr
 version=1.5.2
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-installbuilddir=/usr/share/apr-1/build"
-makedepends="libuuid-devel"
+makedepends="expat-devel libuuid-devel"
 short_desc="Apache Portable Runtime Library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://apr.apache.org/"
@@ -28,7 +28,7 @@ apr-devel_package() {
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
 		vmove "usr/lib/*.exp"
-		vmove usr/lib/pkgconfig 
+		vmove usr/lib/pkgconfig
 		ln -sf /usr/bin/libtool ${PKGDESTDIR}/usr/share/apr-1/build/libtool
 	}
 }


### PR DESCRIPTION
Without the dependency I saw this:
```
xml/apr_xml.c:35:19: fatal error: expat.h: No such file or directory
 #include <expat.h>
                   ^
compilation terminated.
```
It may have worked before because expat was always there or a dependency of libuuid-devel?