### PR TITLE
task: install zsh completion where zsh will find it

### DIFF
--- a/srcpkgs/task/template
+++ b/srcpkgs/task/template
@@ -1,7 +1,7 @@
 # Template file for 'task'
 pkgname=task
 version=2.4.4
-revision=1
+revision=2
 hostmakedepends="cmake"
 makedepends="libuuid-devel"
 build_style="cmake"
@@ -11,3 +11,12 @@ homepage="http://taskwarrior.org/projects/taskwarrior"
 distfiles="http://www.taskwarrior.org/download/${pkgname}-${version}.tar.gz"
 checksum=7ff406414e0be480f91981831507ac255297aab33d8246f98dbfd2b1b2df8e3b
 short_desc="A command-line todo list manager"
+
+post_extract() {
+	sed -i 's, zsh,,' scripts/CMakeLists.txt
+	echo 'install (FILES zsh/_task DESTINATION share/zsh/site-functions)' >> scripts/CMakeLists.txt
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
By default, the function goes in /usr/share/doc/task/scripts/zsh. Installing it in /usr/share/zsh/site-functions means zsh users don't have to do anything to be able to use it.