### PR TITLE
Update gradle version in executable

### DIFF
--- a/srcpkgs/gradle/files/gradle
+++ b/srcpkgs/gradle/files/gradle
@@ -2,6 +2,6 @@
 APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 APP_HOME="/usr/lib/gradle"
-APP_VERSION=2.6
+APP_VERSION=2.8
 
 java $JAVA_OPTS -classpath $APP_HOME/lib/gradle-launcher-$APP_VERSION.jar org.gradle.launcher.GradleMain "$@"


### PR DESCRIPTION
This commit makes the version consistent with the version actually shipped with this package, which fixes gradle exiting with an error on launch.