### PR TITLE
webkit2gtk: unbreak armv6l

### DIFF
--- a/srcpkgs/webkit2gtk/patches/fix_armv6l.patch
+++ b/srcpkgs/webkit2gtk/patches/fix_armv6l.patch
@@ -1,0 +1,23 @@
+Fix code emitted for armv6l to not use movw/movt but ldr.
+See https://bugs.webkit.org/show_bug.cgi?id=131612
+and https://bugs.webkit.org/show_bug.cgi?id=141288
+
+--- Source/JavaScriptCore/offlineasm/arm.rb	2015-07-22 14:37:57.000000000 +0200
++++ Source/JavaScriptCore/offlineasm/arm.rb	2015-08-08 00:31:21.011824644 +0200
+@@ -473,8 +473,16 @@
+                 $asm.puts "mov #{armFlippedOperands(operands)}"
+             end
+         when "mvlbl"
++            if isARMv7 or isARMv7Traditional
+                 $asm.puts "movw #{operands[1].armOperand}, \#:lower16:#{operands[0].value}"
+                 $asm.puts "movt #{operands[1].armOperand}, \#:upper16:#{operands[0].value}"
++            else
++                $mvlbl_counter ||= 0
++                $mvlbl_counter += 1
++                const_label = "_mvlbl_const_label#{$mvlbl_counter}"
++                $asm.puts ".equ #{const_label}, (#{operands[0].value})"
++                $asm.puts "ldr  #{operands[1].armOperand}, =#{const_label}"
++            end
+         when "nop"
+             $asm.puts "nop"
+         when "bieq", "bpeq", "bbeq"

--- a/srcpkgs/webkit2gtk/template
+++ b/srcpkgs/webkit2gtk/template
@@ -1,7 +1,7 @@
 # Template file for 'webkit2gtk'
 pkgname=webkit2gtk
 version=2.8.5
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DPORT=GTK -DENABLE_GTKDOC=OFF -DCMAKE_LINKER=${XBPS_CROSS_TRIPLET}-gcc"
 short_desc="GTK+3 port of the WebKit2 browser engine"


### PR DESCRIPTION
This is a yet untested try to fix the armv6l build - [see build log](http://build.voidlinux.eu/builders/armv6l_builder/builds/16220/steps/shell_3/logs/stdio).
The outcome should be tested by someone who owns an armv6l machine.

The assembler output generated by Source/JavaScriptCore/offlineasm/arm.rb
for the `mvlbl` pseudo opcode for armv6l is similar to that in the
`armMoveImmediate` function in the final else branch.
The difference is that it uses `.equ label, (x - y)` to define the
actual value, the difference between two labels, for `ldr reg, =label`.

See https://bugs.webkit.org/show_bug.cgi?id=131612 for a discussion
and https://bugs.webkit.org/show_bug.cgi?id=141288 if this works out.

FWIW: The generated output can be seen in the file `/builddir/webkitgtk-2.8.5/build/DerivedSources/JavaScriptCore/LLIntAssembly.h` after the progress reaches ~5%. Search for `_mvlbl_const`.