### PR TITLE
qca-qt5: Fixes for Qt5-5.5.0

### DIFF
--- a/srcpkgs/qca-qt5/patches/fix-qiodevice.patch
+++ b/srcpkgs/qca-qt5/patches/fix-qiodevice.patch
@@ -1,0 +1,34 @@
+Since Qt5-5.5.0 explicit include <QIODevice> is required
+if QIODevice is used in headers or source files. It seems
+it was included as a side-effect by other header files before.
+
+--- src/qca_publickey.cpp	2014-11-06 09:15:45.000000000 +0100
++++ src/qca_publickey.cpp	2015-07-07 09:26:59.819005743 +0200
+@@ -25,6 +25,7 @@
+ 
+ #include <QFile>
+ #include <QTextStream>
++#include <QIODevice>
+ 
+ namespace QCA {
+ 
+--- src/qca_keystore.cpp	2014-11-06 09:15:45.000000000 +0100
++++ src/qca_keystore.cpp	2015-07-07 09:29:24.886016202 +0200
+@@ -27,6 +27,7 @@
+ #include <QSet>
+ #include <QMutex>
+ #include <QWaitCondition>
++#include <QIODevice>
+ 
+ #include <stdlib.h> // abort
+ #include <stdio.h>  // fprintf
+--- include/QtCrypto/qca_core.h	2014-11-06 09:15:45.000000000 +0100
++++ include/QtCrypto/qca_core.h	2015-07-07 09:36:30.737046903 +0200
+@@ -38,6 +38,7 @@
+ #include <QList>
+ #include <QSharedData>
+ #include <QSharedDataPointer>
++#include <QIODevice>
+ #include "qca_export.h"
+ #include "qca_support.h"
+ #include "qca_tools.h"

--- a/srcpkgs/qca-qt5/template
+++ b/srcpkgs/qca-qt5/template
@@ -1,7 +1,7 @@
 # Template file for 'qca'
 pkgname=qca-qt5
 version=2.1.0
-revision=2
+revision=3
 wrksrc=${pkgname%-*}-${version}
 build_style=cmake
 configure_args="-DBUILD_TESTS=0 -DQCA_FEATURE_INSTALL_DIR=/usr/share/qca/mkspecs -DWITH_ossl_PLUGIN=yes"
@@ -17,6 +17,11 @@ checksum=226dcd76138c3738cdc15863607a96b3758a4c3efd3c47295939bcea4e7a9284
 
 provides="qca-${version}_${revision}"
 replaces="qca>=0"
+
+pre_configure() {
+	sed -e "s;-D_BSD_SOURCE;-D_DEFAULT_SOURCE;" \
+		-i CMakeLists.txt
+}
 
 qca-qt5-ossl_package() {
 	depends="${sourcepkg}-${version}_${revision}"


### PR DESCRIPTION
Since Qt5-5.5.0 it seems to be necessary to explicitly `#include <QIODevice>`
if this class is used. In previous versions this header may have been included as a
side-effect by other Qt headers.

Also silence the exessive warnings regarding the macro _BSD_SOURCE by
replacing it with _DEFAULT_SOURCE.