### PR TITLE
base-files: add a default prompt

### DIFF
--- a/srcpkgs/base-files/files/profile
+++ b/srcpkgs/base-files/files/profile
@@ -9,6 +9,10 @@ export PATH
 # Set default umask
 umask 022
 
+# Set default prompt
+PS1='\h:\w\$'
+export PS1
+
 # Load profiles from /etc/profile.d
 if [ -d /etc/profile.d/ ]; then
 	for f in /etc/profile.d/*.sh; do


### PR DESCRIPTION
Not sure it will pass the 'minimalism' requirement :)

Seems to have been removed in: https://github.com/voidlinux/void-packages/commit/7c3fb28abbedafe818da4f4a6feb9be922c28465