### PR TITLE
boost: fix incorrect include path

### DIFF
--- a/srcpkgs/boost/patches/fix_poll_h.patch
+++ b/srcpkgs/boost/patches/fix_poll_h.patch
@@ -1,0 +1,15 @@
+The include path <sys/poll.h> is incorrect and packages
+including socket_types.hpp fail to build with musl libc,
+if the -Werror option is active, i.e. treat warnings as errors.
+
+--- boost/asio/detail/socket_types.hpp	2015-03-23 21:24:12.000000000 +0100
++++ boost/asio/detail/socket_types.hpp	2015-07-30 13:10:47.719440415 +0200
+@@ -54,7 +54,7 @@
+ #else
+ # include <sys/ioctl.h>
+ # if !defined(__SYMBIAN32__)
+-#  include <sys/poll.h>
++#  include <poll.h>
+ # endif
+ # include <sys/types.h>
+ # include <sys/stat.h>

--- a/srcpkgs/boost/template
+++ b/srcpkgs/boost/template
@@ -1,7 +1,7 @@
 # Template file for 'boost'
 pkgname=boost
 version=1.58.0
-revision=2
+revision=3
 wrksrc="${pkgname}_${version//\./_}"
 hostmakedepends="bzip2-devel"
 makedepends="zlib-devel bzip2-devel icu-devel"


### PR DESCRIPTION
One example is the `openimageio` package which fails even after patching `#include <sys/poll.h>` to `#include <poll.h>` in the source, because it also includes boost's `socket_types.hpp`.

In glibc headers `/usr/include/poll.h` includes `/usr/include/sys/poll.h` so this patch shouldn't affect anyone, but silence or even unbreak some packages for musl libc.