### PR TITLE
memcached: fix build in musl, add -devel subpkg

### DIFF
--- a/srcpkgs/memcached-devel
+++ b/srcpkgs/memcached-devel
@@ -1,0 +1,1 @@
+memcached

--- a/srcpkgs/memcached/patches/memcached-1.4.24-fix-signal.patch
+++ b/srcpkgs/memcached/patches/memcached-1.4.24-fix-signal.patch
@@ -1,0 +1,40 @@
+diff --git assoc.c assoc.c
+index e6cf09b..cc29611 100644
+--- assoc.c
++++ assoc.c
+@@ -14,7 +14,7 @@
+ #include "memcached.h"
+ #include <sys/stat.h>
+ #include <sys/socket.h>
+-#include <sys/signal.h>
++#include <signal.h>
+ #include <sys/resource.h>
+ #include <fcntl.h>
+ #include <netinet/in.h>
+diff --git items.c items.c
+index 4a22af9..53847be 100644
+--- items.c
++++ items.c
+@@ -2,7 +2,7 @@
+ #include "memcached.h"
+ #include <sys/stat.h>
+ #include <sys/socket.h>
+-#include <sys/signal.h>
++#include <signal.h>
+ #include <sys/resource.h>
+ #include <fcntl.h>
+ #include <netinet/in.h>
+diff --git slabs.c slabs.c
+index c9e29ac..92dffe2 100644
+--- slabs.c
++++ slabs.c
+@@ -10,7 +10,7 @@
+ #include "memcached.h"
+ #include <sys/stat.h>
+ #include <sys/socket.h>
+-#include <sys/signal.h>
++#include <signal.h>
+ #include <sys/resource.h>
+ #include <fcntl.h>
+ #include <netinet/in.h>
+

--- a/srcpkgs/memcached/template
+++ b/srcpkgs/memcached/template
@@ -1,7 +1,7 @@
 # Template file for 'memcached'
 pkgname=memcached
 version=1.4.24
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="libevent-devel"
 short_desc="A distributed memory object caching system"
@@ -11,6 +11,11 @@ homepage="http://www.memcached.org"
 distfiles="http://${pkgname}.org/files/${pkgname}-${version}.tar.gz"
 checksum=08a426c504ecf64633151eec1058584754d2f54e62e5ed2d6808559401617e55
 
-post_install() {
-	rm -rf ${DESTDIR}/usr/include
+memcached-devel_package() {
+	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/include
+	}
 }
+


### PR DESCRIPTION
The current build fails on musl - `#include <sys/signal.h>` generates a compiler warning and the build fails.

The warning is just that the correct include is `#include <signal.h>` - same for glibc.

The included patch has been submitted to upstream mailing list: https://groups.google.com/forum/#!topic/memcached/ThyxJORhxh0