### PR TITLE
common/hooks: Fix hooks when build_style=meta

### DIFF
--- a/common/hooks/post-install/02-remove-perl-files.sh
+++ b/common/hooks/post-install/02-remove-perl-files.sh
@@ -1,7 +1,7 @@
 # This hook removes perl pod/.packlist files.
 
 hook() {
-	if [ "$pkgname" != "perl" ]; then
+	if [ "$pkgname" != "perl" -a -d "${PKGDESTDIR}" ]; then
 		find ${PKGDESTDIR} -type f -name perllocal.pod -delete
 		find ${PKGDESTDIR} -type f -name .packlist -delete
 	fi

--- a/common/hooks/post-install/02-remove-python-bytecode-files.sh
+++ b/common/hooks/post-install/02-remove-python-bytecode-files.sh
@@ -1,5 +1,7 @@
 # This hook removes python bytecode files (.py[co]).
 
 hook() {
-	find ${PKGDESTDIR} -type f -name '*.py[co]' -delete
+    if [ -d "${PKGDESTDIR}" ]; then
+        find ${PKGDESTDIR} -type f -name '*.py[co]' -delete
+    fi
 }

--- a/common/hooks/post-install/03-remove-empty-dirs.sh
+++ b/common/hooks/post-install/03-remove-empty-dirs.sh
@@ -1,12 +1,14 @@
 # This hooks removes empty dirs and warns about them.
 
 hook() {
-	find "${PKGDESTDIR}" -type d -empty|sort -r|while read f; do
-		_dir="${f##${PKGDESTDIR}}"
-		[ -z "${_dir}" ] && continue
-		rmdir --ignore-fail-on-non-empty -p "$f" &>/dev/null
-		msg_warn "$pkgver: removed empty dir: ${_dir}\n"
-	done
-	# Create PKGDESTDIR in case it has been removed previously.
-	mkdir -p ${PKGDESTDIR}
+    if [ -d "${PKGDESTDIR}" ]; then
+        find "${PKGDESTDIR}" -type d -empty|sort -r|while read f; do
+            _dir="${f##${PKGDESTDIR}}"
+            [ -z "${_dir}" ] && continue
+            rmdir --ignore-fail-on-non-empty -p "$f" &>/dev/null
+            msg_warn "$pkgver: removed empty dir: ${_dir}\n"
+        done
+        # Create PKGDESTDIR in case it has been removed previously.
+        mkdir -p ${PKGDESTDIR}
+    fi
 }


### PR DESCRIPTION
`find` would report an error because PKGDESTDIR didn't exist. This makes sure it exists to run the hooks.