### PR TITLE
New Package python-tables 3.2.2

### DIFF
--- a/srcpkgs/python-tables/patches/01_no_utils
+++ b/srcpkgs/python-tables/patches/01_no_utils
@@ -1,0 +1,19 @@
+--- setup.py	2015-09-22 05:02:05.000000000 +0200
++++ setup.py_	2015-12-13 10:42:06.578872182 +0100
+@@ -685,16 +685,6 @@
+ setuptools_kwargs['install_requires'] = requirements
+ # Detect packages automatically.
+ setuptools_kwargs['packages'] = find_packages(exclude=['*.bench'])
+-# Entry points for automatic creation of scripts.
+-setuptools_kwargs['entry_points'] = {
+-    'console_scripts': [
+-        'ptdump = tables.scripts.ptdump:main',
+-        'ptrepack = tables.scripts.ptrepack:main',
+-        'pt2to3 = tables.scripts.pt2to3:main',
+-        'pttree = tables.scripts.pttree:main',
+-        ],
+-    }
+-
+ # Test suites.
+ setuptools_kwargs['test_suite'] = 'tables.tests.test_all.suite'
+ setuptools_kwargs['scripts'] = []

--- a/srcpkgs/python-tables/template
+++ b/srcpkgs/python-tables/template
@@ -1,0 +1,33 @@
+# Template file for 'python-tables'
+pkgname=python-tables
+version=3.2.2
+revision=1
+wrksrc="${pkgname#*-}-${version}"
+build_style=python-module
+python_versions="2.7 3.4"
+pycompile_module="tables"
+hostmakedepends="python-setuptools python3.4-setuptools"
+makedepends="python-devel python3.4-devel python-numpy python3.4-numpy
+ python-Cython python3.4-Cython hdf5-devel"
+depends="python-numpy python-numexpr"
+short_desc="Hierarchical datasets for Python2"
+maintainer="pulux <pulux@pf4sh.de>"
+license="BSD"
+homepage="http://www.pytables.org/"
+distfiles="${PYPI_SITE}/t/tables/tables-${version}.tar.gz"
+checksum=3564b351a71ec1737b503b001eb7ceae1f65d5d6e3ffe1ea75aafba10f37fa84
+
+post_install() {
+	vlicense LICENSE.txt LICENSE
+}
+
+python3.4-tables_package() {
+	pycompile_version="3.4"
+	pycompile_module="tables"
+	depends="python3.4-numpy python3.4-numexpr"
+	short_desc="${short_desc/Python2/Python3.4}"
+	pkg_install() {
+		vmove usr/lib/python3.4
+		vlicense LICENSE.txt LICENSE
+	}
+}

--- a/srcpkgs/python3.4-tables
+++ b/srcpkgs/python3.4-tables
@@ -1,0 +1,1 @@
+python-tables


### PR DESCRIPTION
I droped the utils because the bang line is allways changed to `#!/usr/bin/python3.4`. 