### PR TITLE
runit: fix -Werror failure for i686

### DIFF
--- a/srcpkgs/runit/template
+++ b/srcpkgs/runit/template
@@ -1,7 +1,7 @@
 # Template file for 'runit'
 pkgname=runit
 version=2.1.2
-revision=5
+revision=6
 wrksrc="admin"
 short_desc="A UNIX init scheme with service supervision"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -14,36 +14,42 @@ build_pie=yes
 build_options="static"
 
 do_build() {
-  cd ${pkgname}-${version}/src
+	cd ${pkgname}-${version}/src
 
-  if [ "$build_option_static" ]; then
-	CFLAGS+=" -static"
-	LDFLAGS+=" -static"
-  fi
+	if [ "$build_option_static" ]; then
+		CFLAGS+=" -static"
+		LDFLAGS+=" -static"
+	fi
 
-  sed -e 's,sbin/runit,usr/bin/runit,g' -i runit.h
+	sed -e 's,sbin/runit,usr/bin/runit,g' -i runit.h
 
-  echo "$CC -D_GNU_SOURCE $CFLAGS" >conf-cc
-  echo "$CC $LDFLAGS -Wl,-z -Wl,noexecstack" >conf-ld
-  # set default service path to /var/service
-  sed -i -e 's:^char \*varservice ="/service/";$:char \*varservice ="/var/service/";:' sv.c
+	echo "$CC -D_GNU_SOURCE $CFLAGS" >conf-cc
+	echo "$CC $LDFLAGS -Wl,-z -Wl,noexecstack" >conf-ld
+	# set default service path to /var/service
+	sed -i -e 's:^char \*varservice ="/service/";$:char \*varservice ="/var/service/";:' sv.c
+	# change type short to gid_t for getgroups(2) and setgroups(2)
+	sed -i -e 's:short x\[4\];$:gid_t x[4];:' chkshsgr.c
 
-  make ${makejobs}
+	make ${makejobs}
 }
 
 do_install() {
-  cd ${pkgname}-${version}/src
+	cd ${pkgname}-${version}/src
 
-  # default services
-  vmkdir var
-  ln -s ../run/runit/runsvdir/current ${DESTDIR}/var/service
+	# default services
+	vmkdir var
+	ln -s ../run/runit/runsvdir/current ${DESTDIR}/var/service
 
-  vmkdir usr/bin
-  install -m0755 {chpst,runit,runit-init,runsv,runsvchdir,runsvdir,sv,svlogd,utmpset} ${DESTDIR}/usr/bin
+	local f
+	for f in chpst runit runit-init runsv runsvchdir runsvdir \
+		sv svlogd utmpset; do
+		vbin $f
+	done
 
-  cd ..
-  vmkdir usr/share/man/man8
-  install -m0644 man/* ${DESTDIR}/usr/share/man/man8
+	cd ..
+	for f in man/*; do
+		vman $f
+	done
 
-  vinstall ${FILESDIR}/_sv 644 usr/share/zsh/site-functions
+	vinstall ${FILESDIR}/_sv 644 usr/share/zsh/site-functions
 }


### PR DESCRIPTION
Fix a warning about the wrong type short being used for
getgroups(2) and setgroups(2) parameter 2 which causes the
i686 build to fail here, probably because of -Werror.

Also "modernize" the template's indentation and use
vbin, vman ...