### PR TITLE
strongswan: updated to 5.3.5.

### DIFF
--- a/srcpkgs/strongswan/template
+++ b/srcpkgs/strongswan/template
@@ -1,7 +1,7 @@
 # Template file for 'strongswan'
 pkgname=strongswan
-version=5.3.4
-revision=2
+version=5.3.5
+revision=1
 build_style=gnu-configure
 configure_args="--disable-static"
 depends="iproute2 sqlite"
@@ -12,8 +12,26 @@ maintainer="Toyam <Vaelatern@gmail.com>"
 license="GPL-2"
 homepage="http://www.strongswan.org/"
 distfiles="http://download.strongswan.org/${pkgname}-${version}.tar.bz2"
-checksum=938ad1f7b612e039f1d32333f4865160be70f9fb3c207a31127d0168116459aa
+checksum=2c84b663da652b1ff180a1a73c24a3d7b9fc4b9b8ba6bd07f94a1e33092e6350
 
 post_install() {
+	touch .empty
+	vmkdir /etc/ipsec.d
+	vmkdir /etc/ipsec.d/aacerts
+	vcopy .empty /etc/ipsec.d/aacerts/
+	vmkdir /etc/ipsec.d/acerts
+	vcopy .empty /etc/ipsec.d/acerts/
+	vmkdir /etc/ipsec.d/cacerts
+	vcopy .empty /etc/ipsec.d/cacerts/
+	vmkdir /etc/ipsec.d/certs
+	vcopy .empty /etc/ipsec.d/certs/
+	vmkdir /etc/ipsec.d/crls
+	vcopy .empty /etc/ipsec.d/crls/
+	vmkdir /etc/ipsec.d/ocspcerts
+	vcopy .empty /etc/ipsec.d/ocspcerts/
+	vmkdir /etc/ipsec.d/private 750
+	vcopy .empty /etc/ipsec.d/private/
+	vmkdir /etc/ipsec.d/reqs
+	vcopy .empty /etc/ipsec.d/reqs/
 	vsv strongswan
 }


### PR DESCRIPTION
Also ensured subdirectories of `/etc/ipsec.d/` wouldn't just be removed after the tarball extracts them.