### PR TITLE
ilmbase: Workaround for cross compiling

### DIFF
--- a/srcpkgs/ilmbase/files/eLut.sh
+++ b/srcpkgs/ilmbase/files/eLut.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+eLut() {
+	local i=$1
+	e=$(((i & 0xff) - (127 - 15)))
+	j=$((i>>8))
+	if [ $e -le 0 -o $e -ge 30 ]; then
+		# Special case
+		echo "0"
+	elif [ $j -eq 0 ]; then
+		# Common case - normalized half, no exponent overflow possible
+		echo $((e << 10))
+	else
+		echo $(((e << 10) | 0x8000))
+	fi
+}
+
+echo "//"
+echo "// This is an automatically generated file."
+echo "// Do not edit."
+echo "//"
+echo ""
+echo "{"
+echo -n "   "
+
+i=0
+j=0
+while [ $i -lt 512 ]; do
+	out="$(eLut $i)"
+	printf "%7s," $out
+	j=$((j + 1))
+	if [ $j -eq 8 ]; then
+		j=0
+		printf "\n"
+		[ $i -lt 511 ] && printf "   "
+	fi
+	i=$((i + 1))
+done
+echo "};"

--- a/srcpkgs/ilmbase/files/toFloat.sh
+++ b/srcpkgs/ilmbase/files/toFloat.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+halfToFloat() {
+	local s=$1 e=$2 m=$3
+	if [ $e -eq 0 ]; then
+		if [ $m -eq 0 ]; then
+			# Plus or minus zero
+			echo $((s << 31))
+			return
+		else
+			# Denormalized number -- renormalize it
+			while [ $((m & 0x400)) -eq 0 ]; do
+				m=$((m << 1))
+				e=$((e - 1))
+			done
+			e=$((e + 1))
+			m=$((m & 0x3ff))
+		fi
+	elif [ $e -eq 31 ]; then
+		if [ "$m" -eq 0 ]; then
+			# Positive or negative infinity
+			echo $(((s << 31) | 0x7f800000)) 
+			return
+		else
+			# Nan - preserve sign and significand bits
+			echo $(((s << 31) | 0x7f800000 | (m << 13)))
+			return
+		fi
+	fi
+	# Normalized number
+	e=$((e + (127 - 15)))
+	m=$((m << 13))
+	# Assemble s, e and m
+	echo $(((s << 31) | (e << 23) | m))
+}
+
+
+echo "//"
+echo "// This is an automatically generated file."
+echo "// Do not edit."
+echo "//"
+echo ""
+echo "{"
+echo -n "    "
+
+s=0
+m=0
+e=0
+j=0
+k=0
+while [ $s -lt 2 ]; do
+	while [ $e -lt 32 ]; do
+		while [ $m -lt 1024 ]; do
+			out="$(halfToFloat $s $e $m)"
+			printf "{0x%08x}, " $out
+			m=$((m + 1))
+			j=$((j + 1))
+			if [ $j -eq 4 ]; then
+				printf "\n"
+				k=$((k + 1))
+				[ $k -lt 16384 ] && printf "    "
+				j=0
+			fi
+		done
+		m=0
+		e=$((e + 1))
+	done
+	e=0
+	s=$((s + 1))
+done
+echo "};"

--- a/srcpkgs/ilmbase/template
+++ b/srcpkgs/ilmbase/template
@@ -1,18 +1,28 @@
 # Template file for 'ilmbase'
 pkgname=ilmbase
 version=2.2.0
-revision=2
+revision=3
 build_style=gnu-configure
 short_desc="Base libraries from ILM for OpenEXR"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="BSD"
 homepage="http://www.openexr.com"
-distfiles="http://download.savannah.nongnu.org/releases/openexr/$pkgname-$version.tar.gz"
+distfiles="${NONGNU_SITE}/openexr/$pkgname-$version.tar.gz"
 checksum=ecf815b60695555c1fbc73679e84c7c9902f4e8faa6e8000d2f905b8b86cedc7
-nocross=yes
 
-LDFLAGS="-lpthread"
+LDFLAGS="-L${XBPS_CROSS_BASE}/usr/lib -lpthread"
 
+pre_build() {
+	if [ -n "$CROSS_BUILD" ]; then
+		# Copy shell script header generators - slow but working
+		cp ${FILESDIR}/*.sh ${wrksrc}/Half
+		sed -i Half/Makefile \
+			-e "/eLut.h: eLut/s;$;.sh;" \
+			-e "s;\./eLut > eLut.h;sh eLut.sh > eLut.h;" \
+			-e "/toFloat.h: toFloat/s;$;.sh;" \
+			-e "s;\./toFloat > toFloat.h;sh toFloat.sh > toFloat.h;"
+	fi
+}
 post_install() {
 	vlicense COPYING
 }


### PR DESCRIPTION
The shell scripts produce the exact same output as their cpp couterparts.
Yes, `toFloat.sh` is pretty slow, because it generates 64K values.