### PR TITLE
gpsd: add runit script

### DIFF
--- a/srcpkgs/gpsd/files/gpsd/run
+++ b/srcpkgs/gpsd/files/gpsd/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+[ -r conf ] && . ./conf
+exec /usr/bin/gpsd -N -F /run/gpsd.sock $OPTS ${DEV:=/dev/gps0}

--- a/srcpkgs/gpsd/template
+++ b/srcpkgs/gpsd/template
@@ -1,7 +1,7 @@
 # Template file for 'gpsd'
 pkgname=gpsd
 version=3.15
-revision=1
+revision=2
 build_style=scons
 patch_args=-p1
 make_build_args="dbus_export=0 gpsd_user=gpsd gpsd_group=gpsd sbindir=/usr/bin udevdir=/usr/lib/udev CC=${CC}"
@@ -35,6 +35,7 @@ pre_install() {
 }
 
 post_install() {
+	vsv gpsd
 	vlicense COPYING
 	vlicense AUTHORS
 }


### PR DESCRIPTION
Previously, I removed the /usr/lib/udev files from this package, but later realized they could be useful... Change reverted, runit script added.