### PR TITLE
New package: patchutils-0.3.4

### DIFF
--- a/srcpkgs/patchutils/template
+++ b/srcpkgs/patchutils/template
@@ -1,0 +1,18 @@
+# Template file for 'patchutils'
+pkgname=patchutils
+version=0.3.4
+revision=1
+build_style=gnu-configure
+hostmakedepends="perl"
+depends="perl"
+short_desc="Collection of programs that operate on patch files"
+maintainer="Oliver Kiddle <okiddle@yahoo.co.uk>"
+license="GPL-2"
+homepage="http://cyberelk.net/tim/software/patchutils/"
+distfiles="http://cyberelk.net/tim/data/patchutils/stable/${pkgname}-${version}.tar.xz"
+checksum=cf55d4db83ead41188f5b6be16f60f6b76a87d5db1c42f5459d596e81dabe876
+
+post_install() {
+	vmkdir usr/share/man/man1
+	vcopy doc/*.1 usr/share/man/man1
+}


### PR DESCRIPTION
This includes useful utilities such as interdiff (for comparing two patches), lsdiff (list affected files), splitting, combining etc.