### PR TITLE
xbps-src: implement a by_sha256 hash cache

### DIFF
--- a/common/xbps-src/shutils/update_hash_cache.sh
+++ b/common/xbps-src/shutils/update_hash_cache.sh
@@ -1,0 +1,12 @@
+# vim: set ts=4 sw=4 et:
+
+update_hash_cache() {
+    local cache="$XBPS_SRCDISTDIR/by_sha256"
+    local distfile curfile
+    mkdir -p "$cache"
+    find "$XBPS_SRCDISTDIR" -type f | grep -v by_sha256 | while read -r distfile; do
+        cksum=$(cat "$distfile" | sha256sum | cut -d " " -f 1)
+        curfile="$(basename ${distfile})"
+        ln -vf "$distfile" "${cache}/${cksum}_${curfile}"
+    done
+}

--- a/xbps-src
+++ b/xbps-src
@@ -102,6 +102,9 @@ update-sys
 update-check <pkgname>
     Check upstream site of <pkgname> for new releases.
 
+update-hash-cache
+    Update the hash cache with existing source distfiles.
+
 zap
     Removes a masterdir but preserving ccache, distcc and host directories.
 
@@ -696,6 +699,9 @@ case "$XBPS_TARGET" in
     update-check)
         read_pkg
         update_check
+        ;;
+    update-hash-cache)
+        update_hash_cache
         ;;
     zap)
         masterdir_zap


### PR DESCRIPTION
Closes #1952

Any successfully verified distfile is hard linked into `$XBPS_SRCDISTDIR/by_sha256/$cksum`. Before trying to download a distfile, an exsiting `$XBPS_SRCDISTDIR/by_sha256/$cksum` is hard linked to the `$distfile`.

There is a new xbps-src command `update-hash-cache` which will hard link your existing distfiles to their corresponding cache entries. You may run this once to initially setup the cache, while it isn't mandatory. It will merge distfiles from different directories with identical sha256sum and should thus reduce the space required on disk.