### PR TITLE
chromium-widevine: new chrome version 46.0.2490.86

### DIFF
--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -1,30 +1,29 @@
 # Template file for 'chromium-widevine'
-_chromeVersion=46.0.2490.80
-_chromeRevision=1
-_channel='stable'
-_baseUrl='http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable'
+_chromeVersion="46.0.2490.86"
+_chromeRevision="1"
+_channel="stable"
+_baseUrl="http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable"
 
 pkgname=chromium-widevine
 version=${_chromeVersion}
-revision=5
+revision=1
 short_desc="A browser plugin designed for the viewing of premium video content"
 maintainer="Benjamin Hoffmeyer <hoffmeyer25@gmail.com>"
 homepage="http://www.google.com/chrome"
 license="chrome"
-lib32disabled=yes
-repository=nonfree
 only_for_archs="i686 x86_64"
 depends="chromium binutils xz"
+repository=nonfree
 create_wrksrc=yes
 
 case "${XBPS_TARGET_MACHINE}" in
 x86_64)
 	_filename=google-chrome-${_channel}_${_chromeVersion}-${_chromeRevision}_amd64.deb
-	_chromeChecksum=307fac6999f68092c5aa65524e17f5bc9e9f7cbb7d0e09e601bb6f62eda15c85
+	_chromeChecksum="29c434fe640825a88ca5871ce31b8cba9994776dc5c3c99e579998f14e3455ac"
 	;;
 i686)
 	_filename=google-chrome-${_channel}_${_chromeVersion}-${_chromeRevision}_i386.deb
-	_chromeChecksum=6d3fcd532b1483d961edc4bd65aef79980b41587e736857ff2869ad34732e6b1
+	_chromeChecksum="c8e8d548af976508d235f36fd73fd91515842dab4371b8cd6732e2c8b283016d"
 	;;
 esac
 _chromeUrl="${_baseUrl}/${_filename}"


### PR DESCRIPTION
old url was broken on chromium-pepper-flash, so I ~~stole the pepper flash url & sha~~updated it with the new ones to this since so it works again/