### PR TITLE
git-annex: Fix missing man pages and helper scripts

### DIFF
--- a/srcpkgs/git-annex/template
+++ b/srcpkgs/git-annex/template
@@ -1,7 +1,7 @@
 # Template file for 'git-annex'
 pkgname=git-annex
 version=5.20150824
-revision=2
+revision=3
 nocross=yes
 build_style=haskell-stack
 stackage="lts-3.5"
@@ -18,4 +18,17 @@ checksum=45088dd5ff5a63ca38965e60843e42c1b8424b3437b58af68929cf61ef0819e4
 
 post_extract() {
 	rm -rf standalone/android/tmp
+}
+
+# These install steps are pulled from the install target in the
+# git-annex Makefile. The target can't be called directly because it is
+# comingled with the Cabal build, and we're using Stackage instead
+# Make sure they are in sync with each version upgrade
+post_install() {
+	ln -sf git-annex ${DESTDIR}/usr/bin/git-annex-shell
+
+	vmkdir usr/share/man/man1
+	vcopy man/*.1 usr/share/man/man1
+
+	vinstall bash-completion.bash 0644 usr/share/bash-completion/completions git-annex
 }


### PR DESCRIPTION
Discovered that the git-annex build was missing the man pages and helper scripts. This patch should fix that.