### PR TITLE
New package: python-vobject-0.8.1c

### DIFF
--- a/srcpkgs/python-vobject/template
+++ b/srcpkgs/python-vobject/template
@@ -1,0 +1,16 @@
+# Template file for 'python-vobject'
+pkgname=python-vobject
+version=0.8.1c
+revision=1
+wrksrc=vobject-${version}
+noarch=yes
+build_style=python-module
+pycompile_module="vobject"
+hostmakedepends="python-setuptools"
+depends="python-dateutil"
+short_desc="Vobject parses and creates iCalendar and vCard files in Python2"
+maintainer="Oliver Kiddle <okiddle@yahoo.co.uk>"
+license="Apache-2.0"
+homepage="http://vobject.skyhouseconsulting.com/"
+distfiles="http://vobject.skyhouseconsulting.com/vobject-${version}.tar.gz"
+checksum=594113117f2017ed837c8f3ce727616f9053baa5a5463a7420c8249b8fc556f5


### PR DESCRIPTION
Needed for khard which is similarish to khal but for carddav rather than caldav.