### PR TITLE
qutebrowser: update to 0.4.1.

### DIFF
--- a/srcpkgs/qutebrowser/template
+++ b/srcpkgs/qutebrowser/template
@@ -1,6 +1,6 @@
 # Template file for 'qutebrowser'
 pkgname=qutebrowser
-version=0.4.0
+version=0.4.1
 revision=1
 build_style=python-module
 python_versions="3.4"
@@ -13,7 +13,7 @@ maintainer="Eivind Uggedal <eivind@uggedal.com>"
 license="GPL-3"
 homepage="http://qutebrowser.org/"
 distfiles="https://github.com/The-Compiler/${pkgname}/releases/download/v${version}/${pkgname}-${version}.tar.gz"
-checksum=ddfb33cef8d40eb34e29705b201d3a87cfe360809846462135b2d5b67393c8d8
+checksum=6e1022e4b349fd09bd8efa643d2411badb8305fee911d266db5dce66290a3ed7
 
 pre_build() {
 	a2x -f manpage doc/${pkgname}.1.asciidoc


### PR DESCRIPTION
I'm not the maintainer of the package, but the upstream author :wink:

v0.4.0 breaks with later versions of Python 3.4 (and with 3.5) - just got a crash report because of that, so I thought I'd quickly update the package.

cc @uggedal 