### PR TITLE
gstreamer: fix grammar.y for bison >= 3.0.4

### DIFF
--- a/srcpkgs/gstreamer/patches/fix_bison_grammar_y.patch
+++ b/srcpkgs/gstreamer/patches/fix_bison_grammar_y.patch
@@ -1,0 +1,11 @@
+--- gst/parse/grammar.y	2011-12-30 02:14:35.000000000 +0100
++++ gst/parse/grammar.y	2015-08-04 17:40:31.981404808 +0200
+@@ -36,7 +36,7 @@
+ 
+ typedef void* yyscan_t;
+ 
+-int priv_gst_parse_yylex (void * yylval_param , yyscan_t yyscanner);
++int priv_gst_parse_yylex (void * yylval_param);
+ int priv_gst_parse_yylex_init (yyscan_t scanner);
+ int priv_gst_parse_yylex_destroy (yyscan_t scanner);
+ struct yy_buffer_state * priv_gst_parse_yy_scan_string (char* , yyscan_t);

--- a/srcpkgs/gstreamer/template
+++ b/srcpkgs/gstreamer/template
@@ -1,7 +1,7 @@
 # Template file for 'gstreamer'.
 pkgname=gstreamer
 version=0.10.36
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="--disable-valgrind --enable-docbook"
 hostmakedepends="libtool pkg-config flex python perl docbook-xsl glib-devel"


### PR DESCRIPTION
This patch fixes the compile error. I have no confirmation, if it
is the "Right Thing (tm)" to do, until upstream publishes their
own fix for this issue.

Fixes #2162