### PR TITLE
qtcreator: update to 3.4.1

### DIFF
--- a/srcpkgs/qtcreator-full
+++ b/srcpkgs/qtcreator-full
@@ -1,0 +1,1 @@
+qtcreator

--- a/srcpkgs/qtcreator/patches/musl-no_execinfo_h.patch
+++ b/srcpkgs/qtcreator/patches/musl-no_execinfo_h.patch
@@ -1,0 +1,50 @@
+--- src/plugins/qmldesigner/designercore/exceptions/exception.cpp	2015-04-21 17:56:56.000000000 +0200
++++ src/plugins/qmldesigner/designercore/exceptions/exception.cpp	2015-06-26 13:17:08.600350791 +0200
+@@ -31,7 +31,9 @@
+ #include "exception.h"
+ 
+ #ifdef Q_OS_LINUX
++#if defined(__GLIBC__)
+ #include <execinfo.h>
++#endif
+ #include <cxxabi.h>
+ #endif
+ 
+@@ -107,6 +109,7 @@
+     m_file(file)
+ {
+ #ifdef Q_OS_LINUX
++#ifdef __GLIBC__
+     void * array[50];
+     int nSize = backtrace(array, 50);
+     char ** symbols = backtrace_symbols(array, nSize);
+@@ -118,6 +121,7 @@
+ 
+     free(symbols);
+ #endif
++#endif
+ 
+ if (s_shouldAssert)
+     Q_ASSERT_X(false, function.toUtf8(), QString("%1:%2 - %3").arg(file).arg(line).arg(function).toUtf8());
+--- src/plugins/debugger/shared/backtrace.cpp	2015-04-21 17:56:56.000000000 +0200
++++ src/plugins/debugger/shared/backtrace.cpp	2015-06-26 13:14:54.295358053 +0200
+@@ -35,8 +35,10 @@
+ #if defined(Q_OS_LINUX)
+ #include <stdio.h>
+ #include <signal.h>
++#if defined(__GLIBC__)
+ #include <execinfo.h>
+ #endif
++#endif
+ 
+ namespace Debugger {
+ namespace Internal {
+@@ -45,7 +47,7 @@
+ {
+     if (maxdepth == -1)
+         maxdepth = 200;
+-#if defined(Q_OS_LINUX)
++#if defined(Q_OS_LINUX) && defined(__GLIBC__)
+     void *bt[200] = {0};
+     qDebug() << "BACKTRACE:";
+     int size = backtrace(bt, sizeof(bt) / sizeof(bt[0]));

--- a/srcpkgs/qtcreator/template
+++ b/srcpkgs/qtcreator/template
@@ -1,29 +1,27 @@
 # Template file for 'qtcreator'
 pkgname=qtcreator
-version=3.4.0
-revision=4
+version=3.4.1
+revision=1
 wrksrc=qt-creator-opensource-src-${version}
+build_style=gnu-makefile
+build_pie=yes
+make_build_args="INSTALL_ROOT=\${DESTDIR}/usr"
+make_install_args="${make_build_args}"
 hostmakedepends="perl python pkg-config"
 makedepends="qt5-declarative-devel qt5-script-devel qt5-tools-devel"
-depends="qt5-connectivity-devel qt5-declarative-devel qt5-enginio-devel
- qt5-location-devel qt5-multimedia-devel qt5-quick1-devel qt5-quickcontrols
- qt5-script-devel qt5-sensors-devel qt5-serialport-devel qt5-svg-devel
- qt5-tools-devel qt5-wayland-devel qt5-webchannel-devel qt5-webengine-devel
- qt5-webkit-devel qt5-websockets-devel qt5-x11extras-devel qt5-xmlpatterns-devel
- qt5-declarative-devel qt5-script-devel qt5-tools-devel qt5-doc qt5-plugin-sqlite"
+depends="qt5-declarative-devel qt5-quickcontrols qt5-plugin-sqlite"
 nocross=yes
 short_desc="A cross-platform IDE for Qt developers"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 license="LGPL-2.1"
 homepage="http://qt.io/download-open-source/"
 distfiles="http://download.qt.io/official_releases/qtcreator/${version%.*}/${version}/${wrksrc}.tar.gz"
-checksum=b80baf5be9b0421b3d951a8a0eb411a65cf008f4c753f5a80d205e90fa4fe112
+checksum=029e22307e79c4fb3a34be854dedddaa56476c6c6374c312125b9302bcbc0fd9
 
 do_configure() {
 	MAKEFLAGS=${makejobs} qmake
 }
-do_install() {
-	make INSTALL_ROOT=${DESTDIR}/usr install
+post_install() {
 	# Install the desktop file
 	vinstall ${FILESDIR}/qtcreator.desktop \
 		644 usr/share/applications
@@ -32,4 +30,18 @@ do_install() {
 		644 usr/share/mime/packages
 	vinstall ${wrksrc}/src/plugins/cmakeprojectmanager/CMakeProjectManager.mimetypes.xml \
 		644 usr/share/mime/packages
+}
+
+qtcreator-full_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - full dependencies"
+	depends+=" qt5-connectivity-devel qt5-declarative-devel qt5-enginio-devel qt5-graphicaleffects
+ qt5-location-devel qt5-multimedia-devel qt5-quick1-devel qt5-script-devel qt5-sensors-devel
+ qt5-serialport-devel qt5-svg-devel qt5-tools-devel qt5-wayland-devel qt5-webchannel-devel
+ qt5-webengine-devel qt5-webkit-devel qt5-websockets-devel qt5-x11extras-devel qt5-xmlpatterns-devel
+ qt5-declarative-devel qt5-script-devel qt5-tools-devel qt5-doc qt5-plugin-gtk
+ qt5-plugin-mysql qt5-plugin-odbc qt5-plugin-pgsql qt5-plugin-sqlite"
+	pkg_install() {
+		echo "Just the dependencies"
+	}
 }


### PR DESCRIPTION
+ Split into basic and full dependencies (qtcreator-full)
+ Patch to unbreak musl by removing references to execinfo.h + backtrace()