### PR TITLE
qupzilla: fixes for Qt5-5.5.0

### DIFF
--- a/srcpkgs/qupzilla/patches/fix-qtlocalpeer.patch
+++ b/srcpkgs/qupzilla/patches/fix-qtlocalpeer.patch
@@ -1,0 +1,12 @@
+Include QDataStream for the required definitions
+
+--- src/lib/3rdparty/qtsingleapplication/qtlocalpeer.cpp	2015-01-26 15:26:15.000000000 +0100
++++ src/lib/3rdparty/qtsingleapplication/qtlocalpeer.cpp	2015-07-06 18:32:29.862136464 +0200
+@@ -48,6 +48,7 @@
+ #include "qtlocalpeer.h"
+ #include <QtCore/QCoreApplication>
+ #include <QtCore/QTime>
++#include <QtCore/QDataStream>
+ 
+ #if defined(Q_OS_WIN)
+ #include <QtCore/QLibrary>

--- a/srcpkgs/qupzilla/patches/fix-tldextractor.patch
+++ b/srcpkgs/qupzilla/patches/fix-tldextractor.patch
@@ -1,0 +1,12 @@
+Include QObject for the required definitions
+
+--- src/plugins/TabManager/tldextractor/tldextractor.h	2015-01-26 15:26:15.000000000 +0100
++++ src/plugins/TabManager/tldextractor/tldextractor.h	2015-07-06 18:41:27.630175234 +0200
+@@ -20,6 +20,7 @@
+ 
+ #define TLDExtractor_Version "1.0"
+ 
+ #include <QHash>
++#include <QObject>
+ #include <QStringList>
+ 


### PR DESCRIPTION
The two fixes to build with Qt5-5.5.0 are already included in upstream and will become obsolete with the next version.