### PR TITLE
kdepimlibs: Fix build with newer gpgme-devel

### DIFF
--- a/srcpkgs/kdepimlibs/patches/gpgme_largefile.patch
+++ b/srcpkgs/kdepimlibs/patches/gpgme_largefile.patch
@@ -1,0 +1,31 @@
+Newer versions of gpgme.h require _FILE_OFFSET_BITS defined
+to the same value which gpgme-devel was compiled with.
+I assume here we all use _FILE_OFFSET_BITS=64.
+The gpgmefw.h patch is required because exception.cpp for some
+reason does not include config-gpgme++.h, but <gpgme.h>
+
+--- gpgme++/config-gpgme++.h.cmake	2014-11-04 22:19:27.000000000 +0100
++++ gpgme++/config-gpgme++.h.cmake	2015-07-28 15:34:47.449866029 +0200
+@@ -134,4 +134,9 @@
+ #define     GPG_ERR_SOURCE_DEFAULT ((gpg_err_source_t)22)
+ #endif
+ 
++#ifndef _FILE_OFFSET_BITS
++/* required to build against recent gpgme.h */
++#define _FILE_OFFSET_BITS 64
++#endif
++
+ #endif /* __GPGMEPP_CONFIG_GPGMEPP_H__ */
+--- gpgme++/gpgmefw.h	2014-11-04 22:19:27.000000000 +0100
++++ gpgme++/gpgmefw.h	2015-07-28 15:39:40.636865160 +0200
+@@ -23,6 +23,10 @@
+ #ifndef __GPGMEPP_GPGMEFW_H__
+ #define __GPGMEPP_GPGMEFW_H__
+ 
++#ifndef _FILE_OFFSET_BITS
++#define _FILE_OFFSET_BITS 64
++#endif
++
+ struct gpgme_context;
+ typedef gpgme_context * gpgme_ctx_t;
+ 

--- a/srcpkgs/kdepimlibs/template
+++ b/srcpkgs/kdepimlibs/template
@@ -1,10 +1,10 @@
 # Template file for 'kdepimlibs'
 pkgname=kdepimlibs
 version=4.14.3
-revision=1
+revision=2
 short_desc="KDE PIM Libraries"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL, LGPL, FDL"
+license="GPL-2, LGPL-2.1, FDL"
 homepage="https://projects.kde.org/projects/kde/kdepimlibs"
 distfiles="http://download.kde.org/stable/${version}/src/${pkgname}-${version}.tar.xz"
 checksum=65edb1bec191be1b6f8450dc71eadae734f4ab0585aab0a885207390399868d7


### PR DESCRIPTION
The newer gpgme.h requires _FILE_OFFSET_BITS=64 to be defined,
because gpgme-devel was built with this configuration.