### PR TITLE
libtorrent: update to 0.13.5

### DIFF
--- a/srcpkgs/libtorrent/template
+++ b/srcpkgs/libtorrent/template
@@ -1,7 +1,7 @@
 # Template build file for 'libtorrent'
 pkgname=libtorrent
-version=0.13.4
-revision=4
+version=0.13.5
+revision=1
 build_style=gnu-configure
 configure_args="--enable-static --disable-debug --without-kqueue
  --enable-aligned --with-posix-fallocate"
@@ -9,16 +9,22 @@ hostmakedepends="automake libtool pkg-config"
 makedepends="zlib-devel libressl-devel"
 short_desc="BitTorrent library written in C++"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://libtorrent.rakshasa.no"
+homepage="https://github.com/rakshasa/${pkgname}"
 license="GPL-2"
-distfiles="http://libtorrent.rakshasa.no/downloads/$pkgname-$version.tar.gz"
-checksum=704e097119dc89e2ee4630396b25de1cd64b0549841347ea75b9ef9217084955
+distfiles="https://github.com/rakshasa/${pkgname}/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
+checksum=625a13397828c2b84e17f51200ebee8b4f754c112dbb9c0f31292507fd7c026e
 
 pre_configure() {
 	# Drop cppunit requirement
 	sed '/AM_PATH_CPPUNIT.*/d' -i configure.ac
 	autoreconf -fi
 	sed -e 's,test "$cross_compiling" = yes, false,' -i configure
+}
+post_configure() {
+	# Replace wrong (for cross buidls) -L/lib in Makefiles
+	for f in $(find ${wrksrc} -name Makefile); do
+		sed -i $f -e "s;-L/lib;-L${XBPS_CROSS_BASE}/lib;g"
+	done
 }
 
 libtorrent-devel_package() {


### PR DESCRIPTION
The homepage does not exist anymore, thus migrate to github
Use the github download location and rename file to include pkgname

Partially closes #1924