### PR TITLE
vorbisgain: enable recursive flag

### DIFF
--- a/srcpkgs/vorbisgain/template
+++ b/srcpkgs/vorbisgain/template
@@ -1,8 +1,9 @@
 # Template file for 'vorbisgain'
 pkgname="vorbisgain"
 version="0.37"
-revision=1
+revision=2
 build_style=gnu-configure
+configure_args="--enable-recursive"
 hostmakedepends="pkg-config"
 makedepends="libvorbis-devel"
 short_desc="A utility that computes the ReplayGain values for Ogg Vorbis files"


### PR DESCRIPTION
Out of the man-page:

    -r, --recursive
              Enter directories (recursively) and search for files, if
              directories or file patterns are specified.  Note: Only
              available if vorbisgain was configured with --enable-recursive.