### PR TITLE
boswars: Fix location boswars.desktop and icon file

### DIFF
--- a/srcpkgs/boswars/template
+++ b/srcpkgs/boswars/template
@@ -1,7 +1,7 @@
 # Template file for 'boswars'
 pkgname=boswars
 version=2.7
-revision=1
+revision=2
 wrksrc="${pkgname}-${version}-src"
 hostmakedepends="pkg-config"
 makedepends="lua51-devel libtheora-devel libogg-devel libpng-devel libvorbis-devel MesaLib-devel SDL-devel"
@@ -29,6 +29,6 @@ do_install() {
 	vcopy scripts usr/share/boswars/
 	vcopy sounds usr/share/boswars/
 	vbin ${FILESDIR}/boswars
-	vinstall ${FILESDIR}/boswars.desktop 644 usr/share/applications/boswars.desktop
-	vinstall ${FILESDIR}/boswars.png 644 usr/share/pixmaps/boswars.png
+	vinstall ${FILESDIR}/boswars.desktop 644 usr/share/applications/
+	vinstall ${FILESDIR}/boswars.png 644 usr/share/pixmaps/
 }


### PR DESCRIPTION
Fixed location the boswars.desktop and boswars.png.

/home/travis/build/voidlinux/void-packages/masterdir/destdir//boswars-2.7/usr/share/applications/boswars.desktop/boswars.desktop

/home/travis/build/voidlinux/void-packages/masterdir/destdir//boswars-2.7/usr/share/pixmaps/boswars.png/boswars.png

