### PR TITLE
run xlint parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
         - PATH=$PATH:$HOME/bin
 
     matrix:
+        - XLINT=1
         - ARCH=x86_64 BOOTSTRAP=x86_64
         - ARCH=i686 BOOTSTRAP=i686
         - ARCH=armv6hf BOOTSTRAP=x86_64

--- a/common/travis/bootstrap.sh
+++ b/common/travis/bootstrap.sh
@@ -2,4 +2,6 @@
 #
 # bootstrap.sh
 
+[ "$XLINT" ] && exit 0
+
 ./xbps-src -H $HOME/hostdir binary-bootstrap $1

--- a/common/travis/build.sh
+++ b/common/travis/build.sh
@@ -2,6 +2,8 @@
 #
 # build.sh
 
+[ "$XLINT" ] && exit 0 
+
 if [ "$1" != "$2" ]; then
 	arch="-a $2"
 fi

--- a/common/travis/show_files.sh
+++ b/common/travis/show_files.sh
@@ -2,6 +2,8 @@
 #
 # show_files.sh
 
+[ "$XLINT" ] && exit 0 
+
 if [ "$1" != "$2" ]; then
 	arch="-a $2"
 fi

--- a/common/travis/xlint.sh
+++ b/common/travis/xlint.sh
@@ -2,4 +2,6 @@
 #
 # xlint.sh
 
+[ "$XLINT" ] || exit 0 
+
 awk '{ print "srcpkgs/" $0 "/template" }' /tmp/templates | xargs xlint


### PR DESCRIPTION
This PR adds an extra build job which only runs xlint on changed templates and disables xlint for all others.

Fixes #2017