### PR TITLE
libsasl: fix for build -fPIE

### DIFF
--- a/srcpkgs/libsasl/patches/0012-fix-ac_cv_names.patch
+++ b/srcpkgs/libsasl/patches/0012-fix-ac_cv_names.patch
@@ -1,0 +1,48 @@
+--- a/saslauthd/configure.in	2015-11-20 16:22:07.295862770 +0100
++++ b/saslauthd/configure.in	2015-11-20 16:23:35.581855882 +0100
+@@ -164,30 +164,30 @@
+ 
+ dnl Checks for which function macros exist
+ AC_MSG_CHECKING(whether $CC implements __func__)
+-AC_CACHE_VAL(have_func,
++AC_CACHE_VAL(ac_cv_have_func,
+ [AC_TRY_LINK([#include <stdio.h>],[printf("%s", __func__);],
+-have_func=yes,
+-have_func=no)])
+-AC_MSG_RESULT($have_func)
+-if test "$have_func" = yes; then
++ac_cv_have_func=yes,
++ac_cv_have_func=no)])
++AC_MSG_RESULT($ac_cv_have_func)
++if test "$ac_cv_have_func" = yes; then
+        AC_DEFINE(HAVE_FUNC,[],[Does the compiler understand __func__])
+ else
+        AC_MSG_CHECKING(whether $CC implements __PRETTY_FUNCTION__)
+-       AC_CACHE_VAL(have_pretty_function,
++       AC_CACHE_VAL(ac_cv_have_pretty_function,
+        [AC_TRY_LINK([#include <stdio.h>],[printf("%s", __PRETTY_FUNCTION__);],
+-       have_pretty_function=yes,
+-       have_pretty_function=no)])
+-       AC_MSG_RESULT($have_pretty_function)
+-       if test "$have_pretty_function" = yes; then
++       ac_cv_have_pretty_function=yes,
++       ac_cv_have_pretty_function=no)])
++       AC_MSG_RESULT($ac_cv_have_pretty_function)
++       if test "$ac_cv_have_pretty_function" = yes; then
+                AC_DEFINE(HAVE_PRETTY_FUNCTION,[],[Does compiler understand __PRETTY_FUNCTION__])
+        else
+                AC_MSG_CHECKING(whether $CC implements __FUNCTION__)
+-               AC_CACHE_VAL(have_function,
++               AC_CACHE_VAL(ac_cv_have_function,
+                [AC_TRY_LINK([#include <stdio.h>],[printf("%s", __FUNCTION__);],
+-               have_function=yes,
+-               have_function=no)])
+-               AC_MSG_RESULT($have_function)
+-               if test "$have_function" = yes; then
++               ac_cv_have_function=yes,
++               ac_cv_have_function=no)])
++               AC_MSG_RESULT($ac_cv_have_function)
++               if test "$ac_cv_have_function" = yes; then
+                        AC_DEFINE(HAVE_FUNCTION,[],[Does compiler understand __FUNCTION__])
+                fi
+        fi

--- a/srcpkgs/libsasl/template
+++ b/srcpkgs/libsasl/template
@@ -1,14 +1,14 @@
 # Template file for 'libsasl'
 pkgname=libsasl
 version=2.1.26
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-cram --enable-digest --enable-auth-sasldb
  --enable-plain --enable-anon --enable-login --enable-gssapi --enable-ntlm
  --with-configdir=/etc/sasl2:/etc/sasl:/usr/lib/sasl2
  --disable-otp --disable-srp --disable-srp-setpass --disable-krb4
  --with-devrandom=/dev/urandom"
-hostmakedepends="automake libtool pkg-config"
+hostmakedepends="automake libtool mit-krb5-devel pkg-config"
 makedepends="db-devel mit-krb5-devel"
 wrksrc="cyrus-sasl-${version}"
 short_desc="Cyrus SASL - runtime shared libraries"
@@ -19,36 +19,42 @@ distfiles="ftp://ftp.cyrusimap.org/cyrus-sasl/cyrus-sasl-${version}.tar.gz"
 checksum=8fbc5136512b59bb793657f36fadda6359cae3b08f01fd16b3d406f1345b7bc3
 
 patch_args="-Np1"
-disable_parallel_build=yes
+
+# Seems to be cured with libtool>=2.4.6
+# disable_parallel_build=yes
 
 pre_configure() {
 	# XXX
 	if [ "$CROSS_BUILD" ]; then
 		sed 's,AC_TRY_RUN,AC_TRY_LINK_FUNC,' -i cmulocal/sasl2.m4
 	fi
-	rm -f config/config.guess config/config.sub
-	rm -f config/ltconfig config/ltmain.sh config/libtool.m4
-	rm -fr autom4te.cache
-	libtoolize -c
-	aclocal -I config -I cmulocal
-	automake -a -c
-	autoheader
-	autoconf
 
-	pushd saslauthd
-	rm -f config/config.guess config/config.sub
-	rm -f config/ltconfig config/ltmain.sh config/libtool.m4
-	rm -fr autom4te.cache
-	libtoolize -c
-	aclocal -I config -I ../cmulocal -I ../config
-	automake -a -c
-	autoheader
-	autoconf
-	popd
+	# Remove outdated files
+	rm -f config/config.{guess,sub}
+	rm -f config/lt{config,main.sh} config/libtool.m4
+
+	# Rename configure.in for fewer warnings
+	mv configure.{in,ac}
+
+	# Avoid picking up the target LDFLAGS for makemd5
+	sed -i include/Makefile.am -e "/^CFLAGS/a LDFLAGS ="
+
+	# Rename configure.in for fewer warnings
+	mv saslauthd/configure.{in,ac}
+
+	# Remove check for KRB4; otherwise we would need mt-krb4-devel
+	rm -f config/kerberos_v4.m4
+
+	# Remove placeholder for KRB4 library
+	find -name Makefile.am -exec sed -i "{}" -e "s;= @SASL_KRB_LIB@;= ;" \;
+
+	autoreconf -I $(pwd)/config -I $(pwd)/cmulocal -i -f
 }
 post_install() {
 	# We are only interested in libsasl.
 	rm -rf ${DESTDIR}/usr/{sbin,share,lib/sasl2}
+
+	vlicense COPYING
 }
 
 libsasl-devel_package() {


### PR DESCRIPTION
+ Patch saslauthd/configure.ac to use ac_cv_name variables
+ Remove check for Kerberos4 (we don't support it)
+ Use autoreconf once

Closes #3022