### PR TITLE
espeak: move data files into the library package (libespeak).

### DIFF
--- a/srcpkgs/espeak/template
+++ b/srcpkgs/espeak/template
@@ -1,7 +1,7 @@
 # Template file for 'espeak'
 pkgname="espeak"
 version="1.48.04"
-revision=2
+revision=3
 short_desc="Text to Speech engine"
 maintainer="Martin Riese <grauehaare@gmx.de>"
 license="GPL-3"
@@ -22,9 +22,10 @@ do_build() {
 }
 
 libespeak_package() {
-	shorst_desc+=" - runtime libraries"
+	short_desc+=" - runtime libraries"
 	pkg_install() {
 		vmove "usr/lib/*.so.*"
+		vmove usr/share/espeak-data
 	}
 }
 


### PR DESCRIPTION
The library is unusable without its data files.
Also fix typo.