### PR TITLE
blackbird-themes was installed as Blacbird (sic:k)

### DIFF
--- a/srcpkgs/blackbird-themes/template
+++ b/srcpkgs/blackbird-themes/template
@@ -14,5 +14,5 @@ checksum="ca31362254df2d336b2b090deb925f19a1dba72632ed9c7f82cf406be89ec1e6"
 do_install() {
 	tar xzf v${version}.tar.gz
 	vmkdir usr/share/themes
-	vcopy Blackbird-${version} usr/share/themes/Blacbird
+	vcopy Blackbird-${version} usr/share/themes/Blackbird
 }


### PR DESCRIPTION
This patch corrects a minor misspelling that caused the blackbird-themes
package to be installed as "Blacbird" (note the missing "k" in "Black").