### PR TITLE
setup_pkg(): fix check for pkgname-32bit + update gcc-multilib

### DIFF
--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -212,9 +212,10 @@ get_subpkgs() {
 
 setup_pkg() {
     local pkg="$1" cross="$2"
-    local val _vars f dbgflags arch
+    local basepkg val _vars f dbgflags arch
 
     [ -z "$pkg" ] && return 1
+    basepkg=${pkg%-32bit}
 
     # Start with a sane environment
     unset -v PKG_BUILD_OPTIONS XBPS_CROSS_CFLAGS XBPS_CROSS_CXXFLAGS XBPS_CROSS_CPPFLAGS XBPS_CROSS_LDFLAGS
@@ -272,15 +273,15 @@ setup_pkg() {
         source_file "$f"
     done
 
-    if [ ! -f ${XBPS_SRCPKGDIR}/${pkg}/template ]; then
-        msg_error "xbps-src: unexistent file: ${XBPS_SRCPKGDIR}/${pkg}/template\n"
+    if [ ! -f ${XBPS_SRCPKGDIR}/${basepkg}/template ]; then
+        msg_error "xbps-src: unexistent file: ${XBPS_SRCPKGDIR}/${basepkg}/template\n"
     fi
     if [ -n "$cross" ]; then
         export CROSS_BUILD="$cross"
-        source_file ${XBPS_SRCPKGDIR}/${pkg}/template
+        source_file ${XBPS_SRCPKGDIR}/${basepkg}/template
     else
         unset CROSS_BUILD
-        source_file ${XBPS_SRCPKGDIR}/${pkg}/template
+        source_file ${XBPS_SRCPKGDIR}/${basepkg}/template
     fi
 
     # Check if required vars weren't set.
@@ -316,14 +317,14 @@ setup_pkg() {
         subpackages="$(get_subpkgs)"
     fi
 
-    if [ -h $XBPS_SRCPKGDIR/$pkg ]; then
+    if [ -h $XBPS_SRCPKGDIR/$basepkg ]; then
         # Source all subpkg environment setup snippets.
         for f in ${XBPS_COMMONDIR}/environment/setup-subpkg/*.sh; do
             source_file "$f"
         done
         pkgname=$pkg
-        if ! declare -f ${pkg}_package >/dev/null; then
-            msg_error "$pkgname: missing ${pkg}_package() function!\n"
+        if ! declare -f ${basepkg}_package >/dev/null; then
+            msg_error "$pkgname: missing ${basepkg}_package() function!\n"
         fi
     fi
 

--- a/srcpkgs/gcc-multilib/patches/fix-inline_vfprintf.patch
+++ b/srcpkgs/gcc-multilib/patches/fix-inline_vfprintf.patch
@@ -1,0 +1,26 @@
+Work around a bug when compiling the definition for
+vfprintf(2) in /usr/include/bits/stdio2.h, which does
+not guarantee inlined code for _FORTIFY_SOURCE=2.
+
+Here we just don't include <stdio.h> and declare
+the required types and functions locally.
+
+--- libitm/util.cc	2015-09-02 17:19:01.176016940 +0200
++++ libitm/util.cc	2015-09-02 17:20:03.045016757 +0200
+@@ -24,10 +24,15 @@
+ 
+ #include "libitm_i.h"
+ #include <stdarg.h>
+-#include <stdio.h>
+ 
++#define FILE void 
++extern FILE* stderr;
++extern int fputs(const char*, FILE *);
++extern int fputc(char, FILE *);
++extern int vfprintf(FILE*, const char*, va_list);
++
+ namespace GTM HIDDEN {
+
+ static void
+ gtm_verror (const char *fmt, va_list list)
+ {

--- a/srcpkgs/gcc-multilib/template
+++ b/srcpkgs/gcc-multilib/template
@@ -4,15 +4,15 @@ _triplet="x86_64-unknown-linux-gnu"
 _majorver=4.9
 
 pkgname=gcc-multilib
-version=${_majorver}.2
+version=${_majorver}.3
 revision=1
 wrksrc="gcc-${version}"
 short_desc="The GNU C Compiler (multilib files)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://gcc.gnu.org"
 license="GFDL-1.2, GPL-3, LGPL-2.1"
-distfiles="http://ftp.gnu.org/pub/gnu/gcc/gcc-$version/gcc-$version.tar.bz2"
-checksum=2020c98295856aa13fda0f2f3a4794490757fc24bcca918d52cc8b4917b972dd
+distfiles="${GNU_SITE}/gcc/gcc-$version/gcc-$version.tar.bz2"
+checksum=2332b2a5a321b57508b9031354a8503af6fdfb868b8c1748d33028d100a8b67e
 
 hostmakedepends="perl flex zip unzip"
 makedepends="zlib-devel libmpc-devel ppl-devel cloog-devel
@@ -34,6 +34,8 @@ depends="
 do_configure() {
 	ldconfig &>/dev/null
 
+	# _FORTIFY_SOURCE needs an optimization level.
+	sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" {gcc,libiberty}/configure
 	# As specified in the LFS book, disable installing libiberty.
 	sed -i 's/install_to_$(INSTALL_DEST) //' libiberty/Makefile.in
 	# Do not run fixincludes


### PR DESCRIPTION
Trying to build `gcc-multilib` failed because `glibc-32bit`
has no separate `srcpkg/glibc-32bit/template`, but is a
result of building `glibc` for target arch `i686`.

+ Also update gcc-multilib to gcc-4.9.3