### PR TITLE
bash: source system bashrc on login

### DIFF
--- a/srcpkgs/bash/files/bash.sh
+++ b/srcpkgs/bash/files/bash.sh
@@ -1,0 +1,7 @@
+# Check for interactive bash
+[ -z "$BASH_VERSION" -o -z "$PS1" ] && return
+
+# Bash login shells only run /etc/profile
+# Bash non-login shells run only /etc/bash/bashrc
+# We want to source /etc/bash/bashrc in any case
+[ -f /etc/bash/bashrc ] && . /etc/bash/bashrc

--- a/srcpkgs/bash/template
+++ b/srcpkgs/bash/template
@@ -3,7 +3,7 @@ pkgname=bash
 _bash_distver=4.3
 _bash_patchlevel=039
 version=${_bash_distver}.${_bash_patchlevel}
-revision=5
+revision=6
 wrksrc=${pkgname}-${_bash_distver}
 build_pie=yes
 build_style=gnu-configure
@@ -45,4 +45,5 @@ post_install() {
 	ln -s bash ${DESTDIR}/usr/bin/rbash
 	vmkdir /etc/bash
 	vinstall ${FILESDIR}/bashrc 644 etc/bash
+	vinstall ${FILESDIR}/bash.sh 644 etc/profile.d
 }


### PR DESCRIPTION
This adds /etc/profile.d/bash.sh
```
# Bash login shells only run /etc/profile
# Bash non-login shells run only /etc/bash/bashrc
# We want to source /etc/bash/bashrc in any case
```