### PR TITLE
New package: bogofilter-1.2.4

### DIFF
--- a/srcpkgs/bogofilter/template
+++ b/srcpkgs/bogofilter/template
@@ -1,0 +1,21 @@
+# Template file for 'bogofilter'
+pkgname=bogofilter
+version=1.2.4
+revision=1
+build_style=gnu-configure
+configure_args="--sysconfdir=/etc/${pkgname} --with-database=sqlite"
+depends="perl"
+makedepends="gsl-devel sqlite-devel"
+short_desc="A fast Bayesian spam filtering tool"
+maintainer="Gour <gour@atmarama.net>"
+license="GPL-3"
+homepage="http://bogofilter.sourceforge.net"
+distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=d2f2598d1300307209b7b1905cc0637d2d053c0a4701a8d44383867299578471
+
+conf_files="/etc/bogofilter/bogofilter.cf"
+
+post_install() {
+	vinstall bogofilter.cf.example 644  etc/bogofilter bogofilter.cf
+	vcopy contrib usr/share/contrib
+}


### PR DESCRIPTION
I created bogofilter package which uses sqlite3 as database back-end.

Usually, other distros have bogofilter pacakge built with Berkeley DB as default and then create other (sub)packages with other back-ends.

I have old sqlite3 wordlist.db and have need for it; the package works for me, built on x86_64. 

Sincerely,
Gour
