### PR TITLE
wireshark: restrict capturing to root and members of the wireshark group.

### DIFF
--- a/srcpkgs/wireshark/INSTALL
+++ b/srcpkgs/wireshark/INSTALL
@@ -2,5 +2,6 @@ case "${ACTION}" in
 post)
 	chgrp wireshark usr/bin/dumpcap
 	setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' usr/bin/dumpcap
+	chmod 770 usr/bin/dumpcap
 	;;
 esac

--- a/srcpkgs/wireshark/template
+++ b/srcpkgs/wireshark/template
@@ -1,7 +1,7 @@
 # Template file for 'wireshark'
 pkgname=wireshark
 version=1.12.7
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-ssl --with-pcap --with-libcap --with-zlib --with-lua
  --with-krb5 --with-gtk3=yes --without-portaudio CC_FOR_BUILD=cc"


### PR DESCRIPTION
Permissions on dumpcap were too permissive.