### PR TITLE
Update lsb_release

### DIFF
--- a/srcpkgs/base-files/files/lsb_release
+++ b/srcpkgs/base-files/files/lsb_release
@@ -1,3 +1,6 @@
 #!/bin/sh
-echo Void
+
+printf "Distributor ID:\tVoid\n"
+printf "Description:\tVoid Linux\n"
+printf "Release:\trolling\n"
 exit 0

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,6 +1,6 @@
 # Template file for 'base-files'
 pkgname=base-files
-version=0.132
+version=0.133
 revision=1
 bootstrap=yes
 depends="xbps-triggers"


### PR DESCRIPTION
Certain tools expect the output of lsb_release to be in a specific
format.  This commit alters the output of lsb_release to use this
format such that those tools can correctly identify the system as
Void Linux.