### PR TITLE
grub: set nopie=yes

### DIFF
--- a/srcpkgs/grub/template
+++ b/srcpkgs/grub/template
@@ -1,7 +1,7 @@
 # Template file for 'grub'
 pkgname=grub
 version=2.00
-revision=24
+revision=25
 hostmakedepends="flex"
 makedepends="libusb-compat-devel ncurses-devel freetype-devel
  liblzma-devel device-mapper-devel font-unifont-bdf fuse-devel"
@@ -14,6 +14,7 @@ homepage="http://www.gnu.org/software/grub/"
 distfiles="$GNU_SITE/grub/grub-$version.tar.xz"
 checksum=784ec38e7edc32239ad75b8e66df04dc8bfb26d88681bc9f627133a6eb85c458
 only_for_archs="i686 i686-musl x86_64 x86_64-musl"
+nopie=yes
 
 subpackages="grub-utils grub-i386-efi"
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
I tried to patch include/grub/i386/tsc.h and grub-core/loader/i386/xnu.c
to avoid clobbering %rbx (or %ebx) when using cpuid, but finally the
linking of trig.module would fail due to picking up the LDFLAGS.
Disabling PIE seems to be the only way for now.

If someone wants to try to fix the trig.module linking stage, here's the [modified tsc.h](http://sprunge.us/iKWJ) and [modified xnu.c](http://sprunge.us/QMge)