### PR TITLE
common.sh: set BUILD_XXXFLAGS as autoconf defaults

### DIFF
--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -391,9 +391,13 @@ setup_pkg() {
     export CPP_FOR_BUILD="cpp"
     export LD_FOR_BUILD="ld"
     export CFLAGS_FOR_BUILD="$XBPS_CFLAGS"
+    export BUILD_CFLAGS="$XBPS_CFLAGS"
     export CXXFLAGS_FOR_BUILD="$XBPS_CXXFLAGS"
+    export BUILD_CXXFLAGS="$XBPS_CXXFLAGS"
     export CPPFLAGS_FOR_BUILD="$XBPS_CPPFLAGS"
+    export BUILD_CPPFLAGS="$XBPS_CPPFLAGS"
     export LDFLAGS_FOR_BUILD="$XBPS_LDFLAGS"
+    export BUILD_LDFLAGS="$XBPS_LDFLAGS"
 
     if [ -n "$cross" ]; then
         export CC="${XBPS_CROSS_TRIPLET}-gcc"


### PR DESCRIPTION
Some autotool files (configure.ac) expect host build flags to be
defined as BUILD_CFLAGS, BUILD_CXXFLAGS, BUILD_CPPFLAGS and
BUILD_LDFLAGS. Especially these files tend to default to
LDFLAGS for BUILD_LDFLAGS, which makes host utilities built
with these flags fail with buildpie=yes because of differing
compiler and linker options.

One example is libatasmart where this patch fixes the build.