### PR TITLE
grantlee: update to 0.5.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1247,6 +1247,8 @@ libdbusmenu-gtk3.so.4 libdbusmenu-gtk3-12.10.2_1
 libdbusmenu-qt.so.2 libdbusmenu-qt-0.9.2_1
 libgrantlee_gui.so.0 grantlee-0.3.0_1
 libgrantlee_core.so.0 grantlee-0.3.0_1
+libGrantlee_Templates.so.5 grantlee5-5.0.0_1
+libGrantlee_TextDocument.so.5 grantlee5-5.0.0_1
 libattica.so.0.4 attica-0.4.2_1
 libqca.so.2 qca-2.0.3_1
 librasqal.so.3 librasqal-0.9.30_1

--- a/srcpkgs/grantlee5-devel
+++ b/srcpkgs/grantlee5-devel
@@ -1,0 +1,1 @@
+grantlee5

--- a/srcpkgs/grantlee5/template
+++ b/srcpkgs/grantlee5/template
@@ -1,18 +1,19 @@
-# Template file for 'grantlee'
-pkgname=grantlee
-version=0.5.1
+# Template file for 'grantlee5'
+pkgname=grantlee5
+version=5.0.0
 revision=1
+wrksrc=${pkgname%5}-${version}
 build_style=cmake
 hostmakedepends="cmake"
-makedepends="qt-devel"
-short_desc="Qt4 string template engine based on the Django template system"
+makedepends="qt5-devel qt5-script-devel qt5-tools-devel"
+short_desc="Qt5 string template engine based on the Django template system"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="LGPL-3"
 homepage="https://github.com/steveire/grantlee"
 distfiles="${homepage}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=7669a57c9a2bee24956b1daf6e63a10847172b4c46650345a9a5d14b2686e664
+checksum=0fbb796b1fe1bf8de1793f58748f83d0902991e9bad6f19fb3cc2f3cc808d7c5
 
-grantlee-devel_package() {
+grantlee5-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {


### PR DESCRIPTION
Change homepage because gitorious.org is moving to the
Internet Archive. Also create a new package grantlee5,
because newer versions (>5.0.0) link against Qt5.