### PR TITLE
New package: spim-8.0

### DIFF
--- a/srcpkgs/spim/template
+++ b/srcpkgs/spim/template
@@ -1,0 +1,32 @@
+# Template file for spim
+
+pkgname="spim"
+version="8.0"
+revision=1
+homepage="http://spimsimulator.sourceforge.net/"
+license="BSD"
+distfiles="http://pages.cs.wisc.edu/~larus/SPIM/spim-${version}.tar.gz"
+checksum="6f205776cb9fa112729507008843b289012190ed3131cbd426c610a58387ee4b"
+maintainer="Toyam Cox <vaelatern@gmail.com>"
+hostmakedepends="flex"
+short_desc="Self-contained simulator/debugger that runs MIPS32 programs"
+do_configure() {
+	cd spim
+	sed '/Copyright (c) 1990-2010, James R. Larus./,+26!d' README > LICENSE
+	sed -i Makefile \
+	-e 's:EXCEPTION_DIR = /usr/local/lib/spim:EXCEPTION_DIR = /usr/share/spim:' \
+	-e 's:CFLAGS =:CFLAGS +=:' \
+	-e 's:LDFLAGS =:LDFLAGS +=:' \
+	-e 's:CC = gcc:CC ?= gcc:'
+	CC="$CC" CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" ./Configure
+}
+do_install() {
+	vbin spim/spim
+	vman Documentation/spim.man spim.1
+	vlicense spim/LICENSE LICENSE.BSD
+	vinstall CPU/exceptions.s 755 /usr/share/spim/
+}
+do_build() {
+	cd spim
+	make
+}


### PR DESCRIPTION
This is a zip file from the creator's homepage, not the project homepage. The code for spim has not changed in a while. It is still often used in university classes, as the creator acknowledges. I took a hint from of Gentoo and FreeBSD's ports, and just built spim from [here](http://pages.cs.wisc.edu/~larus/SPIM/) instead of fiddling with SVN checkouts. Since the page in question belongs to the author (Dr. James Larus), I feel it is an acceptable substitute to the official project page (where there are not zip files or tarballs for easy download).