### PR TITLE
expat: Patch to fix CVE-2015-1283

### DIFF
--- a/srcpkgs/expat/patches/xmlparse.patch
+++ b/srcpkgs/expat/patches/xmlparse.patch
@@ -1,0 +1,75 @@
+See https://hg.mozilla.org/releases/mozilla-esr31/rev/2f3e78643f5c
+Patch to fix CVE-2015-1283
+
+--- lib/xmlparse.c
++++ lib/xmlparse.c
+@@ -1646,29 +1646,40 @@ XML_ParseBuffer(XML_Parser parser, int l
+   XmlUpdatePosition(encoding, positionPtr, bufferPtr, &position);
+   positionPtr = bufferPtr;
+   return result;
+ }
+ 
+ void * XMLCALL
+ XML_GetBuffer(XML_Parser parser, int len)
+ {
++/* BEGIN MOZILLA CHANGE (sanity check len) */
++  if (len < 0) {
++    errorCode = XML_ERROR_NO_MEMORY;
++    return NULL;
++  }
++/* END MOZILLA CHANGE */
+   switch (ps_parsing) {
+   case XML_SUSPENDED:
+     errorCode = XML_ERROR_SUSPENDED;
+     return NULL;
+   case XML_FINISHED:
+     errorCode = XML_ERROR_FINISHED;
+     return NULL;
+   default: ;
+   }
+ 
+   if (len > bufferLim - bufferEnd) {
+-    /* FIXME avoid integer overflow */
+     int neededSize = len + (int)(bufferEnd - bufferPtr);
++/* BEGIN MOZILLA CHANGE (sanity check neededSize) */
++    if (neededSize < 0) {
++      errorCode = XML_ERROR_NO_MEMORY;
++      return NULL;
++    }
++/* END MOZILLA CHANGE */
+ #ifdef XML_CONTEXT_BYTES
+     int keep = (int)(bufferPtr - buffer);
+ 
+     if (keep > XML_CONTEXT_BYTES)
+       keep = XML_CONTEXT_BYTES;
+     neededSize += keep;
+ #endif  /* defined XML_CONTEXT_BYTES */
+     if (neededSize  <= bufferLim - buffer) {
+@@ -1687,17 +1698,25 @@ XML_GetBuffer(XML_Parser parser, int len
+     }
+     else {
+       char *newBuf;
+       int bufferSize = (int)(bufferLim - bufferPtr);
+       if (bufferSize == 0)
+         bufferSize = INIT_BUFFER_SIZE;
+       do {
+         bufferSize *= 2;
+-      } while (bufferSize < neededSize);
++/* BEGIN MOZILLA CHANGE (prevent infinite loop on overflow) */
++      } while (bufferSize < neededSize && bufferSize > 0);
++/* END MOZILLA CHANGE */
++/* BEGIN MOZILLA CHANGE (sanity check bufferSize) */
++      if (bufferSize <= 0) {
++        errorCode = XML_ERROR_NO_MEMORY;
++        return NULL;
++      }
++/* END MOZILLA CHANGE */
+       newBuf = (char *)MALLOC(bufferSize);
+       if (newBuf == 0) {
+         errorCode = XML_ERROR_NO_MEMORY;
+         return NULL;
+       }
+       bufferLim = newBuf + bufferSize;
+ #ifdef XML_CONTEXT_BYTES
+       if (bufferPtr) {
+

--- a/srcpkgs/expat/template
+++ b/srcpkgs/expat/template
@@ -1,7 +1,7 @@
 # Template file for 'expat'
 pkgname=expat
 version=2.1.0
-revision=4
+revision=5
 build_style=gnu-configure
 short_desc="XML parser library written in C"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"


### PR DESCRIPTION
Description [is here](http://www.security-database.com/detail.php?alert=CVE-2015-1283)
We should perhaps scan for packages which include local (i.e. 3rdparty) versions of expat instead of using the system provided libs.