### PR TITLE
libcdr: -O0 prevents _FORTIFY_SOURCE

### DIFF
--- a/srcpkgs/libcdr/template
+++ b/srcpkgs/libcdr/template
@@ -1,17 +1,25 @@
 # Template file for 'libcdr'
 pkgname=libcdr
 version=0.1.1
-revision=1
+revision=2
 build_style=gnu-configure
 short_desc="Corel Draw file format importer library"
 maintainer="Enno Boland <eb@s01.de>"
-license="LGPL/MPL"
+license="LGPL-2.1/MPL"
 makedepends="lcms2-devel icu-devel librevenge-devel boost-devel"
 hostmakedepends="pkg-config"
 homepage="https://wiki.documentfoundation.org/DLP/Libraries/libcdr"
 distfiles="http://dev-www.libreoffice.org/src/${pkgname}-${version}.tar.bz2"
 checksum=72fe7bbbf2275242acdf67ad2f9b6c71ac9146a56c409def360dabcac5695b49
 configure_args="--enable-debug"
+
+post_configure() {
+	local _f
+	# -O0 prevents _FORTIFY_SOURCE working
+	for _f in $(find ${wrksrc} -name Makefile); do
+		sed -i $_f -e "s; -O0;;"
+	done
+}
 
 libcdr-devel_package() {
 	depends="libcdr>=${version}_${revision} $makedepends"


### PR DESCRIPTION
The `Makefile`s contain a trailing `-O0` in the `CXXFLAGS` which prevents`_FORTIFY_SOURCE`.