### PR TITLE
base-system-busybox+runit-void: Using relative symbolic link to for /sbin/init

### DIFF
--- a/srcpkgs/base-system-busybox/template
+++ b/srcpkgs/base-system-busybox/template
@@ -1,7 +1,7 @@
 # Build template for 'base-system-busybox'.
 pkgname=base-system-busybox
 version=1.23.2
-revision=6
+revision=7
 wrksrc="busybox-${version}"
 homepage="http://www.busybox.net"
 hostmakedepends="perl"
@@ -59,5 +59,5 @@ do_install() {
 	mv ${DESTDIR}/usr/sbin/* ${DESTDIR}/usr/bin
 	rm -f ${DESTDIR}/{,s}bin
 	# Provide /sbin/init symlink to runit.
-	ln -s /usr/bin/runit-init ${DESTDIR}/usr/bin/init
+	ln -s runit-init ${DESTDIR}/usr/bin/init
 }

--- a/srcpkgs/runit-void/template
+++ b/srcpkgs/runit-void/template
@@ -1,7 +1,7 @@
 # Template file for 'runit-void'
 pkgname=runit-void
 version=20150827
-revision=1
+revision=2
 wrksrc="void-runit-${version}"
 build_pie=yes
 build_style=gnu-makefile
@@ -37,5 +37,5 @@ post_install() {
 	rm -f ${DESTDIR}/etc/runit/runsvdir/current
 	rm -rf ${DESTDIR}/etc/runit/runsvdir/default
 	rm -rf ${DESTDIR}/etc/runit/runsvdir/single
-	ln -s /usr/bin/runit-init ${DESTDIR}/usr/bin/init
+	ln -s runit-init ${DESTDIR}/usr/bin/init
 }


### PR DESCRIPTION
Fixing "initrd + busybox' switch_root" based boots