### PR TITLE
New package: khal-0.6.0

### DIFF
--- a/srcpkgs/khal/template
+++ b/srcpkgs/khal/template
@@ -1,0 +1,27 @@
+# Template file for 'khal'
+pkgname=khal
+version=0.6.0
+revision=1
+build_style=python-module
+python_versions="2.7"
+pycompile_module="khal"
+hostmakedepends="python-setuptools"
+depends="python-click python-configobj python-dateutil python-icalendar python-pytz python-setproctitle python-sqlite python-tzlocal python-urwid python-xdg vdirsyncer"
+short_desc="Command-line calendar build around CalDAV"
+maintainer="Oliver Kiddle <okiddle@yahoo.co.uk>"
+license="MIT"
+homepage="http://lostpackets.de/khal/"
+distfiles="${PYPI_SITE}/k/khal/khal-${version}.tar.gz"
+checksum=1a2e8d56d20b12ed2c3ef2468ff0ce0c658a8a566b249821b0f4b30cce8ada9a
+
+pre_build() {
+	sed -e '/setuptools_scm/d' \
+		-e '/pkginfo/d' \
+		-e "s/use_scm_version=True,/version=\"${version}\",/" \
+		-i setup.py
+}
+
+post_install() {
+	vlicense COPYING
+	vinstall misc/__khal 644 usr/share/zsh/site-functions
+}


### PR DESCRIPTION
Command-line calendar that works with vdirsyncer for accessing caldav servers.