### PR TITLE
gst-plugins-bad: makedepends needs gettext-devel

### DIFF
--- a/srcpkgs/gst-plugins-bad/template
+++ b/srcpkgs/gst-plugins-bad/template
@@ -1,12 +1,12 @@
 # Template file for 'gst-plugins-bad'.
 pkgname=gst-plugins-bad
 version=0.10.23
-revision=11
+revision=12
 lib32disabled=yes
 build_style=gnu-configure
 configure_args="--enable-experimental --disable-static"
-hostmakedepends="automake libtool pkg-config intltool glib-devel"
-makedepends="libpng-devel alsa-lib-devel celt-devel libressl-devel
+hostmakedepends="automake libtool pkg-config intltool glib-devel gettext-devel"
+makedepends="gettext-devel libpng-devel alsa-lib-devel celt-devel libressl-devel
  gst-plugins-base-devel libdca-devel orc-devel libmms-devel exempi-devel
  libexif-devel libmpcdec-devel faac-devel SDL-devel libpng-devel
  faad2-devel libdvdread-devel libdvdnav-devel librsvg-devel libsndfile-devel


### PR DESCRIPTION
Not sure about
```
=> WARNING: gst-plugins-bad-0.10.23_12: libgstphotography-0.10.so.23 not found in common/shlibs!
=> WARNING: gst-plugins-bad-0.10.23_12: libgstsignalprocessor-0.10.so.23 not found in common/shlibs!
=> WARNING: gst-plugins-bad-0.10.23_12: libgstbasecamerabinsrc-0.10.so.23 not found in common/shlibs!
=> WARNING: gst-plugins-bad-0.10.23_12: libgstvdp-0.10.so.23 not found in common/shlibs!
```