### PR TITLE
00-distfiles.sh: add code to purge wrong checksum

### DIFF
--- a/srcpkgs/drbd-utils/template
+++ b/srcpkgs/drbd-utils/template
@@ -1,10 +1,12 @@
 # Template file for 'drbd'
 pkgname=drbd-utils
 version=8.9.4
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="
  --sbindir=/usr/bin \
+ --prefix=/usr \
+ --exec-prefix=/usr \
  --libexecdir=/usr/libexec \
  --with-distro=generic \
  --with-bashcompletion \
@@ -21,13 +23,27 @@ maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="GPL-2"
 homepage="http://www.drbd.org"
 makedepends="eudev-libudev-devel"
-hostmakedepends="flex pkg-config eudev"
+hostmakedepends="automake libtool flex pkg-config eudev libxslt"
 distfiles="http://oss.linbit.com/drbd/drbd-utils-$version.tar.gz"
-checksum=01a8924f8bc1370fc91e0495989d69b65c3b08346006d614d4b1dbdcd1caade5
+checksum=38929279d1bf549fd1ade4ce6773a6fe209db51bbb0efe7bf6d2b7871ba0afbc
+
+if [ -n "$CROSS_BUILD" ]; then
+	hostmakedepends+=" drbd-utils"
+fi
 
 pre_configure() {
-	sed -i 's#^/lib#/usr/lib#' drbd.spec.in
-	sed -i 's#$(DESTDIR)/lib/#$(DESTDIR)/usr/lib/#g' $(find -name Makefile.in)
+	sed -i 's#/lib/drbd#/usr/lib/drbd#' drbd.spec.in
+	NOCONFIGURE=1 ./autogen.sh
+	find -name "*.c" -exec sed -i "{}" -e 's#sys/poll\.h#poll.h#g' \;
+	find -name Makefile.in -exec sed -i "{}" -e 's#$(DESTDIR)/lib#$(DESTDIR)/usr/lib#g' \;
+	if [ -n "$CROSS_BUILD" ]; then
+		# Replace drbdsetup{,-83,84} with the /usr/bin or /usr/libexec counterparts
+		find -name Makefile.in -exec sed -i "{}" \
+			-e 's#^\(\s\)../../user/v83/drbdsetup-83#\1/usr/libexec/drbdsetup-83#' \
+			-e 's#^\(\s\)../../user/v84/drbdsetup-84#\1/usr/libexec/drbdsetup-84#' \
+			-e 's#^\(\s\)../../user/v9/drbdsetup#\1/usr/bin/drbdsetup#' \
+		\;
+	fi
 }
 
 post_install() {


### PR DESCRIPTION
If a distfile changed its checksum (SHA256) without at the same time
also changing its version, the distfile cache needs to be purged.

This is done by verifying only for already existing distfiles that the
specified checksum matches. If it does not, the file and its entry in
/host/sources/by_sha256 are purged using the inode number of the file.

The second loop then as usual fetches the distfiles and verifies their
checksum against the list entry.