### PR TITLE
libstatgrab: unbreak musl

### DIFF
--- a/srcpkgs/libstatgrab/patches/configure-musl.patch
+++ b/srcpkgs/libstatgrab/patches/configure-musl.patch
@@ -1,0 +1,13 @@
+fix build failure with musl libc
+
+--- configure.ac	2015-07-28 23:01:23.742669306 -0300
++++ configure.ac	2015-07-28 23:01:42.039440565 -0300
+@@ -609,7 +609,7 @@
+ 	[openbsd*], [
+ 		AC_DEFINE(OPENBSD, , [Building on OpenBSD])
+ 	],
+-	[linux-gnu*], [
++	[linux-gnu*|linux-musl*], [
+ 		AC_DEFINE(LINUX, , [Building on GNU/Linux])
+ 		AM_CONDITIONAL(SETUIDBINS, true)
+ 		BIN_OWNER="root"

--- a/srcpkgs/libstatgrab/patches/os_info-musl.patch
+++ b/srcpkgs/libstatgrab/patches/os_info-musl.patch
@@ -1,0 +1,13 @@
+musl doesn't support _SC_LONG_BIT, just use the value from limits.h
+
+--- src/libstatgrab/os_info.c	2015-07-28 23:27:05.860119689 -0300
++++ src/libstatgrab/os_info.c	2015-07-28 23:27:22.931906262 -0300
+@@ -472,7 +472,7 @@
+ 		host_info_buf->bitwidth = 64;
+ 	}
+ 	else {
+-		host_info_buf->bitwidth = sysconf(_SC_LONG_BIT); // well, maybe 64-bit disabled 128-bit system o.O
++		host_info_buf->bitwidth = LONG_BIT;
+ 	}
+ 	host_info_buf->host_state = sg_unknown_configuration;
+ # endif

--- a/srcpkgs/libstatgrab/template
+++ b/srcpkgs/libstatgrab/template
@@ -1,9 +1,10 @@
 # Template file for 'libstatgrab'
 pkgname=libstatgrab
 version=0.91
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
+hostmakedepends="autoconf"
 makedepends="ncurses-devel"
 short_desc="Library being useful interface to system statistics"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -11,6 +12,10 @@ homepage="http://www.i-scream.org/libstatgrab"
 license="LGPL-2.1, GPL-2"
 distfiles="http://www.mirrorservice.org/sites/ftp.i-scream.org/pub/i-scream/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=03e9328e4857c2c9dcc1b0347724ae4cd741a72ee11acc991784e8ef45b7f1ab
+
+pre_configure() {
+	autoconf
+}
 
 libstatgrab-devel_package() {
 	depends="${sourcepkg}-${version}_${revision}"


### PR DESCRIPTION
configure needs to know about `linux-musl`, and musl doesn't implement `_SC_LONG_BIT`