### PR TITLE
couchdb: fix build and runit file

### DIFF
--- a/srcpkgs/couchdb/files/couchdb/run
+++ b/srcpkgs/couchdb/files/couchdb/run
@@ -2,5 +2,5 @@
 export HOME=/var/lib/couchdb
 mkdir -p /var/run/couchdb
 chown couchdb /var/run/couchdb
-exec chpst -u couchdb:couchdb couchdb   -r 5 -b  -o /dev/null  -e /dev/null
+exec chpst -u couchdb:couchdb couchdb -r 5 -o /dev/null  -e /dev/null
 

--- a/srcpkgs/couchdb/patches/0001-build-support-OTP-18.0.patch
+++ b/srcpkgs/couchdb/patches/0001-build-support-OTP-18.0.patch
@@ -1,0 +1,76 @@
+--- /tmp/uHVDRN_INSTALL.Unix	2015-07-16 20:50:58.709145634 -0500
++++ INSTALL.Unix	2015-07-16 20:50:45.781145327 -0500
+@@ -39,7 +39,7 @@
+ 
+ You should have the following installed:
+ 
+- * Erlang OTP (>=R14B01, =<R17) (http://erlang.org/)
++ * Erlang OTP (>=R14B01, =<R18) (http://erlang.org/)
+  * ICU                          (http://icu-project.org/)
+  * OpenSSL                      (http://www.openssl.org/)
+  * Mozilla SpiderMonkey (1.8.5) (http://www.mozilla.org/js/spidermonkey/)
+--- /tmp/VavklE_INSTALL.Windows	2015-07-16 20:50:58.714145634 -0500
++++ INSTALL.Windows	2015-07-16 20:50:45.781145327 -0500
+@@ -29,7 +29,7 @@
+ 
+ You will need the following installed:
+ 
+- * Erlang OTP (>=14B01, <R17)    (http://erlang.org/)
++ * Erlang OTP (>=14B01, <R18)    (http://erlang.org/)
+  * ICU        (>=4.*)            (http://icu-project.org/)
+  * OpenSSL    (>=0.9.8r)         (http://www.openssl.org/)
+  * Mozilla SpiderMonkey (=1.8.5) (http://www.mozilla.org/js/spidermonkey/)
+--- /tmp/rXCQPu_configure.ac	2015-07-16 20:50:58.719145634 -0500
++++ configure.ac	2015-07-16 20:50:45.782145327 -0500
+@@ -411,7 +411,7 @@
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking Erlang version compatibility" >&5
+ $as_echo_n "checking Erlang version compatibility... " >&6; }
+-erlang_version_error="The installed Erlang version must be >= R14B (erts-5.8.1) and =< 17 (erts-6.0)"
++erlang_version_error="The installed Erlang version must be >= R14B (erts-5.8.1) and =< 18 (erts-7.0)"
+ 
+ version="`${ERL} -version 2>&1 | ${SED} 's/[[^0-9]]/ /g'` 0 0 0"
+ major_version=`echo $version | ${AWK} "{print \\$1}"`
+@@ -419,7 +419,7 @@
+ patch_version=`echo $version | ${AWK} "{print \\$3}"`
+ echo -n "detected Erlang version: $major_version.$minor_version.$patch_version..."
+ 
+-if test $major_version -lt 5 -o $major_version -gt 6; then
++if test $major_version -lt 5 -o $major_version -gt 7; then
+     as_fn_error $? "$erlang_version_error major_version does not match" "$LINENO" 5
+ fi
+ 
+@@ -438,9 +438,9 @@
+ AC_SUBST(otp_release)
+ 
+ AM_CONDITIONAL([USE_OTP_NIFS],
+-    [can_use_nifs=$(echo $otp_release | grep -E "^(R14B|R15|R16|17)")])
++    [can_use_nifs=$(echo $otp_release | grep -E "^(R14B|R15|R16|17|18)")])
+ AM_CONDITIONAL([USE_EJSON_COMPARE_NIF],
+-    [can_use_ejson=$(echo $otp_release | grep -E "^(R14B03|R15|R16|17)")])
++    [can_use_ejson=$(echo $otp_release | grep -E "^(R14B03|R15|R16|17|18)")])
+ 
+ has_crypto=`\
+     ${ERL} -eval "\
+--- /tmp/lQzdll_unix.rst	2015-07-16 20:50:58.724145634 -0500
++++ share/doc/src/install/unix.rst	2015-07-16 20:50:45.801145327 -0500
+@@ -52,7 +52,7 @@
+ 
+ You should have the following installed:
+ 
+-* `Erlang OTP (>=R14B01, =<R17) <http://erlang.org/>`_
++* `Erlang OTP (>=R14B01, =<R18) <http://erlang.org/>`_
+ * `ICU                          <http://icu-project.org/>`_
+ * `OpenSSL                      <http://www.openssl.org/>`_
+ * `Mozilla SpiderMonkey (1.8.5) <http://www.mozilla.org/js/spidermonkey/>`_
+--- /tmp/nUxhRb_windows.rst	2015-07-16 20:50:58.728145635 -0500
++++ share/doc/src/install/windows.rst	2015-07-16 20:50:45.801145327 -0500
+@@ -90,7 +90,7 @@
+ 
+ You should have the following installed:
+ 
+-* `Erlang OTP (>=14B01, <R17)    <http://erlang.org/>`_
++* `Erlang OTP (>=14B01, <R18)    <http://erlang.org/>`_
+ * `ICU        (>=4.*)            <http://icu-project.org/>`_
+ * `OpenSSL    (>0.9.8r)          <http://www.openssl.org/>`_
+ * `Mozilla SpiderMonkey (=1.8.5) <http://www.mozilla.org/js/spidermonkey/>`_

--- a/srcpkgs/couchdb/patches/fix-configure.patch
+++ b/srcpkgs/couchdb/patches/fix-configure.patch
@@ -1,0 +1,38 @@
+--- configure.orig	2015-07-16 20:45:43.942138153 -0500
++++ configure	2015-07-16 20:44:30.432136406 -0500
+@@ -18532,7 +18532,7 @@
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking Erlang version compatibility" >&5
+ $as_echo_n "checking Erlang version compatibility... " >&6; }
+-erlang_version_error="The installed Erlang version must be >= R14B (erts-5.8.1) and =< 17 (erts-6.0)"
++erlang_version_error="The installed Erlang version must be >= R14B (erts-5.8.1) and =< 18 (erts-7.0)"
+ 
+ version="`${ERL} -version 2>&1 | ${SED} 's/[^0-9]/ /g'` 0 0 0"
+ major_version=`echo $version | ${AWK} "{print \\$1}"`
+@@ -18540,7 +18540,7 @@
+ patch_version=`echo $version | ${AWK} "{print \\$3}"`
+ echo -n "detected Erlang version: $major_version.$minor_version.$patch_version..."
+ 
+-if test $major_version -lt 5 -o $major_version -gt 6; then
++if test $major_version -lt 5 -o $major_version -gt 8; then
+     as_fn_error $? "$erlang_version_error major_version does not match" "$LINENO" 5
+ fi
+ 
+@@ -18559,7 +18559,7 @@
+ 
+ 
+ 
+- if can_use_nifs=$(echo $otp_release | grep -E "^(R14B|R15|R16|17)"); then
++ if can_use_nifs=$(echo $otp_release | grep -E "^(R14B|R15|R16|17|18)"); then
+   USE_OTP_NIFS_TRUE=
+   USE_OTP_NIFS_FALSE='#'
+ else
+@@ -18567,7 +18567,7 @@
+   USE_OTP_NIFS_FALSE=
+ fi
+ 
+- if can_use_ejson=$(echo $otp_release | grep -E "^(R14B03|R15|R16|17)"); then
++ if can_use_ejson=$(echo $otp_release | grep -E "^(R14B03|R15|R16|17|18)"); then
+   USE_EJSON_COMPARE_NIF_TRUE=
+   USE_EJSON_COMPARE_NIF_FALSE='#'
+ else

--- a/srcpkgs/couchdb/template
+++ b/srcpkgs/couchdb/template
@@ -1,7 +1,7 @@
 # Template file for 'couchdb'
 pkgname=couchdb
 version=1.6.1
-revision=3
+revision=4
 wrksrc="apache-couchdb-$version"
 build_style=gnu-configure
 conf_files="/etc/couchdb/default.ini /etc/couchdb/local.ini"


### PR DESCRIPTION
Upstream couchdb has a patch to fix building on Erlang 18. Additionally, the service file has couchdb fork to a background process which breaks how runit expects services to run.