### PR TITLE
gnome: batch update packages

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -855,8 +855,7 @@ libcolorhug.so.2 libcolord-1.1.7_1
 libnm-gtk.so.0 libnm-gtk-0.9.1.95_1
 libcaribou.so.0 caribou-0.4.0_1
 libgupnp-av-1.0.so.2 gupnp-av-0.10.0_1
-libgrilo-0.2.so.1 grilo-0.2.0_1
-libgrilo-0.2.so.10 grilo-0.2.13_1
+libgrilo-0.2.so.1 grilo-0.2.14_1
 libgrlnet-0.2.so.0 grilo-0.2.0_1
 libgrlpls-0.2.so.0 grilo-0.2.9_1
 libquvi.so.7 libquvi-0.4.0_1

--- a/srcpkgs/anjuta/template
+++ b/srcpkgs/anjuta/template
@@ -1,6 +1,6 @@
 # Template file for 'anjuta'
 pkgname=anjuta
-version=3.18.0
+version=3.18.2
 revision=1
 build_style=gnu-configure
 build_options="gir"
@@ -10,7 +10,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="https://projects.gnome.org/anjuta"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=6a3fec0963f04bc62a9dfb951e577a3276d39c3414083ef73163c3fea8e741ba
+checksum=be864f2f1807e1b870697f646294e997d221d5984a135245543b719e501cef8e
 
 hostmakedepends="pkg-config intltool flex itstool python autogen glib-devel
  $(vopt_if gir gobject-introspection)"

--- a/srcpkgs/bijiben/template
+++ b/srcpkgs/bijiben/template
@@ -1,6 +1,6 @@
 # Template file for 'bijiben'
 pkgname=bijiben
-version=3.18.1
+version=3.18.2
 revision=1
 build_style=gnu-configure
 configure_args="--disable-update-mimedb"
@@ -16,4 +16,4 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://live.gnome.org/Apps/Bijiben"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=07bb0872cb78a02c967bafa1cc4f46e84c7d0c2a8b8b4fa1d1f579b897b366ee
+checksum=45fed3242ba092138760b99e725f0a4d3c8d749ef37c607d43c8f010e11a645d

--- a/srcpkgs/eog-plugins/template
+++ b/srcpkgs/eog-plugins/template
@@ -1,6 +1,6 @@
 # Template file for 'eog-plugins'
 pkgname=eog-plugins
-version=3.16.2
+version=3.16.3
 revision=1
 lib32disabled=yes
 build_style=gnu-configure
@@ -15,4 +15,4 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=f33de3c78d6a7d8a89441daa9c3e49e043dcdc527b0b7d477f0bf2d3af08e534
+checksum=2d2198ed026b1c28329ac3d353b3031c2024277d81d60f3c1e626f4701a73bd2

--- a/srcpkgs/eog/template
+++ b/srcpkgs/eog/template
@@ -1,7 +1,7 @@
 # Template file for 'eog'
 pkgname=eog
-version=3.18.0
-revision=2
+version=3.18.1
+revision=1
 lib32disabled=yes
 build_style=gnu-configure
 build_options="gir"
@@ -17,7 +17,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/eog/${version%.*}/eog-$version.tar.xz"
-checksum=740b2942ea52fbcdbacb0988e07193113017e0607cf5779769c82723b1685e28
+checksum=7b7bb47a680518701e2e724c8632fcf12dcb3c3e45ce1f2bdd4c4ace325793a7
 
 if [ -z "$CROSS_BUILD" ]; then
 	build_options_default="gir"

--- a/srcpkgs/epiphany/template
+++ b/srcpkgs/epiphany/template
@@ -1,6 +1,6 @@
 # Template file for 'epiphany'
 pkgname=epiphany
-version=3.18.0
+version=3.18.1
 revision=1
 build_style=gnu-configure
 configure_args="--disable-schemas-compile --disable-tests"
@@ -17,4 +17,4 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org/projects/epiphany/"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=d5ba67a8cd85c80b81e076862bcab3fc376ba51b0a1536ca7430608d1f50491d
+checksum=12938e2616aef5dd95635bfc899e332ab6b096b6d4dc5b79093e3c6267219c0c

--- a/srcpkgs/evince/template
+++ b/srcpkgs/evince/template
@@ -1,13 +1,13 @@
 # Template file for 'evince'
 pkgname=evince
-version=3.18.1
+version=3.18.2
 revision=1
 short_desc="GNOME Document viewer for multiple document formats"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://projects.gnome.org/evince/"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=7b5023765e6d6fb98da582fe3adc4f268f87b2f35110634e12cdac40f7aa8c31
+checksum=42ad6c7354d881a9ecab136ea84ff867acb942605bcfac48b6c12e1c2d8ecb17
 
 build_style=gnu-configure
 build_options="gir"

--- a/srcpkgs/evolution-data-server/template
+++ b/srcpkgs/evolution-data-server/template
@@ -1,7 +1,7 @@
 # Template file for 'evolution-data-server'
 pkgname=evolution-data-server
-version=3.18.1
-revision=3
+version=3.18.2
+revision=1
 build_style=gnu-configure
 configure_args="--with-openldap --disable-uoa
  --with-krb5=${XBPS_CROSS_BASE}/usr
@@ -18,7 +18,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://www.gnome.org"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=4fe7c520a49d4c7fd67ed6fc2dfb33667f6138368c7bbe3ecd8c4ad2356771bc
+checksum=5942fc1cf395acdc15425939d83824d861d01c57225ee3fc8c1d77009468ce9b
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/evolution/template
+++ b/srcpkgs/evolution/template
@@ -1,6 +1,6 @@
 # Template file for 'evolution'
 pkgname=evolution
-version=3.18.1
+version=3.18.2
 revision=1
 build_style=gnu-configure
 configure_args="--disable-pst-import --with-openldap --disable-bogofilter
@@ -19,7 +19,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://www.gnome.org"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=31aa63c1b6e08ed07af92ffa104ef711d317cd91f9fb9d89fc1be33e09995aa4
+checksum=91b83efaba7e6964657eaa17d4ba820335688fe78c6e85d4a0d337303ed14a8c
 
 evolution-devel_package() {
 	depends="GConf-devel gtkhtml-devel>=4.6.0 evolution-data-server-devel

--- a/srcpkgs/gedit/template
+++ b/srcpkgs/gedit/template
@@ -1,6 +1,6 @@
 # Template file for 'gedit'
 pkgname=gedit
-version=3.18.1
+version=3.18.2
 revision=1
 build_style=gnu-configure
 build_options="gir"
@@ -17,7 +17,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=5ad5aeb01b0a299bb7c154e82fcff96e1a722617fcc4e39b3b57ddcbe88363cd
+checksum=856e451aec29ee45980011de57cadfe89c3cbc53968f6cc865f8efe0bd0d49b1
 
 gedit-devel_package() {
 	depends="gtksourceview-devel>=3.16 libpeas-devel>=1.9"

--- a/srcpkgs/gnome-bluetooth/template
+++ b/srcpkgs/gnome-bluetooth/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-bluetooth'
 pkgname=gnome-bluetooth
-version=3.18.0
+version=3.18.1
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --disable-desktop-update
@@ -14,7 +14,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://live.gnome.org/GnomeBluetooth"
 license="GPL-2, LGPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=f5c0d43226c4ec6a545dddb86181adadbc2b5cf720b640026003b9660fba0b8f
+checksum=c51d5b896d32845a2b5bb6ccd48926c88c8e9ef0915c32d3c56cb7e7974d4a49
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/gnome-calculator/template
+++ b/srcpkgs/gnome-calculator/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-calculator'
 pkgname=gnome-calculator
-version=3.18.1
+version=3.18.2
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool itstool gnome-doc-utils"
@@ -13,4 +13,4 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=1cfae1c2d4e8a39cdc584e2add5022cd5824e6c6539deded60f4b2c4054f9b5c
+checksum=c86c5857409ce1d01896904e97ccf0a1a880f3dcf428a524e5c0fec27b274d64

--- a/srcpkgs/gnome-contacts/template
+++ b/srcpkgs/gnome-contacts/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-contacts'
 pkgname=gnome-contacts
-version=3.18.0
+version=3.18.1
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool $(vopt_if gir gobject-introspection)"
@@ -13,7 +13,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=c81ad739a1f554e4c89979564565e32ceaf1d2cc6c93a6a75d929d7d1fe8e287
+checksum=0418d25e70e73c05f4db58ce843819ef91180a21531549a832eafeaf2700cf26
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/gnome-control-center/template
+++ b/srcpkgs/gnome-control-center/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-control-center'
 pkgname=gnome-control-center
-version=3.18.1
-revision=3
+version=3.18.2
+revision=1
 build_style=gnu-configure
 configure_args="--disable-static --with-cheese"
 short_desc="The GNOME control center"
@@ -9,7 +9,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://www.gnome.org"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=9a59ec1fe03d873a75a669d933f6e37d8243252ff41850da2a9009e99b578b41
+checksum=36fe6157247d2b7c8a98dbb3dbcde1c3a6f9e5e8fcc9ccf357e2b2417578f8ad
 
 hostmakedepends="pkg-config intltool glib-devel gnome-doc-utils gobject-introspection"
 makedepends="

--- a/srcpkgs/gnome-desktop/template
+++ b/srcpkgs/gnome-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-desktop'
 pkgname=gnome-desktop
-version=3.18.1
+version=3.18.2
 revision=1
 build_style=gnu-configure
 configure_args="--with-gnome-distributor=void"
@@ -13,7 +13,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2, LGPL-2.1"
 homepage="http://www.gnome.org"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=ecabbc41f551b7db2686260d35f43fbce4527dc111dd799dbf6395ffa1af772b
+checksum=ddd46d022de137543a71f50c7392b32f9b98d5d3f2b53040b35f5802de2e7b56
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/gnome-documents/template
+++ b/srcpkgs/gnome-documents/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-documents'
 pkgname=gnome-documents
-version=3.18.1
+version=3.18.2
 revision=1
 lib32disabled=yes
 build_style=gnu-configure
@@ -16,7 +16,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=a2184e34de6fb243d39cdcb83473831fc79a651ece3fcf9264f0faf40e08c477
+checksum=850ddaf3366549bbe0696c2ec3a36faf16438b387b8e9cb7812c7d5266a74cd4
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/gnome-getting-started-docs/template
+++ b/srcpkgs/gnome-getting-started-docs/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-gettings-stated-docs'
 pkgname=gnome-getting-started-docs
-version=3.18.1
+version=3.18.2
 revision=1
 noarch="yes"
 build_style=gnu-configure
@@ -10,4 +10,4 @@ short_desc="Getting Started documentation for GNOME"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=296d744d828ca5b60baeffbc158e4aa5ea844fcd13e6a22ed3fc9048c0568866
+checksum=5f4a39d51aba3669d84ce2cb06619a09a92103f58d4bc6728db448398b1f308b

--- a/srcpkgs/gnome-maps/template
+++ b/srcpkgs/gnome-maps/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-maps'
 pkgname=gnome-maps
-version=3.18.1
+version=3.18.2
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool glib-devel $(vopt_if gir gobject-introspection)"
@@ -13,7 +13,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://live.gnome.org/Design/Apps/Maps"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=0f07bf1248705b9b78cd734f788c3d910e9bf34dff6c8595eda9fe1e13686ff9
+checksum=693ff1559252eabe5d8c9c7354333b5aa1996e870936456d15706a0e0bac9278
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/gnome-music/template
+++ b/srcpkgs/gnome-music/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-music'
 pkgname=gnome-music
-version=3.18.0
+version=3.18.2
 revision=1
 lib32disabled=yes
 build_style=gnu-configure
@@ -14,7 +14,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://live.gnome.org/Apps/Music"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=e2e4b99a57c7b5c83ce3deccd38880cbafb875b423ab276204af523bc648d69c
+checksum=81b6ae8b4193774a1dc05e77c59ad8ff5e7debc0aea30ce2ecd13b2ceda10bff
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/gnome-online-accounts/template
+++ b/srcpkgs/gnome-online-accounts/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-online-accounts'
 pkgname=gnome-online-accounts
-version=3.18.1
-revision=2
+version=3.18.2.1
+revision=1
 build_style=gnu-configure
 configure_args="$(vopt_enable gir introspection)
  --enable-google --enable-kerberos --enable-flickr --enable-telepathy
@@ -16,8 +16,8 @@ short_desc="GNOME service to access online accounts"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2"
-distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=6cde6b0966936c533447da8a23cade74de33b7dd6a801e1f8198b890e776c2c2
+distfiles="${GNOME_SITE}/$pkgname/${version%.*.*}/$pkgname-$version.tar.xz"
+checksum=ca0a9c58ea5ac08437ed68fea9e8c3de69a8804e670ccf5a578c6786096ecfac
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/gnome-online-miners/template
+++ b/srcpkgs/gnome-online-miners/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-online-miners'
 pkgname=gnome-online-miners
 version=3.14.3
-revision=3
+revision=4
 lib32disabled=yes
 build_style=gnu-configure
 configure_args="--disable-static"

--- a/srcpkgs/gnome-photos/template
+++ b/srcpkgs/gnome-photos/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-photos'
 pkgname=gnome-photos
-version=3.18.1
+version=3.18.2
 revision=1
 build_style=gnu-configure
 configure_args="--disable-schemas-compile"
@@ -15,7 +15,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=b0226d41bcb6fb822212b34bfaf5b84f8fd550ed97ea1770b64f591a82f106ed
+checksum=7f6169c663b7a0e1b971d5af4def3d9a633e16a24e7d2c593b51be0053f9a0d8
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/gnome-settings-daemon/template
+++ b/srcpkgs/gnome-settings-daemon/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-settings-daemon'
 pkgname=gnome-settings-daemon
-version=3.18.1
-revision=3
+version=3.18.2
+revision=1
 build_style=gnu-configure
 configure_args="--disable-static --disable-schemas-compile --enable-cups"
 hostmakedepends="pkg-config intltool libxslt docbook-xsl glib-devel"
@@ -17,7 +17,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-3"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=fa621a17f1d132fe60461020b0dad20a9fab6b0e3e651628aaa53a8f6a6df2c0
+checksum=3071c7258f22684f7f64b7f735821e4cb25f59fc4665eb08e8d86b560e72fc6f
 
 pre_configure() {
 	# XXX workaround wrong paths for build

--- a/srcpkgs/gnome-shell-extensions/template
+++ b/srcpkgs/gnome-shell-extensions/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-shell-extensions'
 pkgname=gnome-shell-extensions
-version=3.18.1
+version=3.18.2
 revision=1
 noarch="yes"
 build_style=gnu-configure
@@ -13,4 +13,4 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://live.gnome.org/GnomeShell/Extensions"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=7a7535420c0c808d28b5912ed42cfb221930010193083f2d8a7719ea1ffa1cc2
+checksum=cc514ffc896ed8c04853a89cb8e97058f9d5518313becf7c92aea5210b8adf61

--- a/srcpkgs/gnome-shell/template
+++ b/srcpkgs/gnome-shell/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-shell'
 pkgname=gnome-shell
-version=3.18.1
+version=3.18.3
 revision=1
 build_style=gnu-configure
 configure_args="--disable-schemas-compile --disable-systemd LDFLAGS="
@@ -21,7 +21,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://live.gnome.org/GnomeShell"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=14a15215b3e29a25b94f69c58a6565e3a8cb2259b1ca242b906af78172bf3845
+checksum=8517baf8606f970ebf38222411eb7563cab2ae5efbfb088954ce23705b67519b
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/gnome-sound-recorder/template
+++ b/srcpkgs/gnome-sound-recorder/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-sound-recorder'
 pkgname=gnome-sound-recorder
-version=3.18.1
+version=3.18.2
 revision=1
 lib32disabled=yes
 build_style=gnu-configure
@@ -13,7 +13,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=f2d1a862ef5effc1b4c76a3d0fba46d9d33b2e75a6f135ecd54541b5c64da680
+checksum=6f008f81ae760cee297a6a3c8e8b9418005c06897bff973a1e845a4f8c3e202b
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/gnome-system-monitor/template
+++ b/srcpkgs/gnome-system-monitor/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-system-monitor'
 pkgname=gnome-system-monitor
-version=3.18.0.1
-revision=2
+version=3.18.2
+revision=1
 build_style=gnu-configure
 configure_args="--disable-schemas-compile --enable-wnck --disable-systemd"
 hostmakedepends="which pkg-config intltool itstool glib-devel gnome-doc-utils"
@@ -10,5 +10,5 @@ short_desc="Process viewer and system resource monitor for GNOME"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2"
-distfiles="${GNOME_SITE}/$pkgname/${version%.*.*}/$pkgname-$version.tar.xz"
-checksum=71ff8db2fa3eb53d8f54ffd612c6679b231a9d69c13adb91cf63421425953b10
+distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
+checksum=9e4a5d6aefa362448f301907fe07f3889e3dd7824922ceef8c48a7808be3e666

--- a/srcpkgs/gnome-terminal/template
+++ b/srcpkgs/gnome-terminal/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-terminal'
 pkgname=gnome-terminal
-version=3.18.1
+version=3.18.2
 revision=1
 lib32disabled=yes
 build_style=gnu-configure
@@ -16,4 +16,4 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=6eecc81f38c8019d9f49b8950cd814da88d84a8d98c9da98a57be06a1b9f4119
+checksum=5e35c0fa1395258bab83952cfabe4c1828b8655bcd761f8faed70b452bd89efa

--- a/srcpkgs/gnome-tweak-tool/template
+++ b/srcpkgs/gnome-tweak-tool/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-tweak-tool'
 pkgname=gnome-tweak-tool
-version=3.18.0
+version=3.18.1
 revision=1
 noarch=yes
 nocross=yes
@@ -14,4 +14,4 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://live.gnome.org/GnomeTweakTool"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=6c07b9b869d8fdd8625506003bd2c9869fdc798bfb6ba14e168fae7a54ad9b72
+checksum=5c2c1103237648413c2d63a941e06b7057d6b102276b5968517753075de29430

--- a/srcpkgs/grilo/template
+++ b/srcpkgs/grilo/template
@@ -1,7 +1,7 @@
 # Template file for 'grilo'
 pkgname=grilo
-version=0.2.13
-revision=2
+version=0.2.14
+revision=1
 build_style=gnu-configure
 configure_args="--disable-static --disable-vala $(vopt_enable gir introspection)"
 hostmakedepends="automake libtool pkg-config gettext-devel intltool gnome-common
@@ -12,7 +12,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="LGPL-2.1"
 homepage="http://live.gnome.org/Grilo"
 distfiles="${GNOME_SITE}/$pkgname/0.2/$pkgname-$version.tar.xz"
-checksum=f16c12271bb9a7270e58866e1b7d1914b4a447245af44eaf4f4dffe073458838
+checksum=79c82ea1747ae7430a648aa9660e44d88d48c968bcdaeb3b2c5cb97e1c921ccd
 
 # Package build options
 build_options="gir"

--- a/srcpkgs/gucharmap/template
+++ b/srcpkgs/gucharmap/template
@@ -1,6 +1,6 @@
 # Template file for 'gucharmap'
 pkgname=gucharmap
-version=3.18.1
+version=3.18.2
 revision=1
 build_style=gnu-configure
 configure_args="--disable-schemas-compile $(vopt_enable gir introspection)"
@@ -13,7 +13,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=b286d09dcd7811e6678e3d5830970d310d5730f7be5657ec400295df0b36fa35
+checksum=80141d3e892c3c4812c1a8fad8f89978559ef19e933843267e6e9a5524c09ec9
 
 # Package build options
 build_options="gir"

--- a/srcpkgs/mutter/template
+++ b/srcpkgs/mutter/template
@@ -1,7 +1,7 @@
 # Template file for 'mutter'
 pkgname=mutter
-version=3.18.1
-revision=2
+version=3.18.2
+revision=1
 build_style=gnu-configure
 configure_args="--disable-schemas-compile --disable-static --enable-compile-warnings=no"
 hostmakedepends="pkg-config intltool gnome-doc-utils gobject-introspection
@@ -17,7 +17,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=4fdee7c9dc2db3a48f18723f47c3122aa5bddaddb8751701ce243e577e2a69a9
+checksum=8a69326f216c7575ed6cd53938b9cfc49b3b359cde95d3b6a7ed46c837261181
 
 # Package build options
 build_options="gir"

--- a/srcpkgs/nautilus/template
+++ b/srcpkgs/nautilus/template
@@ -1,7 +1,7 @@
 # Template file for 'nautilus'
 pkgname=nautilus
-version=3.18.1
-revision=2
+version=3.18.2
+revision=1
 build_style=gnu-configure
 configure_args="--disable-update-mimedb --disable-debug
  --disable-schemas-compile --disable-nst-extension $(vopt_enable gir introspection)"
@@ -14,7 +14,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2, LGPL-2.1"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=9db310b255268f1bd5e93642821a138029550d96a51b408528377d6b121d55ad
+checksum=68dcf668e2ca93126a899d2e236ef37af2aea93e3fc25eee23ccd7ba911d424a
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/orca/template
+++ b/srcpkgs/orca/template
@@ -1,6 +1,6 @@
 # Template file for 'orca'
 pkgname=orca
-version=3.18.1
+version=3.18.2
 revision=1
 noarch=yes
 build_style=gnu-configure
@@ -16,4 +16,4 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://www.gnome.org/projects/orca"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=dc36242b1814582f3e8448879e282e2b0c005d1c49617767c6ad28eb85c2a757
+checksum=986244af7a0891b758eb8e772bc61d72483808e7e9c790360f9f389045d7262a

--- a/srcpkgs/rhythmbox/template
+++ b/srcpkgs/rhythmbox/template
@@ -1,7 +1,7 @@
 # Template file for 'rhythmbox'
 pkgname=rhythmbox
 version=3.2.1
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--disable-static --disable-schemas-compile
  --with-webkit --with-gudev --without-hal $(vopt_if gir --enable-vala)"

--- a/srcpkgs/sound-juicer/template
+++ b/srcpkgs/sound-juicer/template
@@ -1,6 +1,6 @@
 # Template file for 'sound-juicer'
 pkgname=sound-juicer
-version=3.18.0
+version=3.18.1
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool itstool gnome-doc-utils glib-devel"
@@ -15,4 +15,4 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://burtonini.com/blog/computers/sound-juicer"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=0525cfcdf76379d7aa5255fae2cde9e44ad0a24b12ac953d4fbc3dc55dfab048
+checksum=526d5a84d9b6b8f002f82f9d5678e3850c48e3b5692a499451fc5f36eef0de76

--- a/srcpkgs/totem/template
+++ b/srcpkgs/totem/template
@@ -1,7 +1,7 @@
 # Template file for 'totem'
 pkgname=totem
 version=3.18.1
-revision=1
+revision=2
 short_desc="A GNOME integrated movie player based on Gstreamer"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"

--- a/srcpkgs/vino/template
+++ b/srcpkgs/vino/template
@@ -1,6 +1,6 @@
 # Template file for 'vino'
 pkgname=vino
-version=3.18.0
+version=3.18.1
 revision=1
 build_style=gnu-configure
 configure_args="--disable-schemas-compile"
@@ -15,4 +15,4 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=52be0b036389713eab224abf27f2ca2a067ba5bd1f6b526592703576005e0919
+checksum=07ec6e78bbecd4ee3fce873eb26932fdda9c7642bb09d17ac36483b996fafe5a


### PR DESCRIPTION
The `grilo-0.2.14` package has a revbump back from *.so.10 to *.so.1 !?
Seems a little strange, but works after removing the other grilo entries from `common/shlibs`.
The dependencies are either revbumped or updated.

Packages tested to build ok on x86_64 and x86_64-musl.

What shall we do with `gdm`? It is now at `3.18.2` and could probably also be updated?