### PR TITLE
TwitchNotifier: update to 0.4.2

### DIFF
--- a/srcpkgs/TwitchNotifier/template
+++ b/srcpkgs/TwitchNotifier/template
@@ -1,6 +1,6 @@
 # Template file for 'TwitchNotifier'
 pkgname="TwitchNotifier"
-version="0.4.1"
+version="0.4.2"
 revision=1
 build_style=python-module
 hostmakedepends="python3.4-devel"
@@ -13,4 +13,4 @@ maintainer="Giedrius Statkevičius <giedriuswork@gmail.com>"
 license="GPL-3"
 homepage="https://github.com/GiedriusS/${pkgname}"
 distfiles="https://github.com/GiedriusS/${pkgname}/archive/${version}.tar.gz"
-checksum="1e57b9e00cb542ce75876f07b43d2a5ae458fe7abf38700d3ef35541709bc694"
+checksum="ba42a2fe3ff433a0f1319c4bd162d6fc1f49185eaee02720fcd165217494fcaf"


### PR DESCRIPTION
One substantial stability problem was fixed so I have released a new minor version and this PR updates the package in voidlinux.