### PR TITLE
distcc: can't distribute cpp; add cross-gcc

### DIFF
--- a/srcpkgs/chroot-distcc/template
+++ b/srcpkgs/chroot-distcc/template
@@ -1,7 +1,7 @@
 # Template file for 'chroot-distcc'
 pkgname=chroot-distcc
 version=3.2rc1
-revision=3
+revision=4
 wrksrc="distcc-${version}"
 bootstrap=yes
 build_style=gnu-configure
@@ -21,14 +21,22 @@ pre_configure() {
 }
 
 post_install() {
+	local f x
 	# Remove useless files.
 	rm -f ${DESTDIR}/usr/bin/distccd
 	rm -rf ${DESTDIR}/etc
 	rm -rf ${DESTDIR}/usr/share
 
-	# gcc wrappers	
+	# gcc wrappers
 	vmkdir usr/lib/distcc/bin
-	for f in gcc cc c++ cpp g++; do
+	for f in gcc cc c++ g++; do
 		ln -sfr ${DESTDIR}/usr/bin/distcc ${DESTDIR}/usr/lib/distcc/bin/${f}
+	done
+	# cross-gcc wrappers
+	for x in arm-linux-gnueabi arm-linux-gnueabihf armv7l-linux-gnueabihf \
+		arm-linux-musleabihf armv7l-linux-musleabihf; do
+		for f in gcc cc c++ g++; do
+			ln -sfr ${DESTDIR}/usr/bin/distcc ${DESTDIR}/usr/lib/distcc/bin/${x}-${f}
+		done
 	done
 }

--- a/srcpkgs/distcc/template
+++ b/srcpkgs/distcc/template
@@ -1,7 +1,7 @@
 # Template file for 'distcc'
 pkgname=distcc
 version=3.2rc1
-revision=14
+revision=15
 build_style=gnu-configure
 configure_args="--disable-Werror --with-gtk"
 hostmakedepends="pkg-config"
@@ -19,6 +19,7 @@ checksum=311671e844625d7fdb18dd3d096cd855751cfe8de13827682bcb7beff9133b30
 build_pie=yes
 
 post_install() {
+	local f x
 	# Remove useless files.
 	rm -f ${DESTDIR}/etc/default/distcc
 	rm -f ${DESTDIR}/etc/distcc/commands.allow.sh
@@ -28,8 +29,15 @@ post_install() {
 
 	# gcc wrappers
 	vmkdir usr/lib/distcc/bin
-	for f in gcc cc c++ cpp g++; do
+	for f in gcc cc c++ g++; do
 		ln -sfr ${DESTDIR}/usr/bin/distcc ${DESTDIR}/usr/lib/distcc/bin/${f}
+	done
+	# cross-gcc wrappers
+	for x in arm-linux-gnueabi arm-linux-gnueabihf armv7l-linux-gnueabihf \
+		arm-linux-musleabihf armv7l-linux-musleabihf; do
+		for f in gcc cc c++ g++; do
+			ln -sfr ${DESTDIR}/usr/bin/distcc ${DESTDIR}/usr/lib/distcc/bin/${x}-${f}
+		done
 	done
 }
 


### PR DESCRIPTION
Distributing cpp is not possible (see man page example for
symbolic links), thus the symlink from cpp to distcc was wrong.

On the other hand it is very well possible to distribute cross
compiler jobs. For this to work the cross compiler must be
available on the slave host(s) as well.