### PR TITLE
New package: pcsc-ccid-1.4.19

### DIFF
--- a/srcpkgs/pcsc-ccid-contrib
+++ b/srcpkgs/pcsc-ccid-contrib
@@ -1,0 +1,1 @@
+pcsc-ccid

--- a/srcpkgs/pcsc-ccid-examples
+++ b/srcpkgs/pcsc-ccid-examples
@@ -1,0 +1,1 @@
+pcsc-ccid

--- a/srcpkgs/pcsc-ccid/template
+++ b/srcpkgs/pcsc-ccid/template
@@ -1,0 +1,44 @@
+# Template file for 'pcsc-ccid'
+pkgname=pcsc-ccid
+version=1.4.19
+revision=1
+wrksrc=ccid-${version}
+build_style=gnu-configure
+configure_args="--enable-udev"
+hostmakedepends="pkg-config perl"
+makedepends="pcsclite-devel libudev-devel libusb-compat-devel"
+short_desc="PC/SC driver to support CCID compliant readers"
+maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
+license="LGPL-2.1"
+homepage="http://pcsclite.alioth.debian.org/ccid.html"
+distfiles="${DEBIAN_SITE}/main/c/ccid/ccid_${version}.orig.tar.bz2"
+checksum=cccb2c2bb4e56689efe34559f713102d92f94735542e58d3e4334e1459e934e1
+
+post_install() {
+	vinstall src/92_pcscd_ccid.rules 644 usr/lib/udev/rules.d/
+	vdoc readers/supported_readers.txt
+	vdoc README
+}
+
+pcsc-ccid-contrib_package() {
+	short_desc+=" - contributions"
+	depends="${sourcpkg}>=${version}_${revision}"
+	pkg_install() {
+		vbin contrib/Kobil_mIDentity_switch/Kobil_mIDentity_switch
+		vman contrib/Kobil_mIDentity_switch/Kobil_mIDentity_switch.8
+		vbin contrib/RSA_SecurID/RSA_SecurID_getpasswd
+		vman contrib/RSA_SecurID/RSA_SecurID_getpasswd.1
+	}
+}
+pcsc-ccid-examples_package() {
+	short_desc+=" - examples"
+	depends="${sourcpkg}>=${version}_${revision}"
+	pkg_install() {
+		vmkdir usr/share/${sourcepkg}/examples
+		rm examples/*.o
+		for f in $(find ${wrksrc}/examples -maxdepth 1 -type f); do
+			vcopy $f usr/share/${sourcepkg}/examples
+		done
+	}
+}
+

--- a/srcpkgs/pcsc-ccid/update
+++ b/srcpkgs/pcsc-ccid/update
@@ -1,0 +1,1 @@
+pkgname="${pkgname/pcsc-/}"


### PR DESCRIPTION
The generic PC/SC CCID compliant smart card readers driver from the pcsclite author Ludovic Rousseau. Should work with most (read: more than pcsc-acsccid) USB card readers.
