### PR TITLE
urxvt-perls: remove xsel dependency

### DIFF
--- a/srcpkgs/urxvt-perls/template
+++ b/srcpkgs/urxvt-perls/template
@@ -1,8 +1,8 @@
 # Template file for 'urxvt-perls'
 pkgname=urxvt-perls
 version=2.2
-revision=2
-depends="rxvt-unicode perl xsel"
+revision=3
+depends="rxvt-unicode perl"
 short_desc="Perl extensions for the rxvt-unicode terminal emulator"
 maintainer="nem <nem@posteo.net>"
 license="GPL-2"


### PR DESCRIPTION
The clipboard script does not depend upon xsel. It can be configured to use any command.

Sorry, this time with just one commit.