### PR TITLE
sun7i-kernel: update to 3.4.104.

### DIFF
--- a/srcpkgs/sun7i-kernel/files/config
+++ b/srcpkgs/sun7i-kernel/files/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 3.4.103 Kernel Configuration
+# Linux/arm 3.4.104 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_SYS_SUPPORTS_APM_EMULATION=y
@@ -169,6 +169,7 @@ CONFIG_HAVE_REGS_AND_STACK_ACCESS_API=y
 CONFIG_HAVE_CLK=y
 CONFIG_HAVE_DMA_API_DEBUG=y
 CONFIG_HAVE_ARCH_JUMP_LABEL=y
+CONFIG_HAVE_ARCH_SECCOMP_FILTER=y
 
 #
 # GCOV-based kernel profiling

--- a/srcpkgs/sun7i-kernel/template
+++ b/srcpkgs/sun7i-kernel/template
@@ -1,18 +1,24 @@
 # Template file for 'sun7i-kernel'
 #
-# Latest commit as of 20141009
-_githash="0c7986b137afd15670df1f66c83031a2c5d7b10c"
+# Latest commit as of 20151114
+_githash="a8f8ba9ba383c2358d67b4dcaa5ce5cd4f0dd587"
 _gitshort="${_githash:0:7}"
 
 pkgname=sun7i-kernel
-version=3.4.103
-revision=4
+version=3.4.104
+revision=1
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.kernel.org"
 license="GPL-2"
 short_desc="Linux kernel for sun7i (${version%.*} series [git ${_gitshort}])"
-distfiles="https://github.com/linux-sunxi/linux-sunxi/archive/${_githash}.tar.gz"
-checksum=fb836df43e0f981ed33a18b4b8009360d6cbb5695f378ccb4b2d9fb30d310ca3
+
+_patchurl="https://raw.githubusercontent.com/archlinuxarm/PKGBUILDs/5c82068/core/linux-sun7i"
+distfiles="https://github.com/linux-sunxi/linux-sunxi/archive/${_githash}.tar.gz
+ ${_patchurl}/0001-Backport-firmware-loader.patch
+ ${_patchurl}/0001-Backport-msdos-partition-UUIDs.patch"
+checksum="c7f5881b6338a94deb78fdb02dee57f7db20170fd80ddbe8663e8d0791db1ebe
+ eeceb6459f2f40c91a6a5be8d8c60e68dec2631ec84d6165721edacb059507c4
+ f0bba58788f090dd213df0bde1ea0ce38999a8d28bebe443c899cb9cbc2b5eed"
 
 wrksrc="linux-sunxi-${_githash}"
 _kernver="${version}_${revision}"
@@ -33,17 +39,17 @@ mutable_files="
 	/usr/lib/modules/${_kernver}/modules.alias.bin
 	/usr/lib/modules/${_kernver}/modules.devname"
 
+post_extract() {
+	# Apply backported kernel firmware changes required by eudev>=2.1.
+	patch -p1 -i ${XBPS_BUILDDIR}/0001-Backport-firmware-loader.patch
+	# Apply backported kernel msdos partition UUID changes
+	patch -p1 -i ${XBPS_BUILDDIR}/0001-Backport-msdos-partition-UUIDs.patch
+}
+
 do_configure() {
 	if [ "$CROSS_BUILD" ]; then
 		_args="CROSS_COMPILE=${XBPS_CROSS_TRIPLET}-"
 	fi
-
-	# Apply backported kernel firmware changes required by eudev>=2.1.
-	$XBPS_FETCH_CMD https://raw.githubusercontent.com/archlinuxarm/PKGBUILDs/master/core/linux-sun7i/0001-Backport-firmware-loader.patch
-	patch -p1 -i 0001-Backport-firmware-loader.patch
-	# Apply backported kernel msdos partition UUID changes
-	$XBPS_FETCH_CMD https://raw.githubusercontent.com/archlinuxarm/PKGBUILDs/master/core/linux-sun7i/0001-Backport-msdos-partition-UUIDs.patch
-	patch -p1 -i 0001-Backport-msdos-partition-UUIDs.patch
 
 	unset LDFLAGS
 	if [ -f ${FILESDIR}/config ]; then


### PR DESCRIPTION
archlinuxarm removed `core/linux-sun7i` in favor of multi-platform, mainline armv7 kernel, so now the link to the patches are dead.