### PR TITLE
icecat: fix resources permissions

### DIFF
--- a/srcpkgs/icecat/template
+++ b/srcpkgs/icecat/template
@@ -1,7 +1,7 @@
 # Template build file for 'icecat'.
 pkgname=icecat
 version=31.8.0
-revision=1
+revision=2
 short_desc="GNU version of the Firefox browser"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 homepage="https://www.gnu.org/software/${pkgname}/"
@@ -44,19 +44,6 @@ pre_configure() {
 	_google_api_key="AIzaSyCIFdBA7eQP43R6kXRwTq7j6Mvj1ITze90"
 	echo -n "$_google_api_key" > google-api-key
 	[ ! -d xbps-build ] && mkdir -p xbps-build
-
-	# Remove the spyblock@gnu.org addon because it causes a permanent
-	# error message to be printed at the bottom of the window and is
-	# said to not work right anyway:
-	# http://lists.gnu.org/archive/html/bug-gnuzilla/2015-07/msg00041.html
-	# TODO: find a fix for the annoying error message
-	rm -r extensions/gnu/spyblock@gnu.org
-	sed -i browser/installer/package-manifest.in \
-		-e "/@BINPATH@\/browser\/extensions\/spyblock@gnu.org\/\*/d"
-	sed -i mobile/android/installer/package-manifest.in \
-		-e "/@BINPATH@\/browser\/extensions\/spyblock@gnu.org\/\*/d"
-	sed -i extensions/gnu/abouticecat\@gnu.org/chrome/content/aboutIceCat/aboutIceCat.xhtml \
-		-e "/.*spyblock@gnu.org/d"
 }
 do_configure() {
 	if [ "$CROSS_BUILD" ]; then
@@ -151,6 +138,10 @@ do_build() {
 do_install() {
 	cd xbps-build
 	make DESTDIR=${DESTDIR} install
+
+	# Fix permissions (-rw------- to -rw-r--r--)
+	find ${DESTDIR}/usr/lib/icecat -type f -perm 0600 \
+		-exec chmod 0644 "{}" \;
 
 	vinstall ${FILESDIR}/vendor.js 644 usr/lib/icecat/defaults/pref
 	vinstall ${FILESDIR}/icecat.desktop 644 usr/share/applications


### PR DESCRIPTION
The cause for the annoying error message generated by
the spyblock@gnu.org overlay.xul was due to installed
resource had wrong permissions (0600 instead of 0644).