### PR TITLE
New package: python-atomicwrites-0.1.8

### DIFF
--- a/srcpkgs/python-atomicwrites/template
+++ b/srcpkgs/python-atomicwrites/template
@@ -1,0 +1,32 @@
+# Template file for 'python-atomicwrites'
+pkgname=python-atomicwrites
+version=0.1.8
+revision=1
+noarch=yes
+wrksrc="atomicwrites-${version}"
+build_style="python-module"
+python_versions="2.7 3.4"
+hostmakedepends="python-setuptools python3.4-setuptools"
+depends="python"
+pycompile_module="atomicwrites"
+short_desc="Simple Python2 API for atomic file writes"
+maintainer="Oliver Kiddle <okiddle@yahoo.co.uk>"
+license="MIT"
+homepage="https://pypi.python.org/pypi/atomicwrites/"
+distfiles="${PYPI_SITE}/a/atomicwrites/atomicwrites-${version}.tar.gz"
+checksum=3274adb52bd3ae91d87ba923e0f21fd86c05b71bbaefe2ec0d6679c01f98dc8e
+
+post_install() {
+	vlicense LICENSE
+}
+
+python3.4-atomicwrites_package() {
+	noarch=yes
+	pycompile_version="3.4"
+	pycompile_module="atomicwrites"
+	short_desc="${short_desc/Python2/Python3.4}"
+	pkg_install() {
+		vmove usr/lib/python3.4
+		vlicense LICENSE
+	}
+}

--- a/srcpkgs/python3.4-atomicwrites
+++ b/srcpkgs/python3.4-atomicwrites
@@ -1,0 +1,1 @@
+python-atomicwrites


### PR DESCRIPTION
This is one of the dependencies of vdirsyncer. I don't really need the Python 3.4 variant but I guess it is good form to build both, right?
