### PR TITLE
New package: avidemux-2.6.10

### DIFF
--- a/srcpkgs/avidemux/patches/musl-execinfo.patch
+++ b/srcpkgs/avidemux/patches/musl-execinfo.patch
@@ -1,0 +1,30 @@
+--- avidemux_core/ADM_core/src/ADM_crashdump_unix.cpp	2015-06-10 07:42:47.000000000 +0200
++++ avidemux_core/ADM_core/src/ADM_crashdump_unix.cpp	2015-09-28 08:15:19.568394743 +0200
+@@ -31,8 +31,10 @@
+ #endif
+ #include <sys/machelf.h>
+ #else
++#if defined(__GLIBC__)
+ #include <execinfo.h>
+ #endif
++#endif
+ 
+ #include "ADM_default.h"
+ 
+@@ -166,6 +168,7 @@
+ 	if(mysaveFunction)
+ 		mysaveFunction();
+ 
++#if defined(__GLIBC__)
+ #if !defined(__HAIKU__)
+ 	char wholeStuff[2048];
+ #if !defined(__sun__)
+@@ -209,7 +212,7 @@
+ 	backtrace(fileno(stdout));
+ #endif
+ 	printf("*********** BACKTRACK **************\n");
+-
++#endif
+ 	if(myFatalFunction)
+ 		myFatalFunction("Crash", wholeStuff); // FIXME
+ 

--- a/srcpkgs/avidemux/patches/musl-memcpy.patch
+++ b/srcpkgs/avidemux/patches/musl-memcpy.patch
@@ -1,0 +1,11 @@
+--- avidemux_core/ADM_core/include/ADM_assert.h	2015-06-10 07:42:47.000000000 +0200
++++ avidemux_core/ADM_core/include/ADM_assert.h	2015-09-28 08:08:55.729367070 +0200
+@@ -69,7 +69,7 @@
+ 
+ #define ADM_dealloc(x) ADM_dezalloc( (void *)x)
+ 
+-#ifndef __APPLE__
++#if !defined(__APPLE__) && defined(__GLIBC__)
+   #define memcpy myAdmMemcpy
+ #endif
+ 

--- a/srcpkgs/avidemux/patches/musl-uint.patch
+++ b/srcpkgs/avidemux/patches/musl-uint.patch
@@ -1,0 +1,13 @@
+--- avidemux/common/ADM_requant/tcrequant.c	2015-06-10 07:42:47.000000000 +0200
++++ avidemux/common/ADM_requant/tcrequant.c	2015-09-28 08:32:51.149470555 +0200
+@@ -62,6 +62,10 @@
+ #define MODULE_NAME MODULE_TCREQUANT
+ #include "ADM_debug.h"
+ 
++#if !defined(__GLIBC__)
++typedef uint32_t uint;
++#endif
++
+ 
+ // / MEANX
+  void mixDump_c(uint8_t *p, uint32_t l);

--- a/srcpkgs/avidemux/template
+++ b/srcpkgs/avidemux/template
@@ -1,0 +1,36 @@
+# Template file for 'avidemux'
+pkgname=avidemux
+version=2.6.10
+revision=1
+wrksrc="${pkgname}_${version}"
+hostmakedepends="cmake pkg-config qt5-qmake yasm"
+# XXX: MesaLib-devel, libva-devel, libvdpau-devel, etc. and make display output work
+makedepends="faac-devel faad2-devel gettext-devel jack-devel
+ lame-devel libvorbis-devel libXv-devel sqlite-devel
+ qt5-multimedia-devel qt5-script-devel qt5-tools-devel SDL-devel
+ x264-devel x265-devel xvidcore-devel"
+depends="python"
+nocross=yes
+short_desc="Video editing and processing application"
+maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
+license="GPL-2"
+homepage="http://avidemux.sourceforge.net/"
+distfiles="http://download.oldfoss.com/Avidemux/avidemux_${version}.tar.gz"
+checksum=176c2482a0656f81e307f1505e6dfcdab086ee73e7de363617b884c5d7205aed
+
+do_build() {
+	bash bootStrap.bash --enable-qt5
+}
+do_install() {
+	# Remove Windows stuff
+	rm -r install/usr/share/ADM6_addons/avsfilter
+	cp -aR install/usr ${DESTDIR}
+	ln -s avidemux3_qt5 ${DESTDIR}/usr/bin/avidemux
+	vman man/avidemux.1
+	vinstall avidemux_icon.png 644 usr/share/pixmaps avidemux.png
+	sed avidemux2.desktop \
+		-e "s;avidemux2;avidemux3;g" \
+		-e "s;_gtk;_qt5;g" \
+		> avidemux.desktop
+	vinstall avidemux.desktop 644 usr/share/applications
+}


### PR DESCRIPTION
Closes #2626

Disabled MesaLib, vdpau and libva for now.

I couldn't get vdpau/libva to work right. I could make avidemux link
against the packages, but there was no video frame image displayed in
the UI when the output was set to va or vdpau.

Perhaps I was just missing some additional dependency.