### PR TITLE
zile: fix cross compiling

### DIFF
--- a/srcpkgs/zile/template
+++ b/srcpkgs/zile/template
@@ -1,7 +1,7 @@
 # Template file for 'zile'
 pkgname=zile
 version=2.4.11
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="help2man pkg-config"
 makedepends="acl-devel gc-devel ncurses-devel"
@@ -11,3 +11,11 @@ license="GPL-3"
 homepage="http://www.gnu.org/software/zile"
 distfiles="${GNU_SITE}/$pkgname/$pkgname-$version.tar.gz"
 checksum=1fd27bbddc61491b1fbb29a345d0d344734aa9e80cfa07b02892eedf831fa9cc
+
+post_configure() {
+	if [ "$CROSS_BUILD" ]; then
+		# Can not regenerate zile.1.in because the zile
+		# executable would be required. Use shipped file.
+		sed -i Makefile -e 's;\(\$(srcdir)/doc/zile.1.in:\).*;\1;'
+	fi
+}


### PR DESCRIPTION
Also fix *-musl by disabling the regeneration of the zile.1.in file.
The shipped version should be recent enough AFAICT.
@chneukirchen please merge if you agree.