### PR TITLE
rspamd: fix cross armv[67]l

### DIFF
--- a/srcpkgs/rspamd/patches/enable-curve25519-donna_c.patch
+++ b/srcpkgs/rspamd/patches/enable-curve25519-donna_c.patch
@@ -1,0 +1,12 @@
+Enable curve25519-donn.c for non x86
+
+--- src/libcryptobox/CMakeLists.txt	2015-10-15 14:13:46.000000000 +0200
++++ src/libcryptobox/CMakeLists.txt	2015-10-18 02:33:14.705237158 +0200
+@@ -56,6 +56,7 @@
+ 	SET(CURVESRC ${CURVESRC} ${CMAKE_CURRENT_SOURCE_DIR}/curve25519/curve25519-donna.c)
+ ELSE()
+ 	SET(POLYSRC ${POLYSRC} ${CMAKE_CURRENT_SOURCE_DIR}/poly1305/ref-32.c)
++	SET(CURVESRC ${CURVESRC} ${CMAKE_CURRENT_SOURCE_DIR}/curve25519/curve25519-donna.c)
+ ENDIF()
+ 
+ IF(HAVE_AVX2)

--- a/srcpkgs/rspamd/template
+++ b/srcpkgs/rspamd/template
@@ -1,7 +1,7 @@
 # Template file for 'rspamd'
 pkgname=rspamd
 version=1.0.6
-revision=1
+revision=2
 build_style=cmake
 configure_args="
  -DRSPAMD_USER=rspamd \


### PR DESCRIPTION
This fixes the [linker error](http://build.voidlinux.eu/builders/armv7l_builder/builds/18562/steps/shell_3/logs/stdio) (missing scalarmult_donna symbol),
but I don't know if it also works.