### PR TITLE
proot: unbreak musl

### DIFF
--- a/srcpkgs/proot/files/ptrace_compat.h
+++ b/srcpkgs/proot/files/ptrace_compat.h
@@ -1,0 +1,80 @@
+#if !defined(_PTRACE_COMPAT_H_)
+#define	_PTRACE_COMPAT_H_
+
+
+/* Type of the REQUEST argument to `ptrace.'  */
+enum __ptrace_request
+{
+  __PTRACE_TRACEME = 0,
+  __PTRACE_PEEKTEXT = 1,
+  __PTRACE_PEEKDATA = 2,
+  __PTRACE_PEEKUSER = 3,
+  __PTRACE_POKETEXT = 4,
+  __PTRACE_POKEDATA = 5,
+  __PTRACE_POKEUSER = 6,
+  __PTRACE_CONT = 7,
+  __PTRACE_KILL = 8,
+  __PTRACE_SINGLESTEP = 9,
+  __PTRACE_GETREGS = 12,
+  __PTRACE_SETREGS = 13,
+  __PTRACE_GETFPREGS = 14,
+  __PTRACE_SETFPREGS = 15,
+  __PTRACE_ATTACH = 16,
+  __PTRACE_DETACH = 17,
+  __PTRACE_GETFPXREGS = 18,
+  __PTRACE_SETFPXREGS = 19,
+  __PTRACE_SYSCALL = 24,
+  __PTRACE_SETOPTIONS = 0x4200,
+  __PTRACE_GETEVENTMSG = 0x4201,
+  __PTRACE_GETSIGINFO = 0x4202,
+  __PTRACE_SETSIGINFO = 0x4203,
+  __PTRACE_GETREGSET = 0x4204,
+  __PTRACE_SETREGSET = 0x4205,
+  __PTRACE_SEIZE = 0x4206,
+  __PTRACE_INTERRUPT = 0x4207,
+  __PTRACE_LISTEN = 0x4208,
+  __PTRACE_PEEKSIGINFO = 0x4209,
+  __PTRACE_GETSIGMASK = 0x420a,
+  __PTRACE_SETSIGMASK = 0x420b
+};
+
+
+/* Flag for PTRACE_LISTEN.  */
+enum __ptrace_flags
+{
+  __PTRACE_SEIZE_DEVEL = 0x80000000
+};
+
+/* Options set using PTRACE_SETOPTIONS.  */
+enum __ptrace_setoptions
+{
+  __PTRACE_O_TRACESYSGOOD	= (1 << 0),
+  __PTRACE_O_TRACEFORK		= (1 << 1),
+  __PTRACE_O_TRACEVFORK		= (1 << 2),
+  __PTRACE_O_TRACECLONE		= (1 << 3),
+  __PTRACE_O_TRACEEXEC		= (1 << 4),
+  __PTRACE_O_TRACEVFORKDONE	= (1 << 5),
+  __PTRACE_O_TRACEEXIT		= (1 << 6),
+  __PTRACE_O_TRACESECCOMP	= (1 << 7),
+  __PTRACE_O_EXITKILL		= (1 << 20),
+  __PTRACE_O_MASK		= __PTRACE_O_EXITKILL | ((1 << 8) - 1)
+};
+
+/* Wait extended result codes for the above trace options.  */
+enum __ptrace_eventcodes
+{
+  __PTRACE_EVENT_FORK	= 1,
+  __PTRACE_EVENT_VFORK	= 2,
+  __PTRACE_EVENT_CLONE	= 3,
+  __PTRACE_EVENT_EXEC	= 4,
+  __PTRACE_EVENT_VFORK_DONE = 5,
+  __PTRACE_EVENT_EXIT	= 6,
+  __PTRACE_EVENT_SECCOMP  = 7
+};
+
+enum __ptrace_peeksiginfo_flags
+{
+  __PTRACE_PEEKSIGINFO_SHARED = (1 << 0)
+};
+
+#endif /* _PTRACE_COMPAT_H */

--- a/srcpkgs/proot/patches/linux_wait_h.patch
+++ b/srcpkgs/proot/patches/linux_wait_h.patch
@@ -1,0 +1,34 @@
+--- src/ptrace/ptrace.c	2014-12-15 15:18:11.000000000 +0100
++++ src/ptrace/ptrace.c	2015-07-12 13:13:45.970093333 +0200
+@@ -28,6 +28,7 @@
+ #include <sys/uio.h>    /* struct iovec, */
+ #include <sys/param.h>  /* MIN(), MAX(), */
+ #include <string.h>     /* memcpy(3), */
++#include <linux/wait.h> /* __WALL, __WCLONE */
+ 
+ #include "ptrace/ptrace.h"
+ #include "ptrace/user.h"
+--- src/ptrace/wait.c	2014-12-15 15:18:11.000000000 +0100
++++ src/ptrace/wait.c	2015-07-12 13:16:41.930106019 +0200
+@@ -26,6 +26,7 @@
+ #include <stdbool.h>    /* bool, true, false, */
+ #include <signal.h>     /* SIG*, */
+ #include <talloc.h>     /* talloc*, */
++#include <linux/wait.h> /* __WALL, __WCLONE */
+ 
+ #include "ptrace/wait.h"
+ #include "ptrace/ptrace.h"
+--- src/tracee/tracee.c	2014-12-15 15:18:11.000000000 +0100
++++ src/tracee/tracee.c	2015-07-12 13:20:01.058120375 +0200
+@@ -31,6 +31,11 @@
+ #include <signal.h>     /* kill(2), SIGKILL, */
+ #include <sys/ptrace.h> /* ptrace(2), PTRACE_*, */
+ #include <errno.h>      /* E*, */
++#include <linux/wait.h> /* __WALL, __WCLONE */
++
++#if !defined(__W_STOPCODE)
++#define __W_STOPCODE(sig) ((sig) << 8 | 0x7f)
++#endif
+ 
+ #include "tracee/tracee.h"
+ #include "tracee/reg.h"

--- a/srcpkgs/proot/patches/musl_execinfo.patch
+++ b/srcpkgs/proot/patches/musl_execinfo.patch
@@ -1,0 +1,28 @@
+--- src/cli/cli.c	2014-12-15 15:18:11.000000000 +0100
++++ src/cli/cli.c	2015-07-12 13:18:46.548115003 +0200
+@@ -30,7 +30,9 @@
+ #include <sys/types.h>     /* getpid(2),  */
+ #include <unistd.h>        /* getpid(2),  */
+ #include <errno.h>         /* errno(3), */
++#if defined(__GLIBC__)
+ #include <execinfo.h>      /* backtrace_symbols(3), */
++#endif
+ #include <limits.h>        /* INT_MAX, */
+ 
+ #include "cli/cli.h"
+@@ -555,6 +557,7 @@
+ void __cyg_profile_func_enter(void *this_function, void *call_site) DONT_INSTRUMENT;
+ void __cyg_profile_func_enter(void *this_function, void *call_site)
+ {
++#if defined(__GLIBC__)
+ 	void *const pointers[] = { this_function, call_site };
+ 	char **symbols = NULL;
+ 
+@@ -567,6 +570,7 @@
+ end:
+ 	if (symbols != NULL)
+ 		free(symbols);
++#endif /* defined(__GLIBC__) */
+ 
+ 	if (indent_level < INT_MAX)
+ 		indent_level++;

--- a/srcpkgs/proot/patches/ptrace_compat.patch
+++ b/srcpkgs/proot/patches/ptrace_compat.patch
@@ -1,0 +1,12 @@
+--- src/tracee/tracee.h	2014-12-15 15:18:11.000000000 +0100
++++ src/tracee/tracee.h	2015-07-12 13:12:10.726086466 +0200
+@@ -28,6 +28,9 @@
+ #include <stdbool.h>   /* bool,  */
+ #include <sys/queue.h> /* LIST_*, */
+ #include <sys/ptrace.h>/* enum __ptrace_request */
++#if !defined(__GLIBC__)
++#include "ptrace_compat.h"
++#endif
+ #include <talloc.h>    /* talloc_*, */
+ 
+ #include "arch.h" /* word_t, user_regs_struct, */

--- a/srcpkgs/proot/template
+++ b/srcpkgs/proot/template
@@ -1,7 +1,7 @@
 # Template file for 'proot'
 pkgname=proot
 version=5.1.0
-revision=1
+revision=2
 wrksrc="PRoot-${version}"
 makedepends="libarchive-devel talloc-devel"
 short_desc="User-space implementation of chroot, mount --bind, and binfmt_misc"
@@ -15,6 +15,10 @@ pre_build() {
 	sed -i "s,strip,:,g" src/GNUmakefile
 	sed -i "s,objcopy,${OBJCOPY},g" src/GNUmakefile
 	sed -i "s,objdump,${OBJDUMP},g" src/GNUmakefile
+	sed -i "s,--input ,--input-target ,g" src/GNUmakefile
+	sed -i "s,--output ,--output-target ,g" src/GNUmakefile
+	# Fix glibc ptrace.h specific constants for musl libc
+	cp ${FILESDIR}/ptrace_compat.h ${wrksrc}/src
 }
 do_build() {
 	cd src


### PR DESCRIPTION
This makes proot build on musl, but requires testing to make
sure the resulting binary works as expected.

Also the glibc result need review, because my changes
to the objcopy parameters may be wrong:
man objcopy(1) does not list `--input` or `--ouput` parameters,
but just `--input-target` and `--output-target`.
