### PR TITLE
Revert "zsh: register 'sh' alternatives group."

### DIFF
--- a/srcpkgs/zsh/template
+++ b/srcpkgs/zsh/template
@@ -1,7 +1,7 @@
 # Template file for 'zsh'
 pkgname=zsh
 version=5.1.1
-revision=2
+revision=3
 lib32disabled=yes
 build_pie=yes
 build_style=gnu-configure
@@ -25,10 +25,6 @@ homepage="http://www.zsh.org"
 license="zsh"
 distfiles="http://www.zsh.org/pub/zsh-$version.tar.xz"
 checksum=74e9453b5470b3c0970f9f93cfd603d241c3d7b1968adc0e4b3951073e8d3dec
-
-alternatives="
- sh:sh:/usr/bin/zsh
- sh:sh.1:/usr/share/man/man1/zsh.1"
 
 pre_configure() {
 	# Set correct keymap path


### PR DESCRIPTION
zsh is no POSIX compatible shell. They are working on it, but I think, that it will have many bad implications to use it as an sh alternative.