### PR TITLE
vpnc: revert part of musl patch

### DIFF
--- a/srcpkgs/vpnc/patches/0001-fix-musl.patch
+++ b/srcpkgs/vpnc/patches/0001-fix-musl.patch
@@ -2,12 +2,13 @@ diff --git sysdep.c sysdep.c
 index ff07753..43fdb74 100644
 --- sysdep.c
 +++ sysdep.c
-@@ -59,7 +59,7 @@
+@@ -59,7 +59,9 @@
  #if defined(__DragonFly__)
  #include <net/tun/if_tun.h>
  #elif defined(__linux__)
--#include <linux/if_tun.h>
-+/*#include <linux/if_tun.h>*/
++#ifdef __GLIBC__
+ #include <linux/if_tun.h>
++#endif
  #elif defined(__APPLE__)
  /* no header for tun */
  #elif defined(__CYGWIN__)

--- a/srcpkgs/vpnc/template
+++ b/srcpkgs/vpnc/template
@@ -1,7 +1,7 @@
 # Template file for 'vpnc'
 pkgname=vpnc
 version=0.5.3
-revision=4
+revision=5
 hostmakedepends="perl"
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=' vpnc'


### PR DESCRIPTION
commit 1779dabd7d1ac181f2fee102f55e9f8360c33006 causes:

vpnc: can't initialise tunnel interface: No such file or directory