### PR TITLE
New package: gumbo-parser-0.10.1

### DIFF
--- a/srcpkgs/gumbo-parser-devel
+++ b/srcpkgs/gumbo-parser-devel
@@ -1,0 +1,1 @@
+gumbo-parser

--- a/srcpkgs/gumbo-parser/template
+++ b/srcpkgs/gumbo-parser/template
@@ -1,0 +1,26 @@
+# Template file for 'gumbo-parser'
+pkgname=gumbo-parser
+version=0.10.1
+revision=1
+build_style=gnu-configure
+hostmakedepends="autoconf automake libtool"
+short_desc="An HTML5 parsing library in pure C99"
+maintainer="Oliver Kiddle <okiddle@yahoo.co.uk>"
+license="Apache-2.0"
+homepage="https://github.com/google/gumbo-parser"
+distfiles="https://github.com/google/gumbo-parser/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
+checksum=28463053d44a5dfbc4b77bcf49c8cee119338ffa636cc17fc3378421d714efad
+
+pre_configure() {
+	NOCONFIGURE=1 ./autogen.sh
+}
+
+gumbo-parser-devel_package() {
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+	}
+}


### PR DESCRIPTION
The same source tarball also includes a python module along with a setup.py which should ideally also be packaged. I'm only actually interested in having the C library available myself but if you have suggestions on how to combine the gnu-configure and python-module build styles then let me know.