### PR TITLE
libdwarf: add soname to package

### DIFF
--- a/srcpkgs/libdwarf/patches/add-soname.patch
+++ b/srcpkgs/libdwarf/patches/add-soname.patch
@@ -1,0 +1,13 @@
+diff --git libdwarf/Makefile.in libdwarf/Makefile.in
+index 28c62a9..da69093 100644
+--- libdwarf/Makefile.in
++++ libdwarf/Makefile.in
+@@ -122,7 +122,7 @@ libdwarf.a: dwarf_names.h dwarf_names.c  $(OBJS) dwarf_names.o
+ 	$(AR) $(ARFLAGS) $@ $(OBJS)  dwarf_names.o > ar-output-temp
+ 
+ libdwarf.so: dwarf_names.h dwarf_names.c $(OBJS) dwarf_names.o
+-	$(CC) $(CFLAGS) -shared $(OBJS)  dwarf_names.o -o $@
++	$(CC) $(CFLAGS) -shared $(OBJS)  dwarf_names.o -Wl,-soname,$@ -o $@
+ 
+ none:
+ 	echo "do nothing " $@

--- a/srcpkgs/libdwarf/template
+++ b/srcpkgs/libdwarf/template
@@ -1,7 +1,7 @@
 # Template build file for 'libdwarf'
 pkgname=libdwarf
 version=20150507
-revision=1
+revision=2
 build_style=configure
 configure_args="--prefix=/usr --enable-shared"
 short_desc="DWARF Debugging Information Format Library"


### PR DESCRIPTION
This is to make sure libdwarf.so is added to the shlib-provides