### PR TITLE
lxqt-qtplugin: fix checksum

### DIFF
--- a/srcpkgs/lxqt-qtplugin/template
+++ b/srcpkgs/lxqt-qtplugin/template
@@ -1,7 +1,7 @@
 # Template file for 'lxqt-qtplugin'
 pkgname=lxqt-qtplugin
 version=0.9.0
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="cmake pkg-config"
 makedepends="liblxqt-devel libqtxdg-devel"
@@ -10,7 +10,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-3"
 homepage="http://lxqt.org/"
 distfiles="http://downloads.lxqt.org/lxqt/${version}/${pkgname}-${version}.tar.xz"
-checksum=0d996abc2081b9c77f5dc9c1d24b14ee44c47b9b906ee3f71fb2d28d04c72bb7
+checksum=7bc715d55ccf7b4356dc89b23f441b79b2a79a523efdb67bc4a81acaa86243c5
 
 pre_configure() {
 	sed -i 's,lxqt-qt5,lxqt,' CMakeLists.txt


### PR DESCRIPTION
The gpg signature looks good, and gentoo uses the same hash:
https://github.com/gentoo/gentoo-portage-rsync-mirror/blob/master/lxqt-base/lxqt-qtplugin/Manifest

I can't find any information about the 0d996abc2081b9c77f5dc9c1d24b14ee44c47b9b906ee3f71fb2d28d04c72bb7 hash.