### PR TITLE
fortune-mod: unbreak musl

### DIFF
--- a/srcpkgs/fortune-mod/files/error.c
+++ b/srcpkgs/fortune-mod/files/error.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdio.h>
+#define _GNU_SOURCE
+#include <errno.h>
+
+void error(int status, int errnum, const char* format, ...)
+{
+	va_list ap;
+
+	fflush(stdout);
+	fprintf(stderr, "%s: ", program_invocation_name);
+	va_start(ap, format);
+	vfprintf(stderr, format, ap);
+	va_end(ap);
+	if (errnum)
+		fprintf(stderr, ":%d", errnum);
+	if (status)
+		exit(status);
+}

--- a/srcpkgs/fortune-mod/files/error.h
+++ b/srcpkgs/fortune-mod/files/error.h
@@ -1,0 +1,4 @@
+#ifndef _ERROR_H_
+#define _ERROR_H_
+void error(int status, int errnum, const char* format, ...);
+#endif	/* _ERROR_H_ */

--- a/srcpkgs/fortune-mod/template
+++ b/srcpkgs/fortune-mod/template
@@ -15,6 +15,13 @@ nocross=yes
 do_build() {
 	sed -i "s|^CFLAGS=.*|CFLAGS=${CFLAGS} -fsigned-char \$(DEFINES)|" Makefile
 	sed -i "s|^LDFLAGS=.*|LDFLAGS=${LDFLAGS}|" Makefile
+	sed -i "s;u_int;uint;" util/strfile.h
+	case "$XBPS_TARGET_MACHINE" in
+		*-musl)
+			cp ${FILESDIR}/error.{c,h} ${wrksrc}/fortune
+			sed -e "s;-DBSD_REGEX;-DPOSIX_REGEX;" -i Makefile
+			sed -e "s;fortune\.o;fortune.o error.o;" -i fortune/Makefile
+	esac
 	make CC=$CC COOKIEDIR=/usr/share/fortunes
 }
 do_install() {


### PR DESCRIPTION
librecode expects to link against something which defines a function `void error(int status, int errnum, const char* format, ...);` which gnu libc defines. This is despite the fact that musl libc does not have error.h.

The easiest way around this is to add a function to the fortune-mod object files for musl builds which mimicks what glibc error(3) does.
