### PR TITLE
New package: gnome-games-1.0 (meta package)

### DIFF
--- a/srcpkgs/gnome-games/template
+++ b/srcpkgs/gnome-games/template
@@ -1,0 +1,27 @@
+# Template file for 'gnome-games'
+pkgname=gnome-games
+version=1.0
+revision=1
+build_style=meta
+depends="
+	gnome-chess
+	gnome-klotski
+	gnome-mahjongg
+	gnome-mines
+	gnome-nibbles
+	gnome-robots
+	gnome-sudoku
+	gnome-tetravex
+	atomix
+	five-or-more
+	four-in-a-row
+	hitori
+	iagno
+	lightsoff
+	quadrapassel
+	swell-foop
+	tali"
+short_desc="Collection of GNOME games"
+maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
+license="GPL-2, GPL-3"
+homepage="http://wiki.gnome.org/Apps"


### PR DESCRIPTION
This doesn't include aisleriot, because it can't be cross built due to guile(c).