### PR TITLE
gtkmm2: compile with -std=c++11

### DIFF
--- a/srcpkgs/gtkmm2/template
+++ b/srcpkgs/gtkmm2/template
@@ -1,7 +1,7 @@
 # Template build file for 'gtkmm'.
 pkgname=gtkmm2
 version=2.24.4
-revision=3
+revision=4
 wrksrc=gtkmm-${version}
 build_style=gnu-configure
 configure_args="--disable-static --disable-documentation"
@@ -13,6 +13,8 @@ license="LGPL-2.1"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 distfiles="${GNOME_SITE}/gtkmm/2.24/gtkmm-$version.tar.xz"
 checksum=443a2ff3fcb42a915609f1779000390c640a6d7fd19ad8816e6161053696f5ee
+
+CXXFLAGS="-std=c++11"
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh


### PR DESCRIPTION
Some header file which is included when building gtkmm2
now requires the c++ compiler to support c++11.