### PR TITLE
libdca: add libm to LDFLAGS

### DIFF
--- a/srcpkgs/libdca/template
+++ b/srcpkgs/libdca/template
@@ -1,7 +1,7 @@
 # Template file for 'libdca'
 pkgname=libdca
 version=0.0.5
-revision=8
+revision=9
 build_style=gnu-configure
 short_desc="DTS Coherent Acoustics decoder"
 homepage="http://www.videolan.org/developers/libdca.html"
@@ -9,6 +9,8 @@ license="GPL-2"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 distfiles="http://download.videolan.org/pub/videolan/$pkgname/$version/$pkgname-$version.tar.bz2"
 checksum=dba022e022109a5bacbe122d50917769ff27b64a7bba104bd38ced8de8510642
+
+LDFLAGS="-lm"
 
 post_install() {
 	# Fix manpage links.


### PR DESCRIPTION
When linking the pow(3) and log(3) functions are not found.