### PR TITLE
lxqt-panel: unbreak musl

### DIFF
--- a/srcpkgs/lxqt-panel/patches/int64-musl.patch
+++ b/srcpkgs/lxqt-panel/patches/int64-musl.patch
@@ -1,0 +1,12 @@
+include stdint.h for int64 on musl (should be cstdint but gives an error related to C++11)
+
+--- plugin-sysstat/lxqtsysstat.cpp	2015-02-08 11:31:27.000000000 -0200
++++ plugin-sysstat/lxqtsysstat.cpp	2015-07-28 23:51:15.864992133 -0300
+@@ -37,6 +37,7 @@
+ #include <QPainter>
+ #include <QResizeEvent>
+ #include <QVBoxLayout>
++#include <stdint.h>
+ 
+ LxQtSysStat::LxQtSysStat(const ILxQtPanelPluginStartupInfo &startupInfo):
+     QObject(),

--- a/srcpkgs/lxqt-panel/template
+++ b/srcpkgs/lxqt-panel/template
@@ -1,7 +1,7 @@
 # Template file for 'lxqt-panel'
 pkgname=lxqt-panel
 version=0.9.0
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DUSE_QT5=1 -DLIB_SUFFIX="
 hostmakedepends="cmake pkg-config"


### PR DESCRIPTION
Together with https://github.com/voidlinux/void-packages/pull/2120 and https://github.com/voidlinux/void-packages/pull/2119 lxqt builds now with musl.