### PR TITLE
tracebox: update to 0.3

### DIFF
--- a/srcpkgs/tracebox/template
+++ b/srcpkgs/tracebox/template
@@ -1,12 +1,13 @@
 # Template file for 'tracebox'
 pkgname=tracebox
-version=0.2
+version=0.3
 revision=1
 _click_ver=2.0.1
-_crafter_ver=0.3
+_crafter_git=891567b28fa88a8a14e6d11815dc2d9fff75329c
+_crafter_ver=0.3git
 build_style=gnu-configure
 hostmakedepends="automake pkg-config libtool unzip"
-makedepends="libpcap-devel lua-devel"
+makedepends="libpcap-devel json-c-devel lua-devel"
 short_desc="A middlebox detection tool"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 license="GPL-2"
@@ -15,18 +16,18 @@ homepage="http://www.tracebox.org/"
 distfiles="
 https://github.com/tracebox/tracebox/archive/v${version}.tar.gz>tracebox-${version}.tar.gz
 https://github.com/bhesmans/click/archive/v${_click_ver}.tar.gz>click-${_click_ver}.tar.gz
-https://github.com/pellegre/libcrafter/archive/version-${_crafter_ver}.tar.gz>libcrafter-version-${_crafter_ver}.tar.gz"
+https://github.com/pellegre/libcrafter/archive/${_crafter_git}.zip>libcrafter-${_crafter_ver}.zip"
 checksum="
-39a7a70edb386defe03fabafe0ec8dd448ec8a24adcb2df8ea70f4ea16dfffd8
+973dcf7069cfff3fbcbb7aa71168bb0cfeb146ddec58d78de87fba30149e40e9
 4e48591cb385000ee8daedf3cc18d4b00a9c5a142cc001e0780f0c7ebd713764
-4608b10470aaa5a711b13b7c9db93fc6c3daca8c26ae7e81b0d7aa8af3a497aa"
+a004346589e4f66662a6cd2367a9000f761f1959a5c43648b952452f1eaec36a"
 
 pre_configure() {
 	# Do what ./bootstrap.sh would have done but without using git to pull submodules
 	mkdir -p ${wrksrc}/test/tools ${wrksrc}/noinst/libcrafter
 	mv -v ../click-${_click_ver} test/tools/click
-	mv -v ../libcrafter-version-${_crafter_ver}/{.gitignore,README,libcrafter} noinst/libcrafter
-	rmdir -v ../libcrafter-version-${_crafter_ver}
+	mv -v ../libcrafter-${_crafter_git}/{.gitignore,README,libcrafter} noinst/libcrafter
+	rmdir -v ../libcrafter-${_crafter_git}
 	# Set missing AM_PROG_AR
 	sed -e "/AC_PROG_CXX/iAM_PROG_AR=${AR}" -i noinst/libcrafter/libcrafter/configure.ac
 	autoreconf --force --install --verbose


### PR DESCRIPTION
+ Use libcrafter git revision, because tracebox fails to build with libcrafter-0.3