### PR TITLE
libreoffice-bin: update to 5.0.0

### DIFF
--- a/srcpkgs/libreoffice-bin/template
+++ b/srcpkgs/libreoffice-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'libreoffice-bin'
 pkgname=libreoffice-bin
-version=4.4.5
+version=5.0.0
 revision=1
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.libreoffice.org/"
@@ -11,15 +11,15 @@ _disturi="http://download.documentfoundation.org/libreoffice/stable/${version}/d
 if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 	_arch=x86-64
 	distfiles="${_disturi}/x86_64/LibreOffice_${version}_Linux_${_arch}_deb.tar.gz"
-	checksum=f551dfaca1b63b63782e9b3645649a4a11629483a06edb2b3dfd0f7a78847436
+	checksum=d639c814ee01fa122f34f8b7b374697a504c2c625a7bae1a051ce60b08a718e8
 elif [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
 	_arch=x86
 	distfiles="${_disturi}/x86/LibreOffice_${version}_Linux_${_arch}_deb.tar.gz"
-	checksum=c0912752bbd09bc534c71b2c2d58352c8a9c02a31f0edc8180d0f8fa22c35f78
+	checksum=6b2595d46c3a44ccddeaa624c3d36d06b882fb22a743fb19bf71102391a823b1
 fi
 
 only_for_archs="i686 x86_64"
-wrksrc="LibreOffice_${version}.2_Linux_${_arch}_deb"
+wrksrc="LibreOffice_${version}.5_Linux_${_arch}_deb"
 depends="shared-mime-info desktop-file-utils hicolor-icon-theme"
 provides="libreoffice-${version}_${revision}"
 replaces="libreoffice>=0"


### PR DESCRIPTION
I updated to 4.4.5 already, since 4.4.3 was no longer available.
We may update to 5.0.0 while I'm not sure a major version jump is desired.