### PR TITLE
New package: trinity-1.5

### DIFF
--- a/srcpkgs/trinity/patches/arch.h.patch
+++ b/srcpkgs/trinity/patches/arch.h.patch
@@ -1,0 +1,6 @@
+--- include/arch.h	2015-10-02 13:44:46.653183687 -0300
++++ include/arch.h.new	2015-10-02 13:44:38.297184059 -0300
+@@ -1,3 +1,4 @@
++#include <stdint.h>
+ #pragma once
+ #include "types.h"

--- a/srcpkgs/trinity/template
+++ b/srcpkgs/trinity/template
@@ -1,0 +1,20 @@
+# Template file for 'trinity'
+pkgname=trinity
+version=1.5
+revision=1
+build_style=gnu-configure
+configure_script="./configure.sh"
+short_desc="Linux system call fuzzer"
+maintainer="Diogo Leal <diogo@diogoleal.com>"
+license="GPL-2"
+only_for_archs="armv6l armv7l i686 x86_64"
+homepage="https://github.com/kernelslacker/trinity"
+distfiles="https://github.com/kernelslacker/trinity/archive/v${version}.tar.gz"
+checksum=af5213b5382f4567243e50ae445ea29368d239b351c9f22ef16b7945fdb367ef
+
+do_install(){
+	vbin trinity
+	vdoc Documentation/HACKING.txt
+	vdoc Documentation/pro-tips.txt
+	vdoc README
+}


### PR DESCRIPTION
When I use ```build_style=gnu-makefile```, occurs this errors:

```
=> trinity-1.5_1: running pre-build hook: 02-script-wrapper ... 
=> trinity-1.5_1: running do_build ... CC  arg-decoder.o arg-decoder.c:5:30: fatal error: arch.h: No such file or directory #include "arch.h" //PAGE_MASK ^ compilation terminated. Makefile:97: recipe for target 'arg-decoder.o' failed make: *** 
[arg-decoder.o] Error 1
```