### PR TITLE
libclc-git: update to 20150912

### DIFF
--- a/srcpkgs/libclc-git/template
+++ b/srcpkgs/libclc-git/template
@@ -1,7 +1,7 @@
 # Template file for 'libclc-git'
 pkgname=libclc-git
-version=20150408
-revision=2
+version=20150912
+revision=1
 build_style=configure
 hostmakedepends="git python libffi-devel libedit-devel zlib-devel llvm clang ncurses-devel"
 short_desc="Open implementation of the OpenCL C programming language"
@@ -13,7 +13,7 @@ replaces="libclc>=0"
 noarch=yes
 
 do_fetch() {
-	local _githash="69ebc81135ee35aab0154a5eed057830f962ab00"
+	local _githash="f9b8aac70c01a85cf70267320a97fe0c51fb15da"
 	local url="http://llvm.org/git/libclc.git"
 	msg_normal "Fetching source from $url ...\n"
 	git clone ${url} ${wrksrc}
@@ -22,4 +22,7 @@ do_fetch() {
 }
 do_configure() {
 	./configure.py --prefix=/usr
+}
+post_install() {
+	vlicense LICENSE.TXT
 }


### PR DESCRIPTION
Update to git hash f9b8aac70c01a85cf70267320a97fe0c51fb15da
because the previous does no longer build with llvm-3.7.0