### PR TITLE
mcomix: Added python-setuptools to depends

### DIFF
--- a/srcpkgs/mcomix/template
+++ b/srcpkgs/mcomix/template
@@ -1,12 +1,12 @@
 # Template file for 'mcomix'
 pkgname=mcomix
 version=1.01
-revision=1
+revision=2
 noarch=yes
 build_style=python-module
 pycompile_module="${pkgname}"
 hostmakedepends="python-setuptools"
-depends="pygtk python-Pillow xdg-utils"
+depends="python-setuptools pygtk python-Pillow xdg-utils"
 short_desc="GTK+ comic book viewer"
 maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
 license="GPL-2"


### PR DESCRIPTION
pkg_resources, a module imported from /usr/bin/mcomix, is from python-setuptools.