### PR TITLE
transmission: unbreak musl

### DIFF
--- a/srcpkgs/transmission/template
+++ b/srcpkgs/transmission/template
@@ -1,7 +1,7 @@
 # Template file for 'transmission'
 pkgname=transmission
 version=2.84
-revision=10
+revision=11
 build_style=gnu-configure
 configure_args="--enable-nls --enable-cli --enable-daemon --enable-utp --without-systemd-daemon"
 hostmakedepends="pkg-config intltool"
@@ -24,6 +24,12 @@ if [ -z "$CROSS_BUILD" ]; then
 	subpackages+=" transmission-qt"
 fi
 
+post_configure() {
+	# Add missing includes which happen as side-effects with glibc
+	sed -i libtransmission/transmission.h \
+		 -e "/#include <inttypes.h>.*/i #include <sys/types.h> /* ssize_t */" \
+		 -e "/#include <inttypes.h>.*/i #include <stdio.h> /* off_t */"
+}
 do_build() {
 	make CXXFLAGS="${CXXFLAGS} -std=c++11" LDFLAGS="${LDFLAGS}" ${makejobs}
 	if [ -z "$CROSS_BUILD" ]; then
@@ -77,6 +83,10 @@ transmission-gtk_package() {
 		vmove usr/share/icons/hicolor
 		vmove usr/share/applications
 		vmove usr/share/pixmaps
+		# This install path seems to be used with musl libc
+		if [ -d ${DESTDIR}/usr/lib/locale ]; then
+			mv ${DESTDIR}/usr/lib/locale ${DESTDIR}/usr/share
+		fi
 		vmove usr/share/locale
 	}
 }


### PR DESCRIPTION
- Add missing includes which happen as side-effects with glibc
- Move usr/lib/locale to usr/share/locale for musl libc (better fix?)