### PR TITLE
vim: Added flag clientserver and update version for 7.4.865

### DIFF
--- a/srcpkgs/vim/template
+++ b/srcpkgs/vim/template
@@ -1,6 +1,6 @@
 # Template file for 'vim'
 pkgname=vim
-version=7.4.827
+version=7.4.865
 revision=1
 hostmakedepends="pkg-config"
 makedepends="ncurses-devel acl-devel libXt-devel gtk+-devel perl
@@ -11,8 +11,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.vim.org"
 license="GPL-2"
 distfiles="https://github.com/${pkgname}/${pkgname}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=8920db8115c78d260abbb2757ebf0e1e64d6e2f989626435fffad1ef37a9760f
-
+checksum=b3c92b2bc6ba7933b38fdf1879f8d7014efeb7b94aead6ef82f7c4a954fb75cf
 subpackages="vim-common vim-x11 gvim"
 # XXX vim-huge cannot be cross compiled for now.
 if [ -z "$CROSS_BUILD" ]; then
@@ -63,7 +62,7 @@ do_configure() {
 		cd $wrksrc/vim-huge
 		./configure ${configure_args} ${args} --with-x=no --enable-gui=no \
 			--with-features=huge --enable-perlinterp --enable-pythoninterp \
-			--enable-rubyinterp --enable-luainterp
+			--enable-rubyinterp --enable-luainterp --enable-clientserver
 
 		cd $wrksrc/vim-huge-python3
 		./configure ${configure_args} ${args} --with-x=no --enable-gui=no \


### PR DESCRIPTION
I added to the template came to flag [ClientServer](http://vimdoc.sourceforge.net/htmldoc/remote.html#clientserver).

The reason I added this flag is for the operation of [vmail] (https://github.com/danchoi/vmail/), an email client that uses vim as backend.

Oh, I took and updated version of vim for the latest.

https://github.com/danchoi/vmail/issues/173
