### PR TITLE
Implement XBPS_DISTFILES_MIRROR (second try)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,27 @@ To enable it:
     $ cd void-packages
     $ echo XBPS_CHROOT_CMD=proot >> etc/conf
 
+### Distfiles mirror(s)
+
+In etc/conf you may optionally define a mirror or a list of mirrors to search for distfiles.
+    $ echo 'XBPS_DISTFILES_MIRROR="ftp://192.168.100.5/gentoo/distfiles"' >> etc/conf
+
+If more than one mirror is to be searched, you can either specify multiple URLs separated
+with blanks, or add to the variable like this
+    $ echo 'XBPS_DISTFILES_MIRROR+=" http://repo.voidlinux.de/distfiles"' >> etc/conf
+Make sure to put the blank after the first double quote in this case.
+
+The mirrors are searched in order for the distfiles to build a package until the
+checksum of the downloaded file matches the one specified in the template.
+
+Ultimately, if no mirror carries the distfile, or in case all downloads failed the
+checksum verification, the original download location is used.
+
+If you use `proot` or `uchroot` for your XBPS_CHROOT_CMD, you may also specify a local path
+using the `file://` prefix or simply an absolute path on your build host (e.g. /mnt/distfiles).
+Mirror locations specified this way are bind mounted inside the chroot environment
+under $XBPS_MASTERDIR and searched for distfiles just the same as remote locations.
+
 ### Quick setup in Void
 
 Clone the `void-packages` git repository, install the bootstrap packages:

--- a/xbps-src
+++ b/xbps-src
@@ -351,6 +351,32 @@ read_pkg() {
     setup_pkg $XBPS_TARGET_PKG $XBPS_CROSS_BUILD
 }
 
+setup_distfiles_mirror() {
+    local mirror scheme path
+
+    # Scheme file:// mirror locations only work with uchroot or proot
+    for mirror in $XBPS_DISTFILES_MIRROR; do
+        scheme="file"
+        if [[ "$mirror" == *://* ]]; then
+            scheme="${mirror%%://*}"
+            path="${mirror#${scheme}://}"
+        else
+            path="$mirror"
+        fi
+        [ "$scheme" != "file" ] && continue
+        if [ "$XBPS_CHROOT_CMD" == "uchroot" -o "$XBPS_CHROOT_CMD" == "proot" ]; then
+            if [ ! -d "$path" ]; then
+                msg_warn "Invalid path in XBPS_DISTFILES_MIRROR ($mirror)\n"
+                continue
+            fi
+            mkdir -p "$XBPS_MASTERDIR/$path"
+            XBPS_CHROOT_CMD_ARGS+=" -b $path:$path"
+        else
+            msg_warn "File URLs ($mirror) don't work with '$XBPS_CHROOT_CMD'\n"
+        fi
+    done
+}
+
 readonly XBPS_VERSION_REQ="0.46"
 readonly XBPS_VERSION=$(xbps-uhelper -V|awk '{print $2}')
 readonly XBPS_SRC_VERSION="113"
@@ -516,7 +542,7 @@ export XBPS_SHUTILSDIR XBPS_CROSSPFDIR XBPS_TRIGGERSDIR \
     XBPS_SKIP_REMOTEREPOS XBPS_CROSS_BUILD XBPS_PKG_OPTIONS \
     XBPS_CONFIG_FILE XBPS_KEEP_ALL XBPS_HOSTDIR XBPS_MASTERDIR \
     XBPS_SRC_VERSION XBPS_DESTDIR XBPS_MACHINE XBPS_TEMP_MASTERDIR \
-    XBPS_BINPKG_EXISTS XBPS_LIBEXECDIR XBPS_DISTDIR
+    XBPS_BINPKG_EXISTS XBPS_LIBEXECDIR XBPS_DISTDIR XBPS_DISTFILES_MIRROR
 
 for i in REPOSITORY DESTDIR BUILDDIR SRCDISTDIR; do
     eval val="\$XBPS_$i"
@@ -571,6 +597,9 @@ check_build_requirements
 
 if [ -z "$IN_CHROOT" ]; then
     trap 'exit_func' INT TERM
+    if [ -n "$XBPS_DISTFILES_MIRROR" ]; then
+        setup_distfiles_mirror
+    fi
 fi
 
 #


### PR DESCRIPTION
The idea is to remove some burden from the original download
locations for distfiles by specifying one or more mirror locations.

+ Works with `http://` or `ftp://` mirrors for all supported `$XBPS_CHROOT_CMD` variants
+ Works with `file://` mirrors together with `uchroot` and `proot` (fixed a typo and it works now)