### PR TITLE
ffmpeg: Enable AAC audio encoder

### DIFF
--- a/srcpkgs/ffmpeg/template
+++ b/srcpkgs/ffmpeg/template
@@ -1,7 +1,7 @@
 # Template file for 'ffmpeg'
 pkgname=ffmpeg
 version=2.7.1
-revision=1
+revision=2
 short_desc="Decoding, encoding and streaming software"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-3"
@@ -11,8 +11,8 @@ checksum=7e07b97d2415feeae9c9b5595e35e7b7aab33207e81bf9f8c0d1eece43f7f720
 
 hostmakedepends="pkg-config perl yasm"
 makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-devel
- libXext-devel libXvMC-devel faad2-devel lame-devel libtheora-devel gnutls-devel
- libvorbis-devel x264-devel xvidcore-devel jack-devel SDL-devel
+ libXext-devel libXvMC-devel faac-devel faad2-devel lame-devel libtheora-devel
+ gnutls-devel libvorbis-devel x264-devel xvidcore-devel jack-devel SDL-devel
  libcdio-paranoia-devel libvpx-devel librtmp-devel freetype-devel libmodplug-devel
  speex-devel celt-devel harfbuzz-devel libass-devel opus-devel pulseaudio-devel"
 


### PR DESCRIPTION
We have faac-devel and can thus enable AAC encoding in ffmpeg.