### PR TITLE
Hiawatha 9.14

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1962,7 +1962,9 @@ librrd_th.so.4 rrdtool-1.4.9_1
 libmosquitto.so.1 libmosquitto-1.4_1
 libmosquittopp.so.1 libmosquittopp-1.4_1
 libmpv.so.1 mpv-0.8.0_2
-libmbedtls.so.9 mbedtls-1.3.11_1
+libmbedtls.so.10 mbedtls-2.0.0_1
+libmbedcrypto.so.0 mbedtls-2.0.0_1
+libmbedx509.so.0 mbedtls-2.0.0_1
 libdmtx.so.0 libdmtx-0.7.4_1
 libdbus-c++-1.so.0 libdbus-c++-0.9.0_1
 libdbus-c++-glib-1.so.0 libdbus-c++-0.9.0_1

--- a/srcpkgs/hiawatha/template
+++ b/srcpkgs/hiawatha/template
@@ -1,7 +1,7 @@
 # Template file for 'hiawatha'
 pkgname=hiawatha
-version=9.13
-revision=2
+version=9.14
+revision=1
 build_style=cmake
 hostmakedepends="cmake"
 makedepends="libxslt-devel mbedtls-devel"
@@ -10,11 +10,10 @@ maintainer="Enno Boland <eb@s01.de>"
 license="GPL-2"
 homepage="https://hiawatha-webserver.org"
 distfiles="$homepage/files/$pkgname-$version.tar.gz"
-checksum=6ae204199849340f8ec5a1becbc3f3d80f8d5280f1feff8a12a25f8bc40dc225
+checksum=79c92587cd86a0461d952c99036f5615dacdcaccabe0a9a29359e6044d809bfa
 configure_args="
  -DLOG_DIR=/var/log/hiawatha
  -DPID_DIR=/run
- -DENABLE_SSL=ON
  -DWEBROOT_DIR=/var/www
  -DWORK_DIR=/var/lib/hiawatha
  -DUSE_SYSTEM_MBEDTLS=ON
@@ -25,8 +24,8 @@ conf_files="
  /etc/hiawatha/error.xslt
  /etc/hiawatha/index.xslt
  /etc/hiawatha/hiawatha.conf"
+LDFLAGS="-lmbedtls -lmbedx509 -lmbedcrypto"
 
 post_install() {
-	mv ${DESTDIR}/usr/sbin/* ${DESTDIR}/usr/bin
 	vsv hiawatha
 }

--- a/srcpkgs/mbedtls/template
+++ b/srcpkgs/mbedtls/template
@@ -1,28 +1,18 @@
 # Template file for 'mbedtls'
 pkgname=mbedtls
-version=1.3.11
+version=2.0.0
 revision=1
 replaces="polarssl>=0 libpolarssl>=0"
 short_desc="Portable cryptographic TLS library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+hostmakedepends="perl cmake"
 license="GPL-2"
 homepage="https://tls.mbed.org/"
 distfiles="https://tls.mbed.org/download/mbedtls-${version}-gpl.tgz"
-checksum=67a593027b6a442a4fa5b6c224c4ac8cdae5be721f5a28a11d34f10dcda441cb
-
-do_build() {
-	sed -i -e 's|//\(#define POLARSSL_THREADING_C\)|\1|' \
-		-e 's|//\(#define POLARSSL_THREADING_PTHREAD\)|\1|' \
-		include/polarssl/config.h
-	make CC=$CC SHARED=1 ${makejobs} no_test
-}
-do_install() {
-	make DESTDIR=${DESTDIR}/usr install
-	rm ${DESTDIR}/usr/lib/libmbedtls.so
-	rm ${DESTDIR}/usr/lib/libpolarssl.so
-	ln -s libmbedtls.so.8 ${DESTDIR}/usr/lib/libmedtls.so
-	ln -s libmbedtls.so.8 ${DESTDIR}/usr/lib/libpolarssl.so
-}
+checksum=149a06621368540b7e1cef1b203c268439c2edbf29e2e9471d8021125df34952
+build_style=cmake
+configure_args=' -DENABLE_TESTING=Off -DUSE_SHARED_MBEDTLS_LIBRARY=On
+ -DLINK_WITH_PTHREAD=On'
 
 mbedtls-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
* Updates hiawatha to 9.14 and mbedtls to 2.0.0.
* Uses cmake for mbedtls instead of make