### PR TITLE
New package: pam-krb5-4.7.

### DIFF
--- a/srcpkgs/pam-krb5/template
+++ b/srcpkgs/pam-krb5/template
@@ -1,0 +1,18 @@
+# Template file for 'pam-krb5'
+pkgname=pam-krb5
+version=4.7
+revision=1
+build_style=gnu-configure
+configure_args="--libdir=/usr/lib/"
+makedepends="pam-devel mit-krb5-devel"
+depends="pam mit-krb5"
+short_desc="Kerberos v5 PAM module"
+maintainer="Toyam Cox <Vaelatern@gmail.com>"
+license="BSD"
+homepage="http://www.eyrie.org/~eagle/software/pam-krb5/"
+distfiles="http://archives.eyrie.org/software/kerberos/${pkgname}-${version}.tar.gz"
+checksum=9b4ff52d0456939a0fe6d6676a965a6c2351d9f2c011de8402bfc12c547a7412
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
Issue #3119

Upstream calls itself pam-krb5. It seems to be a tossup between
that and libpam-krb5, so I flipped a coin and named with upstream.