### PR TITLE
mksh: register 'sh' alternatives group.

### DIFF
--- a/srcpkgs/mksh/template
+++ b/srcpkgs/mksh/template
@@ -1,7 +1,7 @@
 # Template file for 'mksh'
 pkgname=mksh
 version=R51
-revision=1
+revision=2
 wrksrc=mksh
 build_pie=yes
 register_shell="/bin/mksh"
@@ -11,6 +11,10 @@ homepage="https://www.mirbsd.org/mksh.htm"
 license="MirOS"
 distfiles="https://www.mirbsd.org/MirOS/dist/mir/${pkgname}/${pkgname}-${version}.tgz"
 checksum="9feeaa5ff33d8199c0123675dec29785943ffc67152d58d431802bc20765dadf"
+
+alternatives="
+ sh:sh:/usr/bin/mksh
+ sh:sh.1:/usr/share/man/man1/mksh.1"
 
 build_options="static"
 


### PR DESCRIPTION
This change registers the MirBSD KornShell `mksh(1)` with the `sh` alternatives group.