### PR TITLE
New package: musl-fts-1.0

### DIFF
--- a/srcpkgs/musl-fts/template
+++ b/srcpkgs/musl-fts/template
@@ -1,0 +1,21 @@
+# Template file for 'musl-fts'
+pkgname=musl-fts
+version=1.0
+revision=1
+build_style=gnu-configure
+hostmakedepends="automake"
+only_for_archs="aarch64-musl armv6l-musl armv7l-musl i686-musl mips-musl mipsel-musl mipselhf-musl x86_64-musl"
+short_desc="Implementation of fts(3) for musl libc"
+maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
+license="BSD"
+homepage="http://github.com/pullmoll/musl-fts"
+distfiles="https://github.com/pullmoll/${pkgname}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
+checksum=5a1ff3bc2794163253b775072ac50c73d23df7ea05f54373c132d6231553e586
+
+pre_configure() {
+	./bootstrap.sh
+}
+
+post_install() {
+	vlicense COPYING
+}


### PR DESCRIPTION
This is intended to standardize handling of packages for musl libc
which require an fts(3) implementation. Adding musl-fts to the
makedepends and linking /usr/lib/libfts.a to the target (i.e.
`LIBS="-lfts"`) should suffice.