### PR TITLE
utox: update to 0.4.5

### DIFF
--- a/srcpkgs/utox/template
+++ b/srcpkgs/utox/template
@@ -1,15 +1,15 @@
 # Template file for 'utox'
 pkgname="utox"
-version=0.3.2
+version=0.4.5
 revision=1
 short_desc="Lightweight TOX instant messenger client written in C"
-maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
+maintainer="Spencer Hill <spencernh77@gmail.com>"
 license="GPL-3"
-homepage="https://wiki.tox.im/UTox"
-makedepends="toxcore-devel-git filteraudio-devel-git fontconfig-devel freetype-devel libopenal-devel libvpx-devel libX11-devel libXext-devel libXrender-devel dbus-devel v4l-utils-devel libsodium-devel opus-devel"
+homepage="https://utox.org"
+makedepends="toxcore-devel-git filteraudio-devel-git fontconfig-devel freetype-devel libopenal-devel libvpx-devel libX11-devel libXext-devel libXrender-devel dbus-devel v4l-utils-devel libsodium-devel opus-devel git"
 hostmakedepends="pkg-config"
-distfiles="https://github.com/notsecure/uTox/archive/v${version}.tar.gz"
-checksum=848025075e21355c3a8aa959092313d66b4ad6ae03630eb30cc3afce750acc68
+distfiles="https://github.com/GrayHatter/uTox/archive/v${version}.tar.gz"
+checksum=7d744a4e1c0a4b060434924e25312e336f4a2df3236a152893660c0fb374ece7
 build_style="gnu-makefile"
 wrksrc="uTox-${version}"
 


### PR DESCRIPTION
This will require the toxcore-git update to build properly.