### PR TITLE
openjdk: fix building in current environment

### DIFF
--- a/srcpkgs/openjdk/template
+++ b/srcpkgs/openjdk/template
@@ -12,7 +12,7 @@ _openjdk_version="openjdk-1.8.0_${_jdk_update}"
 # Template file for 'openjdk'
 pkgname=openjdk
 version=${_java_ver}u${_jdk_update}
-revision=1
+revision=2
 nocross=yes
 wrksrc=jdk8u-jdk8u${_jdk_update}-b${_jdk_build}/
 build_style=gnu-configure
@@ -68,6 +68,10 @@ checksum="
 # Build is still parallel, but don't use -jN.
 disable_parallel_build=yes
 
+# -D_FORTIFY_SOURCE=2 doesn't work with CXX_O_FLAG_NONE="-O0"
+CFLAGS=${CFLAGS/-D_FORTIFY_SOURCE=2/}
+CXXFLAGS=${CXXFLAGS/-D_FORTIFY_SOURCE=2/}
+
 build_options="oracle_bootstrap"
 build_options_default="oracle_bootstrap"
 desc_option_oracle_bootstrap="Bootstrap using Oracle JDK"
@@ -80,6 +84,9 @@ post_extract() {
 	cd hotspot
 	# https://bugs.openjdk.java.net/browse/JDK-8041658
 	patch -p1 < ${FILESDIR}/002_gcc.make-4.9.patch
+	# patch supported os versions to include 4 and 4.1
+	sed -i ${wrksrc}/hotspot/make/linux/Makefile \
+		-e "/SUPPORTED_OS_VERSION =/s;\(.*\);\1 4% 4.1%;"
 }
 
 post_install() {


### PR DESCRIPTION
- The hotspot OS version tests supported at most Linux-3.x; add 4 and 4.1
- The -D_FORTIFY_SOURCE=2 conflicts with CXX_O_FLAG_NONE="-O0", thus remove it