### PR TITLE
openexr: unbreak cross

### DIFF
--- a/srcpkgs/openexr/template
+++ b/srcpkgs/openexr/template
@@ -1,7 +1,7 @@
 # Template file for 'openexr'
 pkgname=openexr
 version=2.2.0
-revision=2
+revision=3
 build_style=gnu-configure
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.openexr.com/"
@@ -9,16 +9,28 @@ license="BSD"
 short_desc="High dynamic-range (HDR) image file format"
 hostmakedepends="pkg-config"
 makedepends="ilmbase-devel zlib-devel"
-distfiles="http://download.savannah.nongnu.org/releases/${pkgname}/${pkgname}-${version}.tar.gz"
+distfiles="${NONGNU_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum="36a012f6c43213f840ce29a8b182700f6cf6b214bea0d5735594136b44914231"
 
-# XXX
-nocross="http://build.voidlinux.eu/builders/armv7l-musl_builder/builds/3335/steps/shell_3/logs/stdio"
+LDFLAGS="-L${XBPS_CROSS_BASE}/usr/lib -lrt"
 
-LDFLAGS="-lrt"
+post_configure() {
+	if [ "$CROSS_BUILD" ]; then
+		# Don't try to rebuild these header files when cross compiling
+		# in the hope the shipped tables are ok to use as is.
+		sed -i ${wrksrc}/IlmImf/Makefile \
+			-e "/BUILT_SOURCES = /s;b44ExpLogTable.h dwaLookups.h;;" \
+			-e "/CLEANFILES = /s; b44ExpLogTable.h;;" \
+			-e "/CLEANFILES = /s; dwaLookups.h;;" \
+			-e "/b44ExpLogTable.h: b44ExpLogTable/d" \
+			-e "/\.\/b44ExpLogTable > b44ExpLogTable.h/d" \
+			-e "/dwaLookups.h: dwaLookups/d" \
+			-e "/\.\/dwaLookups > dwaLookups.h/d"
+	fi
+}
 
 post_install(){
-    vlicense LICENSE
+	vlicense LICENSE
 }
 
 libopenexr_package() {


### PR DESCRIPTION
The result needs testing on the cross platforms, though.
There is no guarantee the shipped tables `IlmImf/dwaLookup.h`
and `IlmImf/b44ExpLogTable.h` are okay to use as is.

Looking at the source generating the tables a minor difference in float
functions or floating point accuracy between the system which generated
the shipped tables and the cross targets *may* ruin the idea.

So only testing programs in this pkg or pkgs using libopenexr-devel on
arm* can eventually tell if this is ok.