### PR TITLE
New package: libtorrent1-1.0.5

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2067,3 +2067,4 @@ libgegl-sc-0.3.so gegl3-0.3.0_1
 libprocps.so.4 procps-ng-3.3.10_8
 libskarnet.so.2 skalibs-2.3.5.1_1
 libportablexdr.so.0 portablexdr-4.9.1_1
+libtorrent-rasterbar.so.8 libtorrent1-1.0.5_1

--- a/srcpkgs/libtorrent1-devel
+++ b/srcpkgs/libtorrent1-devel
@@ -1,0 +1,1 @@
+libtorrent1

--- a/srcpkgs/libtorrent1/template
+++ b/srcpkgs/libtorrent1/template
@@ -1,0 +1,28 @@
+# Template build file for 'libtorrent1'
+pkgname=libtorrent1
+version=1.0.5
+revision=1
+wrksrc=libtorrent-rasterbar-${version}
+build_style=gnu-configure
+configure_args="--enable-static --disable-debug --without-kqueue
+ --enable-aligned --with-posix-fallocate
+ --with-boost-libdir=${XBPS_CROSS_BASE}/usr/lib"
+hostmakedepends="pkg-config"
+makedepends="boost-devel zlib-devel libressl-devel"
+short_desc="BitTorrent library written in C++ (v1.x)"
+maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
+homepage="http://www.libtorrent.org/"
+license="BSD"
+distfiles="${SOURCEFORGE_SITE}/libtorrent/libtorrent-rasterbar-${version}.tar.gz"
+checksum=474a43da2147bec7e333c10f70b07221f4732dd67e071d5e90acc7edb8f657b0
+
+libtorrent1-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+	}
+}


### PR DESCRIPTION
Create a new major version package of libtorrent(-rasterbar)
and switch to the new homepage http://www.libtorrent.org/
The license also changed from GPL-2 to BSD.