### PR TITLE
doxygen: fix bogus flex version checks

### DIFF
--- a/srcpkgs/doxygen/patches/fix-version_check.patch
+++ b/srcpkgs/doxygen/patches/fix-version_check.patch
@@ -1,0 +1,75 @@
+--- src/code.l	2015-05-31 21:01:12.000000000 +0200
++++ src/code.l	2015-11-21 16:51:03.196986482 +0100
+@@ -3695,7 +3695,7 @@
+ extern "C" { // some bogus code to keep the compiler happy
+   void codeYYdummy() { yy_flex_realloc(0,0); } 
+ }
+-#elif YY_FLEX_SUBMINOR_VERSION<33
++#elif YY_FLEX_MAJOR_VERSION==2 && YY_FLEX_MINOR_VERSION==5 && YY_FLEX_SUBMINOR_VERSION<33
+ #error "You seem to be using a version of flex newer than 2.5.4 but older than 2.5.33. These versions do NOT work with doxygen! Please use version <=2.5.4 or >=2.5.33 or expect things to be parsed wrongly!"
+ #endif
+ 
+--- src/fortrancode.l	2015-05-31 21:01:12.000000000 +0200
++++ src/fortrancode.l	2015-11-21 21:50:13.726585997 +0100
+@@ -1306,7 +1306,7 @@
+ extern "C" { // some bogus code to keep the compiler happy
+   void fortrancodeYYdummy() { yy_flex_realloc(0,0); } 
+ }
+-#elif YY_FLEX_SUBMINOR_VERSION<33
++#elif YY_FLEX_MAJOR_VERSION==2 && YY_FLEX_MINOR_VERSION==5 && YY_FLEX_SUBMINOR_VERSION<33
+ #error "You seem to be using a version of flex newer than 2.5.4 but older than 2.5.33. These versions do NOT work with doxygen! Please use version <=2.5.4 or >=2.5.33 or expect things to be parsed wrongly!"
+ #else
+ extern "C" { // some bogus code to keep the compiler happy
+--- src/vhdlcode.l	2015-05-31 21:01:12.000000000 +0200
++++ src/vhdlcode.l	2015-11-21 21:52:24.840575768 +0100
+@@ -1613,7 +1613,7 @@
+ extern "C" { // some bogus code to keep the compiler happy
+   void vhdlcodeYYdummy() { yy_flex_realloc(0,0); } 
+ }
+-#elif YY_FLEX_SUBMINOR_VERSION<33
++#elif YY_FLEX_MAJOR_VERSION==2 && YY_FLEX_MINOR_VERSION==5 && YY_FLEX_SUBMINOR_VERSION<33
+ #error "You seem to be using a version of flex newer than 2.5.4 but older than 2.5.33. These versions do NOT work with doxygen! Please use version <=2.5.4 or >=2.5.33 or expect things to be parsed wrongly!"
+ #endif
+ 
+--- src/xmlcode.l	2015-05-31 21:01:12.000000000 +0200
++++ src/xmlcode.l	2015-11-21 21:53:38.411570028 +0100
+@@ -407,7 +407,7 @@
+ extern "C" { // some bogus code to keep the compiler happy
+   void xmlcodeYYdummy() { yy_flex_realloc(0,0); } 
+ }
+-#elif YY_FLEX_SUBMINOR_VERSION<33
++#elif YY_FLEX_MAJOR_VERSION==2 && YY_FLEX_MINOR_VERSION==5 && YY_FLEX_SUBMINOR_VERSION<33
+ #error "You seem to be using a version of flex newer than 2.5.4. These are currently incompatible with 2.5.4, and do NOT work with doxygen! Please use version 2.5.4 or expect things to be parsed wrongly! A bug report has been submitted (#732132)."
+ #endif
+ 
+--- src/pycode.l	2015-05-31 21:01:12.000000000 +0200
++++ src/pycode.l	2015-11-21 21:58:01.071549535 +0100
+@@ -1503,7 +1503,7 @@
+ extern "C" { // some bogus code to keep the compiler happy
+   void pycodeYYdummy() { yy_flex_realloc(0,0); } 
+ }
+-#elif YY_FLEX_SUBMINOR_VERSION<33
++#elif YY_FLEX_MAJOR_VERSION==2 && YY_FLEX_MINOR_VERSION==5 && YY_FLEX_SUBMINOR_VERSION<33
+ #error "You seem to be using a version of flex newer than 2.5.4. These are currently incompatible with 2.5.4, and do NOT work with doxygen! Please use version 2.5.4 or expect things to be parsed wrongly! A bug report has been submitted (#732132)."
+ #endif
+ 
+--- src/commentscan.l	2015-05-31 21:01:12.000000000 +0200
++++ src/commentscan.l	2015-11-21 22:06:11.285511289 +0100
+@@ -1103,7 +1103,7 @@
+ 					      // but we need to know the position in the input buffer where this 
+ 					      // rule matched.
+ 					      // for flex 2.5.33+ we should use YY_CURRENT_BUFFER_LVALUE
+-#if YY_FLEX_MINOR_VERSION>=5 && YY_FLEX_SUBMINOR_VERSION>=33
++#if YY_FLEX_MINOR_VERSION>=6 || (YY_FLEX_MINOR_VERSION==5 && YY_FLEX_SUBMINOR_VERSION>=33)
+ 					      inputPosition=prevPosition + (int)(yy_bp - YY_CURRENT_BUFFER_LVALUE->yy_ch_buf);
+ #else
+ 					      inputPosition=prevPosition + (int)(yy_bp - yy_current_buffer->yy_ch_buf);
+@@ -1165,7 +1165,7 @@
+                                           g_memberGroupHeader.resize(0);
+ 					  parseMore=TRUE;
+                                           needNewEntry = TRUE;
+-#if YY_FLEX_MINOR_VERSION>=5 && YY_FLEX_SUBMINOR_VERSION>=33
++#if YY_FLEX_MINOR_VERSION>=6 || (YY_FLEX_MINOR_VERSION==5 && YY_FLEX_SUBMINOR_VERSION>=33)
+ 				          inputPosition=prevPosition + (int)(yy_bp - YY_CURRENT_BUFFER_LVALUE->yy_ch_buf) + strlen(yytext);
+ #else
+ 				          inputPosition=prevPosition + (int)(yy_bp - yy_current_buffer->yy_ch_buf) + strlen(yytext);

--- a/srcpkgs/doxygen/template
+++ b/srcpkgs/doxygen/template
@@ -1,7 +1,7 @@
 # Template file for 'doxygen'
 pkgname=doxygen
 version=1.8.10
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="cmake perl python flex"
 short_desc="Source code documentation generator tool"


### PR DESCRIPTION
The checks did not take care of a change in YY_FLEX_MINOR_VERSION
and now failed for flex>=2.6.0