### PR TITLE
New package: guilt-0.36

### DIFF
--- a/srcpkgs/guilt/template
+++ b/srcpkgs/guilt/template
@@ -1,0 +1,16 @@
+# Template file for 'guilt'
+pkgname=guilt
+version=0.36
+revision=1
+noarch=yes
+build_style=gnu-makefile
+make_build_args="-C Documentation"
+make_install_args="mandir=/usr/share/man install install-doc"
+hostmakedepends="xmlto asciidoc perl"
+depends="bash git"
+short_desc="Manipulate quilt like patches on top of git"
+maintainer="Oliver Kiddle <okiddle@yahoo.co.uk>"
+license="GPL-2"
+homepage="http://repo.or.cz/w/guilt.git"
+distfiles="http://guilt.31bits.net/src/${pkgname}-${version}.tar.gz"
+checksum=34fba8e0ac59fb9729170c91e06a90a228a7d9110b13c9b06f6a6ed417aa2711


### PR DESCRIPTION
This is like quilt or mercurial queues but for git. Similar to stgit (stacked git) but patches are stored in plain text which means you can but them in turn in a separate git repository.