### PR TITLE
ccache: update to 3.2.3

### DIFF
--- a/srcpkgs/ccache/template
+++ b/srcpkgs/ccache/template
@@ -1,7 +1,7 @@
 # Template file for 'ccache'
 pkgname=ccache
-version=3.2.2
-revision=3
+version=3.2.3
+revision=1
 bootstrap=yes
 build_style=gnu-configure
 makedepends="zlib-devel"
@@ -10,7 +10,13 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://ccache.samba.org"
 license="GPL-2"
 distfiles="http://samba.org/ftp/${pkgname}/${pkgname}-${version}.tar.bz2"
-checksum=440f5e15141cc72d2bfff467c977020979810eb800882e3437ad1a7153cce7b2
+checksum=b07165d4949d107d17f2f84b90b52953617bf1abbf249d5cc20636f43337c98c
+
+post_configure() {
+	# Fix wrong dependency on a lib
+	sed -i Makefile \
+		-e "s;\(ccache\$(EXEEXT): \$(ccache_objs)\).*;\1;"
+}
 
 post_install() {
 	vmkdir usr/lib/ccache/bin


### PR DESCRIPTION
Fix for cross compiling according to this mail:
```
Joel Rosdahl <joel@rosdahl.net> writes:
> I'm happy to announce ccache version 3.2.3.

Hate to be the bearer of bad news, but this fails to build for me on
late-model OS X:

$ ./configure
$ make 
gcc -DHAVE_CONFIG_H  -DSYSCONFDIR=/usr/local/etc -I. -I.  -g -O2 -Wall -W -c -o main.o main.c
...
gcc -DHAVE_CONFIG_H  -DSYSCONFDIR=/usr/local/etc -I. -I.  -g -O2 -Wall -W -c -o conf.o conf.c
make: *** No rule to make target `-lz', needed by `ccache'.  Stop.

The reason appears to be that the Makefile gets generated like so:

$ grep extra_libs Makefile
extra_libs = -lz
ccache$(EXEEXT): $(ccache_objs) $(extra_libs)
        $(CC) $(all_cflags) -o $@ $(ccache_objs) $(all_ldflags) $(extra_libs) $(LIBS)
test/main$(EXEEXT): $(base_objs) $(test_objs) $(extra_libs)
        $(CC) $(all_cflags) -o $@ $(base_objs) $(test_objs) $(all_ldflags) $(extra_libs) $(LIBS)

and of course "-lz" isn't a valid dependency.  Manually removing
$(extra_libs) from these two dependency lists fixes it.

I do not recall having had this problem the last time I built ccache,
but that was 3.2.1, so I don't know whether it was introduced in
3.2.2 or 3.2.3.

                        regards, tom lane

_______________________________________________
ccache mailing list
ccache@lists.samba.org
https://lists.samba.org/mailman/listinfo/ccache
```