### PR TITLE
mozjs24: set nopie=yes

### DIFF
--- a/srcpkgs/mozjs24/template
+++ b/srcpkgs/mozjs24/template
@@ -1,7 +1,7 @@
 # Template file for 'mozjs24'
 pkgname=mozjs24
 version=24.2.0
-revision=5
+revision=6
 wrksrc="mozjs-${version}"
 build_wrksrc="js/src"
 build_style=gnu-configure
@@ -13,6 +13,7 @@ license="MPL-1.1, GPL-2, LGPL-2.1"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 distfiles="${MOZILLA_SITE}/js/mozjs-${version}.tar.bz2"
 checksum=e62f3f331ddd90df1e238c09d61a505c516fe9fd8c5c95336611d191d18437d8
+nopie=yes
 
 do_configure() {
 	local _args


### PR DESCRIPTION
It won't build with PIE, because configure detects a compiler bug.