### PR TITLE
sslh: add pcre support (fixes musl)

### DIFF
--- a/srcpkgs/sslh/files/sslh/run
+++ b/srcpkgs/sslh/files/sslh/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec sslh -f -u nobody -F /etc/sslh.cfg
+exec sslh -f -u nobody -F/etc/sslh.cfg

--- a/srcpkgs/sslh/patches/enable-pcre.patch
+++ b/srcpkgs/sslh/patches/enable-pcre.patch
@@ -1,0 +1,104 @@
+diff --git Makefile Makefile
+index ef77957..4d3857d 100644
+--- Makefile
++++ Makefile
+@@ -1,6 +1,8 @@
+ # Configuration
+ 
+ VERSION=$(shell ./genver.sh -r)
++ENABLE_REGEX=1
++USELIBPCRE=1
+ USELIBCONFIG=1	# Use libconfig? (necessary to use configuration files)
+ USELIBWRAP?=	# Use libwrap?
+ USELIBCAP=	# Use libcap?
+@@ -22,6 +24,15 @@ CFLAGS ?=-Wall -g $(CFLAGS_COV)
+ LIBS=
+ OBJS=common.o sslh-main.o probe.o
+ 
++ifneq ($(strip $(ENABLE_REGEX)),)
++	CPPFLAGS+=-DENABLE_REGEX
++endif
++
++ifneq ($(strip $(USELIBPCRE)),)
++	LIBS:=$(LIBS) -lpcre
++	CPPFLAGS+=-DLIBPCRE
++endif
++
+ ifneq ($(strip $(USELIBWRAP)),)
+ 	LIBS:=$(LIBS) -lwrap
+ 	CPPFLAGS+=-DLIBWRAP
+diff --git probe.c probe.c
+index 8cff937..1e8c060 100644
+--- probe.c
++++ probe.c
+@@ -21,7 +21,13 @@
+ 
+ #define _GNU_SOURCE
+ #include <stdio.h>
++#ifdef ENABLE_REGEX
++#ifdef LIBPCRE
++#include <pcreposix.h>
++#else
+ #include <regex.h>
++#endif
++#endif
+ #include <ctype.h>
+ #include "probe.h"
+ 
+@@ -226,6 +232,7 @@ static int is_tls_protocol(const char *p, int len, struct proto *proto)
+ 
+ static int regex_probe(const char *p, int len, struct proto *proto)
+ {
++#ifdef ENABLE_REGEX
+     regex_t **probe = proto->data;
+     regmatch_t pos = { 0, len };
+ 
+@@ -233,6 +240,11 @@ static int regex_probe(const char *p, int len, struct proto *proto)
+         /* try them all */;
+ 
+     return (*probe != NULL);
++#else
++    /* Should never happen as we check when loading config file */
++    fprintf(stderr, "FATAL: regex probe called but not built in\n");
++    exit(5);
++#endif
+ }
+ 
+ /* 
+diff --git sslh-main.c sslh-main.c
+index 9cc8a06..be54698 100644
+--- sslh-main.c
++++ sslh-main.c
+@@ -25,7 +25,13 @@
+ #ifdef LIBCONFIG
+ #include <libconfig.h>
+ #endif
++#ifdef ENABLE_REGEX
++#ifdef LIBPCRE
++#include <pcreposix.h>
++#else
+ #include <regex.h>
++#endif
++#endif
+ 
+ #include "common.h"
+ #include "probe.h"
+@@ -174,6 +180,7 @@ static int config_listen(config_t *config, struct addrinfo **listen)
+ #ifdef LIBCONFIG
+ static void setup_regex_probe(struct proto *p, config_setting_t* probes)
+ {
++#ifdef ENABLE_REGEX
+     int num_probes, errsize, i, res;
+     char *err;
+     const char * expr;
+@@ -201,6 +208,10 @@ static void setup_regex_probe(struct proto *p, config_setting_t* probes)
+             exit(1);
+         }
+     }
++#else
++    fprintf(stderr, "line %d: regex probe specified but not compiled in\n", config_setting_source_line(probes));
++    exit(5);
++#endif
+ }
+ #endif
+ 

--- a/srcpkgs/sslh/template
+++ b/srcpkgs/sslh/template
@@ -1,10 +1,10 @@
 # Template file for 'sslh'
 pkgname=sslh
 version=1.17
-revision=1
+revision=2
 build_pie=yes
 hostmakedepends="perl"
-makedepends="libconfig-devel libcap-devel"
+makedepends="pcre-devel libconfig-devel libcap-devel"
 short_desc="Applicative Protocol Multiplexer"
 maintainer="Markus Berger <pulux@pf4sh.de>"
 license="GPL-2"
@@ -16,7 +16,7 @@ do_build() {
 	sed -i 's|^MAN=sslh.8.gz|MAN=sslh.8|g' Makefile
 	sed -i 's|sbin|bin|g' Makefile
 	sed -i 's|sslh.pod \| gzip -9 - > $(MAN)|sslh.pod > $(MAN)|g' Makefile
-	make CC=$CC USELIBCONFIG=1 USELIBCAP=1
+	make CC=$CC ENABLE_REGEX=1 USELIBPCRE=1 USELIBCONFIG=1 USELIBCAP=1
 }
 do_install() {
 	make DESTDIR=${DESTDIR} PREFIX=/usr install


### PR DESCRIPTION
This adds a patch to sslh - it enables using PCRE as the regex library instead of using POSIX regex.

On musl, sslh doesn't compile w/ regex enabled because sslh makes use of a non-POSIX regex feature.

I have a PR open upstream for this fix - https://github.com/yrutschle/sslh/pull/62