### PR TITLE
poppler{,-qt4,-qt5}: update to 0.35.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -354,7 +354,7 @@ libMagickCore-6.Q16.so.2 libmagick-6.8.8.4_1
 libMagickWand-6.Q16.so.2 libmagick-6.8.8.4_1
 libMagick++-6.Q16.so.6 libmagick-6.9.0.5_1
 libltdl.so.7 libltdl-2.2.6_1
-libpoppler.so.53 poppler-0.34.0_1
+libpoppler.so.54 poppler-0.35.0_1
 libpoppler-glib.so.8 poppler-glib-0.18.2_1
 libpoppler-cpp.so.0 poppler-cpp-0.18.2_1
 libpoppler-qt4.so.4 poppler-qt4-0.22.3_1

--- a/srcpkgs/cups-filters/template
+++ b/srcpkgs/cups-filters/template
@@ -1,7 +1,7 @@
 # Template file for 'cups-filters'
 pkgname=cups-filters
 version=1.0.71
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-static --with-rcdir=no --enable-avahi
  --with-browseremoteprotocols=DNSSD,CUPS"

--- a/srcpkgs/evas_generic_loaders/template
+++ b/srcpkgs/evas_generic_loaders/template
@@ -1,7 +1,7 @@
 # Template file for 'evas_generic_loaders'
 pkgname=evas_generic_loaders
 version=1.15.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="$(vopt_enable gstreamer) $(vopt_enable pdf poppler)
  $(vopt_enable ps spectre) $(vopt_enable svg) $(vopt_enable raw libraw)"

--- a/srcpkgs/inkscape/template
+++ b/srcpkgs/inkscape/template
@@ -1,7 +1,7 @@
 # Template file for 'inkscape'
 pkgname=inkscape
 version=0.91
-revision=6
+revision=7
 build_style=gnu-configure
 configure_args="--enable-lcms --enable-poppler-cairo
  --without-gnome-vfs --disable-static"

--- a/srcpkgs/ipe/template
+++ b/srcpkgs/ipe/template
@@ -1,7 +1,7 @@
 # Template file for 'ipe'
 pkgname=ipe
 version=7.1.8
-revision=1
+revision=2
 _tools_commit=3c1bfb642f53c114262ed732a5f16f0a8ad1649b
 hostmakedepends="pkg-config"
 makedepends="qt-devel lua-devel libjpeg-turbo-devel cairo-devel poppler-devel"

--- a/srcpkgs/poppler-qt4/template
+++ b/srcpkgs/poppler-qt4/template
@@ -4,7 +4,7 @@
 # A CYCLIC DEPENDENCY: qt -> cups -> poppler -> qt.
 #
 pkgname=poppler-qt4
-version=0.34.0
+version=0.35.0
 revision=1
 wrksrc="poppler-${version}"
 build_style=gnu-configure
@@ -21,7 +21,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://poppler.freedesktop.org"
 distfiles="${homepage}/poppler-$version.tar.xz"
-checksum=1ba4ba9a2f9eb1e62ee6d736f4d82be4fc5f6dd177dc2b03febbe2ef2e515cb0
+checksum=e86755b1a4df6efe39d84f581c11bcb0e34976166a671a7b700c28ebaa3e2189
 
 post_install() {
 	rm -f ${DESTDIR}/usr/lib/libpoppler.*

--- a/srcpkgs/poppler-qt5/template
+++ b/srcpkgs/poppler-qt5/template
@@ -4,7 +4,7 @@
 # A CYCLIC DEPENDENCY: qt5 -> cups -> poppler -> qt5.
 #
 pkgname=poppler-qt5
-version=0.34.0
+version=0.35.0
 revision=1
 wrksrc="poppler-${version}"
 build_style=gnu-configure
@@ -21,7 +21,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://poppler.freedesktop.org"
 distfiles="${homepage}/poppler-$version.tar.xz"
-checksum=1ba4ba9a2f9eb1e62ee6d736f4d82be4fc5f6dd177dc2b03febbe2ef2e515cb0
+checksum=e86755b1a4df6efe39d84f581c11bcb0e34976166a671a7b700c28ebaa3e2189
 
 post_install() {
 	rm -f ${DESTDIR}/usr/lib/libpoppler.*

--- a/srcpkgs/poppler/template
+++ b/srcpkgs/poppler/template
@@ -3,7 +3,7 @@
 # THIS PKG MUST BE SYNCHRONIZED WITH "srcpkgs/poppler-qt{4,5}".
 #
 pkgname=poppler
-version=0.34.0
+version=0.35.0
 revision=1
 build_style=gnu-configure
 configure_args="--enable-zlib --enable-libcurl --enable-libjpeg
@@ -19,7 +19,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://poppler.freedesktop.org"
 distfiles="${homepage}/$pkgname-$version.tar.xz"
-checksum=1ba4ba9a2f9eb1e62ee6d736f4d82be4fc5f6dd177dc2b03febbe2ef2e515cb0
+checksum=e86755b1a4df6efe39d84f581c11bcb0e34976166a671a7b700c28ebaa3e2189
 
 # Package build options
 build_options="gir"


### PR DESCRIPTION
+ revbump packages depending on libpoppler.so.53 -> 54