### PR TITLE
gnome-mplayer: unbreak x86_64-musl

### DIFF
--- a/srcpkgs/gnome-mplayer/template
+++ b/srcpkgs/gnome-mplayer/template
@@ -1,10 +1,10 @@
 # Template file for 'gnome-mplayer'
 pkgname=gnome-mplayer
 version=1.0.9
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-schemas-install"
-hostmakedepends="pkg-config intltool"
+hostmakedepends="pkg-config intltool glib-devel"
 # XXX missing libgpod
 makedepends="dbus-glib-devel libnotify-devel gtk+3-devel gmtk-devel
  libXScrnSaver-devel nautilus-devel alsa-lib-devel pulseaudio-devel


### PR DESCRIPTION
arm* targets require a fix for `gmtk` which is more than just adding `glib-devel` and runinng `autoreconf -if` in `pre_configure()`... there is some m4 macro missing (...GCONF.. whatever :)
