### PR TITLE
Manual.md: add note about supplying licenses

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -246,7 +246,8 @@ The optional 4th argument can be used to change the `file name`.
 
 	Installs `file` into `usr/share/licenses/<pkgname>` in the pkg
 	`$DESTDIR`. The optional 2nd argument can be used to change the
-	`file name`.
+	`file name`. Note: Non-`GPL` licenses, `MIT`, `BSD` and `ISC` require the 
+	license file to	be supplied with the binary package.
 
 - *vsv()* `vsv <service>`
 


### PR DESCRIPTION
This just adds a note about supplying licenses with packages. Are there any other licenses I should include?