### PR TITLE
base-files: implement lsb_release options

### DIFF
--- a/srcpkgs/base-files/files/lsb_release
+++ b/srcpkgs/base-files/files/lsb_release
@@ -1,6 +1,81 @@
 #!/bin/sh
+#
+# Compatibility script for FSG lsb_release v1.4 or newer
+#
+version="1.0"
+distributor_id="VoidLinux"
+description="Void Linux"
+release="rolling"
+codename="void"
+options=""
+short=0
 
-printf "Distributor ID:\tVoid\n"
-printf "Description:\tVoid Linux\n"
-printf "Release:\trolling\n"
+while [ $# -gt 0 ]; do
+	case "$1" in
+	-v|--version) options="${options} version" ;;
+	-i|--id) options="${options} distributor_id" ;;
+	-d|--description) options="${options} description" ;;
+	-r|--release) options="${options} release" ;;
+	-c|--codename) options="${options} codename" ;;
+	-a|--all) options="version distributor_id description release codename" ;;
+	-s|--short) short=1 ;;
+	-h|--help) cat << _EOF
+SYNOPSIS
+	lsb_release [OPTION]...
+OPTIONS
+	−v, −−version
+	Display the version of the LSB specification against which the distribution is compliant.
+
+	−i, −−id
+	Display the string id of the distributor.
+
+	−d, −−description
+	Display the single line text description of the distribution.
+
+	−r, −−release
+	Display the release number of the distribution.
+
+	−c, −−codename
+	Display the codename according to the distribution release.
+
+	−a, −−all
+	Display all of the above information.
+
+	−s, −−short
+	Display all of the above information in short output format.
+
+	−h, −−help
+	Display this message.
+_EOF
+	esac
+	shift
+done
+
+[ -z "$options" ] && options="version"
+
+if [ "$short" -eq 1 ]; then
+	space=""
+	for opt in $options; do
+		case "$opt" in
+			version) printf "${space}${version}" ;;
+			distributor_id) printf "${space}${distributor_id}" ;;
+			description) printf "${space}\"${description}\"" ;;
+			release) printf "${space}${release}" ;;
+			codename) printf "${space}${codename}" ;;
+		esac
+		space=" "
+	done
+	printf "\n"
+else
+	for opt in $options; do
+		case "$opt" in
+			version) printf "LSB Version:\t${version}\n" ;;
+			distributor_id) printf "Distributor ID:\t${distributor_id}\n" ;;
+			description) printf "Description:\t${description}\n" ;;
+			release) printf "Release:\t${release}\n" ;;
+			codename) printf "Codename:\t${codename}\n" ;;
+		esac
+	done
+fi
+
 exit 0

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,6 +1,6 @@
 # Template file for 'base-files'
 pkgname=base-files
-version=0.133
+version=0.134
 revision=1
 bootstrap=yes
 depends="xbps-triggers"


### PR DESCRIPTION
Some packages rely on FSG compliant output of lsb_release.
Implement according to http://man.cx/lsb_release for v1.4