### PR TITLE
fix compile w/ automake-1.15, inline res_randomid on musl

### DIFF
--- a/srcpkgs/libasr/patches/musl-inline-res_randomid.patch
+++ b/srcpkgs/libasr/patches/musl-inline-res_randomid.patch
@@ -1,0 +1,24 @@
+diff --git configure.ac configure.ac
+index 10aff04..07e149f 100644
+--- configure.ac
++++ configure.ac
+@@ -456,6 +456,7 @@ AC_CHECK_FUNCS([ \
+ 	issetugid \
+ 	memmove \
+ 	reallocarray \
++	res_randomid \
+ 	snprintf \
+ 	strdup \
+ 	strerror \
+diff --git src/asr_private.h src/asr_private.h
+index 0960e37..158e7ff 100644
+--- src/asr_private.h
++++ src/asr_private.h
+@@ -365,3 +365,7 @@ extern FILE * asr_debug;
+ 		asr_statestr((a)->as_state),	\
+ 		asr_statestr((s)));		\
+ 	(a)->as_state = (s); } while (0)
++
++#ifndef HAVE_RES_RANDOMID
++#define res_randomid(x) (0xffff & getpid())
++#endif

--- a/srcpkgs/libasr/template
+++ b/srcpkgs/libasr/template
@@ -1,15 +1,26 @@
 # Template file for 'libasr'
 pkgname=libasr
 version=1.0.2
-revision=1
+revision=2
 build_style=gnu-configure
+hostmakedepends="automake libtool"
 makedepends="libressl-devel"
 short_desc="Simple and portable asynchronous resolver library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="ISC, BSD"
 homepage="https://www.opensmtpd.org/"
-distfiles="https://www.opensmtpd.org/archives/${pkgname}-${version}.tar.gz"
-checksum=a6f5d1c6306938156da3427525572b9b16c1e6be6c69845d390bb63f41a58b34
+distfiles="https://github.com/OpenSMTPD/${pkgname}/archive/${pkgname}-${version}.tar.gz"
+checksum=4ab54264206e255fd6c2de982764bb5ce7857ec8f649ad3ee45771244593b6e1
+wrksrc="${pkgname}-${pkgname}-${version}"
+
+case "$XBPS_TARGET_MACHINE" in
+	*-musl) ;;
+	*) CFLAGS="$CFLAGS -DHAVE_RES_RANDOMID"
+esac
+
+pre_configure() {
+	./bootstrap
+}
 
 post_install() {
 	vlicense LICENCE


### PR DESCRIPTION
The libasr from http://www.opensmtpd.org/archives/libasr-1.0.2.tar.gz has already had ./bootstrap ran, which seems to use autoconf/automake 1.14.1. This breaks the current build script, it tries to find aclocal-1.14, automake-1.14, etc.

Instead, this pulls the release from Github and runs ./bootstrap and now compiles correctly.

Interesting sidenote: the [libasr-1.0.2 announcement](https://www.opensmtpd.org/announces/libasr-1.0.2.txt) mentions that Github is the primary location for libasr information.

The other fix is for usage on musl - OpenSMTPD fails to get through ./configure on musl, because libasr uses the `res_randomid()` function from glibc/uclibc. I made a patch that implements the workaround from this issue: https://github.com/OpenSMTPD/libasr/issues/8

Note: this does not fix OpenSMTPD compilation entirely.