### PR TITLE
ca-certificates: remove expired certificates

### DIFF
--- a/srcpkgs/ca-certificates/files/remove-expired-certs.sh
+++ b/srcpkgs/ca-certificates/files/remove-expired-certs.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Begin remove-expired-certs.sh
+#
+# Version 20120211
+
+# Make sure the date is parsed correctly on all systems
+mydate()
+{
+  local y=$( echo $1 | cut -d" " -f4 )
+  local M=$( echo $1 | cut -d" " -f1 )
+  local d=$( echo $1 | cut -d" " -f2 )
+  local m
+
+  [ -z "${d}" ] && d="0"
+  [ "${d}" -lt 10 ] && d="0${d}"
+
+  case $M in
+    Jan) m="01";;
+    Feb) m="02";;
+    Mar) m="03";;
+    Apr) m="04";;
+    May) m="05";;
+    Jun) m="06";;
+    Jul) m="07";;
+    Aug) m="08";;
+    Sep) m="09";;
+    Oct) m="10";;
+    Nov) m="11";;
+    Dec) m="12";;
+  esac
+
+  certdate="${y}${m}${d}"
+}
+
+DIR="$1"
+[ -z "$DIR" ] && DIR=$(pwd)
+
+today=$(date +%Y%m%d)
+
+find ${DIR} -type f -a -iname "*.crt" -printf "%p\n" | while read cert; do
+  notafter=$(/usr/bin/openssl x509 -enddate -in "${cert}" -noout)
+  date=$( echo ${notafter} |  sed 's/^notAfter=//' )
+  mydate "$date"
+
+  if [ ${certdate} -lt ${today} ]; then
+     echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+     echo "EXPIRED CERTIFICATE FOUND $certdate: \"$(basename ${cert})\""
+     echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+     rm -f "${cert}"
+  fi
+done

--- a/srcpkgs/ca-certificates/template
+++ b/srcpkgs/ca-certificates/template
@@ -1,9 +1,9 @@
 # Template file for 'ca-certificates'
 pkgname=ca-certificates
 version=20150426
-revision=2
+revision=3
 noarch="yes"
-hostmakedepends="python"
+hostmakedepends="libressl-openssl python"
 depends="virtual?openssl run-parts"
 conf_files="/etc/ca-certificates.conf"
 short_desc="Common CA certificates for SSL/TLS"
@@ -12,6 +12,12 @@ homepage="http://packages.qa.debian.org/c/ca-certificates.html"
 license="GPL-2"
 distfiles="${DEBIAN_SITE}/main/c/${pkgname}/${pkgname}_${version}.tar.xz"
 checksum=37dbaa93ed64cc4ae93ac295f9248fbc741bd51376438cfb1257f17efab5494f
+
+post_extract() {
+	cp ${FILESDIR}/remove-expired-certs.sh ${wrksrc}/mozilla
+	sed -i ${wrksrc}/mozilla/Makefile \
+		-e "s;\(.*\)\(python .*\);\1\2\n\1./remove-expired-certs.sh;"
+}
 
 do_build() {
 	make ${makejobs}


### PR DESCRIPTION
This is inspired by (beyond) linux from scratch ca-certificates build description.
The script is slightly modified for this pr.
Currently there are 3 expired certificates removed.