### PR TITLE
rtorrent: update to 0.9.5 and move to github

### DIFF
--- a/srcpkgs/rtorrent/patches/no_xmlrpc_c_compile.patch
+++ b/srcpkgs/rtorrent/patches/no_xmlrpc_c_compile.patch
@@ -1,0 +1,23 @@
+--- scripts/checks.m4	2015-07-02 00:32:45.000000000 +0200
++++ scripts/checks.m4	2015-07-14 15:39:07.334398349 +0200
+@@ -463,19 +463,9 @@
+       fi
+       
+       if eval $xmlrpc_cc_prg --version 2>/dev/null >/dev/null; then
++        AC_MSG_RESULT(ok)
+         CXXFLAGS="$CXXFLAGS `$xmlrpc_cc_prg --cflags server-util`"
+         LIBS="$LIBS `$xmlrpc_cc_prg server-util --libs`"
+-
+-        AC_TRY_LINK(
+-        [ #include <xmlrpc-c/server.h>
+-        ],[ xmlrpc_registry_new(NULL); ],
+-        [
+-          AC_MSG_RESULT(ok)
+-        ], [
+-          AC_MSG_RESULT(failed)
+-          AC_MSG_ERROR(Could not compile XMLRPC-C test.)
+-        ])
+-
+         AC_DEFINE(HAVE_XMLRPC_C, 1, Support for XMLRPC-C.)
+ 
+       else

--- a/srcpkgs/rtorrent/template
+++ b/srcpkgs/rtorrent/template
@@ -1,21 +1,31 @@
 # Template file for 'rtorrent'
 pkgname=rtorrent
-version=0.9.4
-revision=3
+version=0.9.5
+revision=1
 build_style=gnu-configure
 configure_args="--with-xmlrpc-c"
 hostmakedepends="automake libtool pkg-config"
 makedepends="libcurl-devel libsigc++-devel libtorrent-devel ncurses-devel xmlrpc-c-devel"
 short_desc="Ncurses BitTorrent client based on libTorrent"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://libtorrent.rakshasa.no"
+homepage="https://github.com/rakshasa/rtorrent"
 license="GPL-2"
-distfiles="http://libtorrent.rakshasa.no/downloads/$pkgname-$version.tar.gz"
-checksum=bc0a2c1ee613b68f37021beaf4e64a9252f91ed06f998c1e897897c354ce7e84
+distfiles="https://github.com/rakshasa/${pkgname}/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
+checksum=96ab7c168a5a83f4dd7e991cee3a65fda6d76c9bc9a72ac6fefe34a2ded0eb85
 
 pre_configure() {
 	# Drop cppunit requirement
 	sed '/AM_PATH_CPPUNIT.*/d' -i configure.ac
 	autoreconf -fi
 	sed -e 's,test "$cross_compiling" = yes, false,' -i configure
+}
+post_configure() {
+	local f
+	for f in $(find ${wrksrc} -name Makefile); do
+		sed -e "s;-L/usr/lib;-L${XBPS_CROSS_BASE}/usr/lib;g" -i $f
+		sed -e "s;-I/usr/include;-L${XBPS_CROSS_BASE}/usr/include;g" -i $f
+	done
+	case "$XBPS_TARGET_ARCH" in
+		*-musl) sed -e "s;-lm;-lm -lc;" Makefile
+	esac
 }


### PR DESCRIPTION
cross armv6hf-musl is broken. It doesn't find `__write` when linking the executable.
For now I'll leave it broken, as I don't know where to look for the problem.

