### PR TITLE
passwordsafe: add yubikey/yubico support, fix update check, 'password…

### DIFF
--- a/srcpkgs/passwordsafe/template
+++ b/srcpkgs/passwordsafe/template
@@ -1,15 +1,13 @@
 # Template file for 'passwordwsafe'
 pkgname=passwordsafe
 version="0.97BETA"
-revision=1
+revision=2
 wrksrc="pwsafe-${version}"
 build_style=gnu-makefile
-# TODO: pkg dependencies to support yubikey
-make_build_args="NO_YUBI=1"
 make_build_target="release help I18N"
 # Makefile uses perl to generate core_st.cpp, zip to generate help files
 hostmakedepends="perl wxWidgets-devel zip pkg-config gettext"
-makedepends="wxWidgets-devel libXt-devel libXtst-devel libxerces-c-devel libuuid-devel"
+makedepends="wxWidgets-devel libXt-devel libXtst-devel libxerces-c-devel libuuid-devel libykpers-devel"
 short_desc="Simple & Secure Password Management"
 maintainer="Rui Abreu Ferreira <raf-ep@gmx.com>"
 license="Artistic-2.0"
@@ -19,22 +17,28 @@ checksum=f1cdbdda7ef795d974772e40a0d040deb296c110ded1bd05a524a6baa152a9a8
 nocross=yes
 
 do_install() {
-	vbin src/ui/wxWidgets/GCCUnicodeRelease/pwsafe
-	vinstall install/desktop/pwsafe.desktop 644 usr/share/applications
-	vinstall install/graphics/pwsafe.png 644 usr/share/icons/hicolor/48x48/apps/
+	# use 'passwordsafe' in filenames as much as possible.
+	vbin src/ui/wxWidgets/GCCUnicodeRelease/pwsafe passwordsafe
+	vinstall install/desktop/pwsafe.desktop 644 usr/share/applications passwordsafe.desktop
+	vinstall install/graphics/pwsafe.png 644 usr/share/icons/hicolor/48x48/apps passwordsafe.png
+	sed -i -e 's,^\(Exec\|Icon\)=.*,\1=passwordsafe,' ${DESTDIR}/usr/share/applications/passwordsafe.desktop
+
 	# Help files
-	for f in help/help*.zip; do
-		vinstall $f 644 usr/share/${pkgname}/help
-	done
+	# 0.97BETA: localized help files are useless
+	#           without locales (see below).
+	#           keep only english help file.
+	#for f in help/help*.zip; do
+	#	vinstall $f 644 usr/share/${pkgname}/help
+	#done
+	vinstall help/helpEN.zip 644 usr/share/passwordsafe/help
 	# XML files
-	vmkdir usr/share/pwsafe
 	vcopy xml usr/share/${pkgname}
 	vlicense LICENSE
 	vdoc docs/config.txt
-	vman docs/pwsafe.1
-	# 0.97BETA: ignore locales:
-	#        weird behaviour on GUI language change in application.
-	#        might be related to UTF-8.
+	vman docs/pwsafe.1 passwordsafe.1
+	# 0.97BETA: no locales.
+	#           runtime crash on language change in GUI,
+	#           and additional entries appears in data file.
 	#vmkdir usr/share/locale
 	#vcopy src/ui/wxWidgets/I18N/mos/* usr/share/locale
 }

--- a/srcpkgs/passwordsafe/update
+++ b/srcpkgs/passwordsafe/update
@@ -1,0 +1,2 @@
+# Passwordsafe linux port uses "BETA" in release name
+pattern="\K[\d.]+BETA(?=)"


### PR DESCRIPTION
…safe' everywhere, no locale for help.

Taking advantage of PR #3126 (yubikey/yubico support) for  passwordsafe.

ping @equalsraf as runtime tester too.
