### PR TITLE
spotify: add xz dependency so install doesn't fail at extracting tar.xz

### DIFF
--- a/srcpkgs/spotify/template
+++ b/srcpkgs/spotify/template
@@ -13,7 +13,7 @@ build_style=fetch
 makedepends="libgpg-error-devel"
 distfiles="ftp://ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-1.5.4.tar.bz2"
 checksum="d5f88d9f41a46953dc250cdb8575129b37ee2208401b7fa338c897f667c7fb33"
-depends="binutils qt gtk+ nss GConf libXScrnSaver"
+depends="binutils qt gtk+ nss GConf libXScrnSaver xz"
 
 if test "${XBPS_TARGET_MACHINE}" = "x86_64"; then
 	_sversion=".17.1.g9b85d43.7-1_amd64"


### PR DESCRIPTION
Currently an install of spotify without xz will result in this:

```
eater@eaterofvoiddesktop ~/projects/void-packages $ sudo xbps-install spotify                                                                                               <!127><g:origin/fixSpotifyInstall> 

Name    Action    Version           New version            Download size
spotify install   -                 0.9_7                  - 

Size required on disk:        5598KB
Free space on disk:             17GB

Do you want to continue? [Y/n] Y

[*] Downloading binary packages

[*] Verifying package integrity
spotify-0.9_7: verifying RSA signature...

[*] Running transaction tasks
spotify-0.9_7: unpacking ...

[*] Configuring unpacked packages
spotify-0.9_7: configuring ...
looking up repository.spotify.com
connecting to repository.spotify.com:80
requesting http://repository.spotify.com/pool/non-free/s/spotify/spotify-client_0.9.17.1.g9b85d43.7-1_amd64.deb
spotify-client_0.9.17.1.g9b85d43.7-1_amd64.deb: 41MB [avg rate: 38MB/s]
spotify-client_0.9.17.1.g9b85d43.7-1_amd64.deb: OK
Error while extracting
ERROR: spotify-0.9_7: [configure] INSTALL script failed to execute the post ACTION: Operation not permitted
```

And after some debugging I found out xz was missing from my system and used in the post install script. 

So hereby I've added xz to the dependencies for this package, which would fix this issue.

`./xbps-src pkg spotify` ran succesfully.
`xlint template` exited with no output and exit code 0.