### PR TITLE
firefox-esr: fix arm*-musl

### DIFF
--- a/srcpkgs/firefox-esr/template
+++ b/srcpkgs/firefox-esr/template
@@ -1,7 +1,7 @@
 # Template build file for 'firefox-esr'.
 pkgname=firefox-esr
 version=38.2.1
-revision=1
+revision=2
 wrksrc="mozilla-esr${version%%.*}"
 short_desc="Lightweight gecko-based web browser"
 maintainer="Eivind Uggedal <eivind@uggedal.com>"
@@ -22,9 +22,16 @@ makedepends="nss-devel libjpeg-turbo-devel libpng-devel
 depends="nss>=3.17 desktop-file-utils hicolor-icon-theme"
 conflicts="firefox>=0"
 
-case "$XBPS_TARGET_MACHINE" in
-	armv[67]l-musl) broken="http://build.voidlinux.eu/builders/armv6l-musl_builder/builds/3641/steps/shell_3/logs/stdio";;
-esac
+if [ "$CROSS_BUILD" ]; then
+	# Make config/system_wrappers/alsa/alsalib.h and pulse/pulse.h find
+	# the required includes. Set system nspr and nss include paths.
+	CFLAGS="-I${XBPS_CROSS_BASE}/usr/include/alsa \
+		-I${XBPS_CROSS_BASE}/usr/include/pulse \
+		-I${XBPS_CROSS_BASE}/usr/include/nspr \
+		-I${XBPS_CROSS_BASE}/usr/include/nss"
+	CXXFLAGS="${CFLAGS}"
+	LDFLAGS="-L${XBPS_CROSS_BASE}/usr/lib"
+fi
 
 pre_configure() {
 	case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
This adds the same presets for CFLAGS, CXXFLAGS and LDFLAGS as
in icecat (31.8.0) and fixes cross building for arm*-musl for me.

It could help firefox as well.