### PR TITLE
gogs: update to 0.6.5

### DIFF
--- a/srcpkgs/gogs/files/gopm-lite
+++ b/srcpkgs/gogs/files/gopm-lite
@@ -1,0 +1,134 @@
+#!/bin/sh
+
+# gopm-lite
+# a shell script to download, extract, and link
+# dependencies from a .gopmfile
+# requirements: curl, coreutils
+
+# Needed environment variables:
+# GOPATH - packages will be linked to $GOPATH/src/
+# GOPMSTORE - where to store downloaded packages
+
+# Optional environment variables
+# MAXDEPTH - Maximum amount of attempts to recurse
+#            and download all packages
+# Defaults to 5
+
+# Needed arguments:
+# 1 - path to a .gopmfile
+
+if [ -z "$GOPATH" -o -z "$GOPMSTORE" ]; then
+    printf 'Need the following environment variables defined:\n'
+    printf 'GOPATH\n'
+    printf 'GOPMSTORE\n'
+    exit 1
+fi
+if [ -z "$1" ]; then
+    printf 'Usage: %s /path/to/.gopmfile\n' "$0"
+    exit 1
+fi
+
+if [ -z "$MAXDEPTH" ]; then
+    MAXDEPTH=5
+fi
+
+export MAXDEPTH
+export GOPATH
+export GOPMSTORE
+
+mkdir -p "${GOPATH}/src"
+mkdir -p "${GOPMSTORE}/archives"
+mkdir -p "${GOPMSTORE}/repos"
+
+indeps=""
+curdepth=0
+
+download_and_link() {
+    local gopmfile=$1
+    local extracted_counter=0
+    printf 'Downloading deps for %s\n' "$gopmfile" 1>&2
+    while read line; do
+        if [ "$line" = "[deps]" ]; then
+            indeps="deps"
+            continue
+        fi
+        if [ -z "$line" -a -n "$indeps" ]; then
+            break;
+        fi
+        if [ -z "$indeps" ]; then
+            continue;
+        fi
+
+        host=""
+        user=""
+        package=""
+        tagish=""
+
+        url=$(printf '%s' "$line" | cut -f1 -d'=' | sed 's/ //g');
+        version=$(printf '%s' "$line" | cut -f2 -d'=' | sed 's/ //g');
+
+        host=$(printf '%s' "$url" | cut -f1 -d'/')
+        user=$(printf '%s' "$url" | cut -f2 -d'/')
+        package=$(printf '%s' "$url" | cut -f3 -d'/')
+
+        if [ -z "$package" ]; then
+            package="${user}"
+        fi
+
+
+        if [ "$host" = "gopkg.in" ]; then
+            host="github.com"
+            if [ "$user" = "$package" ]; then
+                package=$(printf '%s' "$package" | cut -f1 -d'.')
+                user="go-$package"
+            else
+                package=$(printf '%s' "$package" | cut -f1 -d'.')
+            fi
+
+        fi
+        if [ "$host" = "golang.org" ]; then
+            host="github.com"
+            user="golang"
+        fi
+
+        if [ -n "$version" ]; then
+            tagish=$(printf '%s' "$version" | cut -f2 -d':')
+        else
+            tagish="master"
+        fi
+
+        if [ ! -e "$GOPMSTORE/archives/$host-$user-$package-$tagish.tar.gz" ]; then
+            curl --silent -R -L -o "$GOPMSTORE/archives/$host-$user-$package-$tagish.tar.gz" "https://$host/$user/$package/archive/$tagish.tar.gz"
+        fi
+        if [ ! -e "$GOPMSTORE/repos/$url.$tagish" ]; then
+            mkdir -p "$GOPMSTORE/repos/$url.$tagish"
+            tar xf "$GOPMSTORE/archives/$host-$user-$package-$tagish.tar.gz" -C "$GOPMSTORE/repos/$url.$tagish" --strip-components=1
+        fi
+
+        if [ ! -e "$GOPATH/src/$url" ]; then
+            mkdir -p "$GOPATH/src/$url"
+            rmdir "$GOPATH/src/$url"
+            ln -s "$GOPMSTORE/repos/$url.$tagish" "$GOPATH/src/$url"
+            extracted_counter=$((extracted_counter+1))
+        fi
+
+    done <"$gopmfile"
+    printf '%s' "$extracted_counter"
+}
+
+packages_processed=$(download_and_link $1)
+printf 'Done with %s packages\n' "$packages_processed" 1>&2
+curdepth=1
+
+export -f download_and_link
+
+while [ ! "$packages_processed" = "0" ]; do
+    if [ "$curdepth" = "$MAXDEPTH" ]; then
+        break
+    fi
+    packages_processed=$(find -L "$GOPATH/src" -name '.gopmfile' -exec bash -c 'download_and_link "$0"' {} \; | awk '{s+=$1} END {print s}')
+    curdepth=$((curdepth+1))
+    printf 'Done with %s packages\n' "$packages_processed" 1>&2
+done
+
+exit 0

--- a/srcpkgs/gogs/template
+++ b/srcpkgs/gogs/template
@@ -1,7 +1,7 @@
 # Template build file for 'gogs'
 pkgname=gogs
-version=0.6.3
-revision=2
+version=0.6.5
+revision=1
 build_style=go
 go_import_path="github.com/gogits/gogs"
 short_desc="Self-hosted Git Service in Go"
@@ -10,12 +10,13 @@ license="MIT"
 homepage="http://gogs.io"
 depends="git"
 distfiles="https://github.com/gogits/gogs/archive/v${version}.tar.gz"
-checksum=6fbd21805ae86b2d1eb1735a8659952036f1a08047a37a0647baaa57fea342bb
-hostmakedepends="git"
+checksum="9605d65f53c0590ed9adca41bee7bef8104cadea663c3a4db94e33092b61c2a3"
+hostmakedepends="git curl"
 
 conf_files="/etc/gogs.ini"
 system_accounts="gogs"
 gogs_homedir="/srv/gogs"
+gogs_shell="/bin/bash"
 make_dirs="
 	/srv/gogs 0755 gogs gogs
 	/srv/gogs/repo 0755 gogs gogs
@@ -30,17 +31,19 @@ post_extract() {
 	mkdir tmp
 	mkdir -p $GOPATH/src/github.com/gogits
 	ln -s $PWD $GOPATH/src/github.com/gogits/${pkgname}
-	TMPDIR=${PWD}/tmp/ go get -tags "sqlite redis memcache" "github.com/gogits/gogs"
+	sed -i 's@golang.org/x/net = commit:937a34c9de13@golang.org/x/net =@' .gopmfile
+	sed -i 's@golang.org/x/text = commit:5b2527008a4c@golang.org/x/text =@' .gopmfile
+	TMPDIR=${PWD}/tmp/ GOPMSTORE=${PWD}/tmp/gopm ${FILESDIR}/gopm-lite .gopmfile 1>/dev/null 2>/dev/null
+	TMPDIR=${PWD}/tmp/ go get -d -tags "sqlite redis memcache" "github.com/gogits/gogs"
 }
 
-
 do_build() {
-	go fix
 	TMPDIR=${PWD}/tmp/ GOOS=linux go build -tags "sqlite redis memcache"
 	rm -rf tmp
 }
 
 do_install() {
+	cd "$GOPATH/src/github.com/gogits/gogs"
 	vbin gogs-${version} gogs
 	install -d "$DESTDIR/usr/share/themes/gogs/default"
 	cp -r public "$DESTDIR/usr/share/themes/gogs/default/"


### PR DESCRIPTION
The gogs build process relies on a tool called "gopm" - it allows for specifying specific versions of dependencies. Without it, "go get" pulls down the latest code from the needed dependencies and the build can break.

Instead of installing and using gopm, I wrote a short script (`misc/generate-distfiles`) to parse the .gopm file and generate distfiles lines, checksum lines, and the do_extract() function.

That's why the distfiles is so huge - it captures all the dependencies from the .gopm file in the source repo.