### PR TITLE
deluge: add xdg-utils as a dependency

### DIFF
--- a/srcpkgs/deluge/template
+++ b/srcpkgs/deluge/template
@@ -1,13 +1,13 @@
 # Template file for 'deluge'
 pkgname=deluge
 version=1.3.11
-revision=2
+revision=3
 noarch=yes
 build_style=python-module
 pycompile_module="deluge"
 hostmakedepends="intltool python-setuptools"
 makedepends="python-setuptools"
-depends="pygtk python-setuptools python-chardet python-xdg Twisted libtorrent-rasterbar"
+depends="pygtk python-setuptools python-chardet python-xdg Twisted libtorrent-rasterbar xdg-utils"
 short_desc="BitTorrent client written in Python/PyGTK"
 maintainer="Alexey Rochev <equeim@gmail.com>"
 homepage="http://deluge-torrent.org/"


### PR DESCRIPTION
xdg-utils is needed to make sure that the "open folder" button works in the context menu of a torrent. If there is no xdg-utils installed then it will simply do nothing which is confusing. I think deluge uses (or tries to use) "xdg-open" which is in the xdg-utils package.