### PR TITLE
fluxbox: unbreak musl by disabling nls

### DIFF
--- a/srcpkgs/fluxbox/template
+++ b/srcpkgs/fluxbox/template
@@ -18,6 +18,9 @@ license="MIT"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=fc8c75fe94c54ed5a5dd3fd4a752109f8949d6df67a48e5b11a261403c382ec0
 
+case "$XBPS_TARGET_MACHINE" in
+	*-musl) configure_args="${configure_args/enable-nls/disable-nls}" ;;
+esac
 post_install() {
 	vinstall ${FILESDIR}/fluxbox.desktop 644 usr/share/xsessions
 	vlicense COPYING


### PR DESCRIPTION
Unfortunately we don't have gencat for musl libc.