### PR TITLE
libxfce4ui: add gtk+3 and new shlibs

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -667,7 +667,9 @@ libgpgme-pthread.so.11 gpgme-1.3.0_1
 libgarcon-1.so.0 garcon-0.1.12_1
 libgarcon-gtk2-1.so.0 garcon-0.4.0_1
 libxfce4ui-1.so.0 libxfce4ui-4.9.2_1
+libxfce4ui-2.so.0 libxfce4ui-4.12.1_2
 libxfce4kbd-private-2.so.0 libxfce4ui-4.9.2_1
+libxfce4kbd-private-3.so.0 libxfce4ui-4.12.1_2
 libxml++-2.6.so.2 libxml++-2.32.0_1
 libftgl.so.2 ftgl-2.1.2_1
 libGLEW.so.1.12 glew-1.12.0_1

--- a/srcpkgs/libxfce4ui/template
+++ b/srcpkgs/libxfce4ui/template
@@ -1,11 +1,11 @@
 # Template file for 'libxfce4ui'
 pkgname=libxfce4ui
 version=4.12.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="xfce4-dev-tools pkg-config intltool glib-devel gettext-devel"
-makedepends="gtk+-devel libxfce4util-devel xfconf-devel dbus-glib-devel
+makedepends="gtk+-devel gtk+3-devel libxfce4util-devel xfconf-devel dbus-glib-devel
  libxml2-devel startup-notification-devel libSM-devel"
 conf_files="/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml"
 short_desc="Replacement of the old libxfcegui4 library"


### PR DESCRIPTION
The gtk+3 libs are required for parole