### PR TITLE
scaleway-base: Initial version

### DIFF
--- a/srcpkgs/scaleway-base/INSTALL
+++ b/srcpkgs/scaleway-base/INSTALL
@@ -1,0 +1,13 @@
+case "$ACTION" in
+post)
+	# enable sshd, ntpdate, ntpd and dhcpcd services.
+	if [ -x /usr/bin/systemctl ]; then
+		systemctl enable sshd.service ntpdate.service ntpd.service dhcpcd.service
+	else
+		mkdir -p etc/runit/runsvdir/default/
+		ln -sf /etc/sv/sshd etc/runit/runsvdir/default/
+		ln -sf /etc/sv/ntpd etc/runit/runsvdir/default/
+		ln -sf /etc/sv/dhcpcd etc/runit/runsvdir/default/
+	fi
+	;;
+esac

--- a/srcpkgs/scaleway-base/template
+++ b/srcpkgs/scaleway-base/template
@@ -1,0 +1,15 @@
+# Template file for 'scaleway-base'
+pkgname=scaleway-base
+version=1
+revision=1
+homepage="http://www.scaleway.com/"
+short_desc="Void Linux Scaleway base files"
+maintainer="Manfred Touron <mtouron@scaleway.com>"
+license="Public Domain"
+
+only_for_archs="armv6l armv6l-musl armv7l armv7l-musl"
+depends="virtual?ntp-daemon"
+
+do_install() {
+	:
+}


### PR DESCRIPTION
Means to be run on Scaleway C1 servers (https://www.scaleway.com).

Actually, we are working on the rpi2 base image:
http://repo.voidlinux.eu/live/current/void-rpi2-rootfs-20150713.tar.xz

https://github.com/scaleway/image-voidlinux/blob/master/Dockerfile