### PR TITLE
python-dbus: fix arm python2.7 bindings

### DIFF
--- a/srcpkgs/python-dbus/template
+++ b/srcpkgs/python-dbus/template
@@ -1,7 +1,7 @@
 # Template file for 'python-dbus'
 pkgname=python-dbus
 version=1.2.0
-revision=6
+revision=7
 lib32disabled=yes
 wrksrc="dbus-python-${version}"
 build_style=gnu-configure
@@ -24,41 +24,45 @@ _do_pre_configure() {
 			pysufx="m"
 		fi
 
-		sed -i "s,PYTHON_INCLUDES=.*,PYTHON_INCLUDES=-I${XBPS_CROSS_BASE}/usr/include/python${pyver}${pysufx},g" ../configure
+		sed -i "s,PYTHON_INCLUDES=.*,PYTHON_INCLUDES=-I${XBPS_CROSS_BASE}/usr/include/python${pyver}${pysufx},g" configure
 	fi
+}
+
+pre_configure() {
+	mkdir -p python2
+	mv * python2 || true
+	cp -a python2 python3.4
 }
 
 do_configure() {
 	# python2
-	mkdir ${wrksrc}/build-python2
-	cd ${wrksrc}/build-python2
+	cd ${wrksrc}/python2
 	_do_pre_configure
-	env PYTHON=python ../configure ${configure_args}
+	env PYTHON=python ./configure ${configure_args}
 
 	# python3.4
-	mkdir ${wrksrc}/build-python3.4
-	cd ${wrksrc}/build-python3.4
+	cd ${wrksrc}/python3.4
 	_do_pre_configure 3.4
-	env PYTHON=python3.4 ../configure ${configure_args}
+	env PYTHON=python3.4 ./configure ${configure_args}
 }
 
 do_build() {
 	# python2
-	cd ${wrksrc}/build-python2
+	cd ${wrksrc}/python2
 	make ${makejobs}
 
 	# python3.4
-	cd ${wrksrc}/build-python3.4
+	cd ${wrksrc}/python3.4
 	make ${makejobs}
 }
 
 do_install() {
 	# python2
-	cd ${wrksrc}/build-python2
+	cd ${wrksrc}/python2
 	make DESTDIR=${DESTDIR} install
 
 	# python3.4
-	cd ${wrksrc}/build-python3.4
+	cd ${wrksrc}/python3.4
 	make DESTDIR=${DESTDIR} install
 }
 


### PR DESCRIPTION
This is a fix for following error I encountered on `armv7hf`:

```sh
$ python2.7 -c 'import dbus; print dbus.version'  
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python2.7/site-packages/dbus/__init__.py", line 82, in <module>
    import dbus.types as types
  File "/usr/lib/python2.7/site-packages/dbus/types.py", line 6, in <module>
    from _dbus_bindings import (
ImportError: /usr/lib/python2.7/site-packages/_dbus_bindings.so: undefined symbol: PyBytes_Type
```

From the `python2.7`  `config.log` [here](http://pastebin.com/w7zCVkAh), on lines 344 and 346 you can see there's some cross contamination between `python2.7` and `python3.4`.
