### PR TITLE
owncloudclient: update to 2.1.0

### DIFF
--- a/srcpkgs/owncloudclient/template
+++ b/srcpkgs/owncloudclient/template
@@ -1,6 +1,6 @@
 # Template file for 'owncloudclient'
 pkgname=owncloudclient
-version=2.0.2
+version=2.1.0
 revision=1
 build_style=cmake
 configure_args="-Wno-dev"
@@ -15,4 +15,4 @@ maintainer="Samuel Chodur <samuelchodur@gmail.com>"
 license="GPL-2"
 homepage="http://www.owncloud.org"
 distfiles="https://download.owncloud.com/desktop/stable/${pkgname}-${version}.tar.xz"
-checksum=2815dce34b568141d7c2ab90bcd733abb6862970917738e3b120d8073ab68228
+checksum=73553f182cc5e3d87a5382bf17f9adf6e1315cc9ea8f530bf39775e709a5d03f


### PR DESCRIPTION
I had to do the following:
$ ./xbps-src zap
$ ./xbps-src binary-bootstrap
before build would work. Not sure if related to my package, or just an update to void-packages that I haven't noticed. 