### PR TITLE
mps-youtube: fixed module error by changing python version

### DIFF
--- a/srcpkgs/mps-youtube/template
+++ b/srcpkgs/mps-youtube/template
@@ -1,13 +1,14 @@
 # Template file for 'mps-youtube'
 pkgname=mps-youtube
 version=0.2.5
-revision=1
+revision=2
 build_style=python-module
+python_versions="3.4"
 noarch=yes
 pycompile_module="mps_youtube"
-hostmakedepends="python-devel python-setuptools"
-makedepends="python-devel"
-depends="pafy python python-setuptools"
+hostmakedepends="python3.4-devel python3.4-setuptools"
+makedepends="python3.4-devel"
+depends="pafy python3.4 python3.4-setuptools"
 short_desc="Terminal based YouTube player and downloader"
 maintainer="Logen K <logen@sudotask.com>"
 license="GPL-3"


### PR DESCRIPTION
mps-youtube was broken for awhile and I noticed the mps changelog mentioning a switch to python3.