### PR TITLE
libwebsockets: update to 1.5

### DIFF
--- a/srcpkgs/libwebsockets/template
+++ b/srcpkgs/libwebsockets/template
@@ -1,9 +1,9 @@
 # Template file for 'libwebsockets'
 pkgname=libwebsockets
-version=1.4
-_ffver=36
-_chromever=43
-revision=5
+version=1.5
+revision=1
+_ffver=41
+_chromever=47
 build_style=cmake
 hostmakedepends="cmake"
 makedepends="zlib-devel libressl-devel libev-devel"
@@ -12,9 +12,9 @@ short_desc="Lightweight client and server websocket library"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="LGPL-2"
 homepage="https://libwebsockets.org"
-wrksrc=libwebsockets-$version-chrome$_chromever-firefox-$_ffver
+wrksrc=libwebsockets-$version-chrome$_chromever-firefox$_ffver
 distfiles="http://git.libwebsockets.org/cgi-bin/cgit/libwebsockets/snapshot/$wrksrc.tar.gz"
-checksum=e11492477e582ef0b1a6ea2f18d81a9619b449170a3a5c43f32a9468461a9798
+checksum=27f3e2dbd04b8375923f6353536c741559a21dd4713f8c302b23441d6fe82403
 CFLAGS="-Wno-error"
 
 libwebsockets-devel_package() {
@@ -22,7 +22,6 @@ libwebsockets-devel_package() {
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/bin
-		vmove usr/lib/cmake
 		vmove usr/share/libwebsockets-test-server
 		vmove usr/include
 		vmove usr/lib/pkgconfig


### PR DESCRIPTION
Update libwebsockets to 1.5 - note that /usr/lib/cmake is no longer installed due to upstream change:
http://git.libwebsockets.org/cgi-bin/cgit/libwebsockets/commit/CMakeLists.txt?id=3ae1badae7a05e0982e0dfbcb078da3d4b92a81d