### PR TITLE
cross-arm-linux-musleabihf: fix unresolved extern

### DIFF
--- a/srcpkgs/cross-aarch64-linux-musl/template
+++ b/srcpkgs/cross-aarch64-linux-musl/template
@@ -11,7 +11,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.20
-revision=1
+revision=2
 short_desc="Cross toolchain for ARM64 LE target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"

--- a/srcpkgs/cross-arm-linux-musleabihf/template
+++ b/srcpkgs/cross-arm-linux-musleabihf/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.20
-revision=1
+revision=2
 short_desc="Cross toolchain for ARMv6 LE Hard Float target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"

--- a/srcpkgs/cross-armv7l-linux-musleabihf/template
+++ b/srcpkgs/cross-armv7l-linux-musleabihf/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.20
-revision=1
+revision=2
 short_desc="Cross toolchain for ARMv7 LE Hard Float target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"

--- a/srcpkgs/cross-i686-linux-musl/template
+++ b/srcpkgs/cross-i686-linux-musl/template
@@ -11,7 +11,7 @@ _archflags="-march=i686"
 
 pkgname=cross-${_triplet}
 version=0.20
-revision=1
+revision=2
 short_desc="Cross toolchain for i686 target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"

--- a/srcpkgs/cross-mips-linux-musl/template
+++ b/srcpkgs/cross-mips-linux-musl/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.20
-revision=2
+revision=3
 short_desc="Cross toolchain for MIPS32r2 BE softfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"

--- a/srcpkgs/cross-mipsel-linux-musl/template
+++ b/srcpkgs/cross-mipsel-linux-musl/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.20
-revision=2
+revision=3
 short_desc="Cross toolchain for MIPS32r2 LE softfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"

--- a/srcpkgs/cross-mipsel-linux-muslhf/template
+++ b/srcpkgs/cross-mipsel-linux-muslhf/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.20
-revision=2
+revision=3
 short_desc="Cross toolchain for MIPS32r2 LE hardfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"

--- a/srcpkgs/cross-x86_64-linux-musl/template
+++ b/srcpkgs/cross-x86_64-linux-musl/template
@@ -10,7 +10,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.20
-revision=1
+revision=2
 short_desc="Cross toolchain for x86_64 with musl"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"

--- a/srcpkgs/gcc/files/gcc-4.9.2-musl.diff
+++ b/srcpkgs/gcc/files/gcc-4.9.2-musl.diff
@@ -702,3 +702,29 @@ diff -r 94ebb0799454 gcc/config/sh/linux.h
  
  #undef SUBTARGET_LINK_EMUL_SUFFIX
  #define SUBTARGET_LINK_EMUL_SUFFIX "_linux"
+
+Use libc write(2) instead of undefined __write() to get rid
+of an error when later linking against libgcc.a
+This should fix the webkitgtk build, see:
+http://build.voidlinux.eu/builders/armv6l-musl_builder/builds/2991/steps/shell_3/logs/stdio
+
+--- a/libgcc/config/arm/linux-atomic-64bit.c	2014-01-02 23:25:22.000000000 +0100
++++ b/libgcc/config/arm/linux-atomic-64bit.c	2015-08-14 10:56:03.383219614 +0200
+@@ -33,7 +33,7 @@
+    kernels; we check for that in an init section and bail out rather
+    unceremoneously.  */
+ 
+-extern unsigned int __write (int fd, const void *buf, unsigned int count);
++extern unsigned int write (int fd, const void *buf, unsigned int count);
+ extern void abort (void);
+ 
+ /* Kernel helper for compare-and-exchange.  */
+@@ -56,7 +56,7 @@
+ 	 for the user - I'm not sure I can rely on much else being
+ 	 available at this point, so do the same as generic-morestack.c
+ 	 write () and abort ().  */
+-      __write (2 /* stderr.  */, err, sizeof (err));
++      write (2 /* stderr.  */, err, sizeof (err));
+       abort ();
+     }
+ };


### PR DESCRIPTION
When linking against libgcc.a, there is an unresolved (in musl libc) external
__write() referenced from libgcc/config/arm/linux-atomic-64bit.c,
so make the patch replace it with libc write(2).

See: http://build.voidlinux.eu/builders/armv6l-musl_builder/builds/2991/steps/shell_3/logs/stdio