### PR TITLE
lua-MessagePack: rename to lua52-MessagePack; fix lua5.2 dependencies

### DIFF
--- a/srcpkgs/lua52-MessagePack/template
+++ b/srcpkgs/lua52-MessagePack/template
@@ -1,20 +1,23 @@
-# Template file for 'lua-MessagePack'
-pkgname=lua-MessagePack
+# Template file for 'lua52-MessagePack'
+pkgname=lua52-MessagePack
 version=0.3.3
-revision=1
-hostmakedepends="lua"
+revision=2
 noarch=yes
-makedepends="lua"
-depends="lua>=5.2"
+wrksrc="${pkgname/52/}-${version}"
+hostmakedepends="lua52"
+makedepends="lua52"
+depends="lua52>=5.2"
 short_desc="A pure Lua implementation of msgpack.org"
 maintainer="Tj Vanderpoel (bougyman) <tj@rubyists.com>"
 license="MIT"
 homepage="https://github.com/fperrad/lua-MessagePack"
 distfiles="${homepage}/archive/${version}.tar.gz"
 checksum=40e86eacac87f4deaa566cdefaaa1ec6ca90ad14a9419805ea90d069736cfda6
+replaces="lua-MessagePack>=0"
 
 do_install() {
 	make PREFIX=/usr DESTDIR="${DESTDIR}" LUAVER=5.2 install
+	vlicense COPYRIGHT LICENSE
 }
 
 


### PR DESCRIPTION
Maybe this should be renamed to `lua52-MessagePack`? Or update it to use use `lua5.3` and add a `lua5.2` subpackage, because I *do* need a `lua5.2` version.