### PR TITLE
inkscape: fix optimized export

### DIFF
--- a/srcpkgs/inkscape/template
+++ b/srcpkgs/inkscape/template
@@ -1,7 +1,7 @@
 # Template file for 'inkscape'
 pkgname=inkscape
 version=0.91
-revision=9
+revision=10
 build_style=gnu-configure
 configure_args="--enable-lcms --enable-poppler-cairo
  --without-gnome-vfs --disable-static"
@@ -10,7 +10,7 @@ makedepends="
  popt-devel libpng-devel gsl-devel gc-devel gtkmm2-devel libxslt-devel
  lcms2-devel poppler-glib-devel boost-devel libmagick-devel
  libvisio-devel libwpg-devel libcdr-devel dbus-glib-devel libgomp-devel"
-depends="desktop-file-utils hicolor-icon-theme"
+depends="desktop-file-utils hicolor-icon-theme python-lxml"
 short_desc="Vector-based drawing program"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://inkscape.org/"


### PR DESCRIPTION
inkscape needs python-lxml for the optimized svg export to work.