### PR TITLE
zsh-syntax-highlighting: install version and revision-hash

### DIFF
--- a/srcpkgs/zsh-syntax-highlighting/template
+++ b/srcpkgs/zsh-syntax-highlighting/template
@@ -1,7 +1,7 @@
 # Template file for 'zsh-syntax-highlighting'
 pkgname=zsh-syntax-highlighting
 version=0.3.0
-revision=1
+revision=2
 noarch=yes
 depends="zsh"
 short_desc="Fish shell like syntax highlighting for Zsh"
@@ -13,6 +13,8 @@ checksum=e2b79e095eb90c539da5ff41892f0c6e8934f1c0bf93b090313172e1be441b26
 
 do_install() {
 	vinstall ${pkgname}.zsh 644 usr/share/zsh/plugins/${pkgname}
+	vinstall .version 644 usr/share/zsh/plugins/${pkgname}
+	vinstall .revision-hash 644 usr/share/zsh/plugins/${pkgname}
 	vcopy highlighters usr/share/zsh/plugins/${pkgname}
 	vlicense COPYING.md
 }


### PR DESCRIPTION
i'm getting these errors:
```
/usr/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh:33: no such file or directory: /usr/share/zsh/plugins/zsh-syntax-highlighting/.version
/usr/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh:34: no such file or directory: /usr/share/zsh/plugins/zsh-syntax-highlighting/.revision-hash
```