### PR TITLE
fontforge: unbreak musl

### DIFF
--- a/srcpkgs/fontforge/template
+++ b/srcpkgs/fontforge/template
@@ -1,9 +1,9 @@
 # Template file for 'fontforge'
 pkgname=fontforge
 version=20150612
-revision=1
+revision=2
 build_style=gnu-configure
-hostmakedepends="automake libtool libltdl-devel pkg-config git python"
+hostmakedepends="automake libtool libltdl-devel pkg-config git python ca-certificates"
 makedepends="libltdl-devel python-devel zlib-devel pango-devel readline-devel
  giflib-devel libpng-devel libjpeg-turbo-devel tiff-devel libxml2-devel
  libspiro-devel hicolor-icon-theme desktop-file-utils"
@@ -19,6 +19,11 @@ checksum="af4997a07c96f7057f08cb5c7d71b19a0e8ac6336e0c48476471b471c0574247
 
 pre_configure() {
 	./bootstrap
+}
+
+pre_build() {
+	# Disable unused #include <execinfo.h>
+	sed -i fontforge/cvundoes.c -e "s;\(.*#include <execinfo.h>\);//\1;"
 }
 
 post_install() {


### PR DESCRIPTION
The needless `#include <execinfo.h>` should probably be reported upstream.