### PR TITLE
vim: update to 7.4.827

### DIFF
--- a/srcpkgs/vim/template
+++ b/srcpkgs/vim/template
@@ -1,10 +1,8 @@
 # Template file for 'vim'
 pkgname=vim
-_distver=7.4
-_patchver=763
-version=${_distver}.${_patchver}
+version=7.4.827
 revision=1
-hostmakedepends="mercurial pkg-config"
+hostmakedepends="pkg-config"
 makedepends="ncurses-devel acl-devel libXt-devel gtk+-devel perl
  ruby-devel python-devel python3.4-devel lua-devel"
 depends="vim-common>=$version"
@@ -12,17 +10,14 @@ short_desc="Vim editor (vi clone)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.vim.org"
 license="GPL-2"
+distfiles="https://github.com/${pkgname}/${pkgname}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
+checksum=8920db8115c78d260abbb2757ebf0e1e64d6e2f989626435fffad1ef37a9760f
 
 subpackages="vim-common vim-x11 gvim"
 # XXX vim-huge cannot be cross compiled for now.
 if [ -z "$CROSS_BUILD" ]; then
 	subpackages+=" vim-huge vim-huge-python3"
 fi
-
-do_fetch() {
-	local url="http://code.google.com/p/vim/"
-	hg clone -u v${_distver/./-}-${_patchver} ${url} ${pkgname}-${version}
-}
 
 pre_configure() {
 	for f in ${subpackages/vim-common/}; do


### PR DESCRIPTION
The template failed to fetch `7.4.763` using `hg clone` for me:
```
requesting all changes
adding changesets
adding manifests
adding file changes
added 7030 changesets with 33364 changes to 2802 files
abort: unknown revision 'v7-4-763'!
```
Thus changed template to download from github.com