### PR TITLE
libusb: update to 1.0.20

### DIFF
--- a/srcpkgs/libusb/template
+++ b/srcpkgs/libusb/template
@@ -1,7 +1,7 @@
 # Template file for 'libusb'
 pkgname=libusb
-version=1.0.19
-revision=3
+version=1.0.20
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libudev-devel"
@@ -10,7 +10,8 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="LGPL-2.1"
 homepage="http://libusb.info"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.tar.bz2"
-checksum=6c502c816002f90d4f76050a6429c3a7e0d84204222cbff2dce95dd773ba6840
+checksum=cb057190ba0a961768224e4dc6883104c6f945b2bf2ef90d7da39e7c1834f7ff
+disable_parallel_build=yes
 
 libusb-devel_package() {
 	depends="libusb>=${version}_${revision}"


### PR DESCRIPTION
Need to disable paralle builds because they sometimes
fail. This seems to be a general libtool problem.