### PR TITLE
make sure that dnsmasq is installed when building libvirt

### DIFF
--- a/srcpkgs/libvirt/template
+++ b/srcpkgs/libvirt/template
@@ -1,7 +1,7 @@
 # Template file for 'libvirt'
 pkgname=libvirt
 version=1.2.21
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--without-hal --with-storage-lvm --with-qemu-user=libvirt
  --with-qemu-group=libvirt --without-netcf --with-interface --disable-static"
@@ -17,7 +17,7 @@ system_accounts="libvirt"
 libvirt_groups="disk,kvm"
 
 hostmakedepends="automake libtool perl pkg-config lvm2 parted gettext-devel
- iptables libxslt docbook-xsl"
+ iptables libxslt docbook-xsl dnsmasq"
 makedepends="readline-devel libcap-ng-devel libnl3-devel attr-devel
  gnutls-devel libsasl-devel libcurl-devel libpcap-devel libxml2-devel
  libparted-devel device-mapper-devel dbus-devel libudev-devel libblkid-devel


### PR DESCRIPTION
if dnsmasq isn't installed while building libvirt, it wil be unable to find dnsmasq at runtime. and when enabling NAT for example you will be hit with errors like:
```
Cannot check dnsmasq binary dnsmasq: No such file or directory
```

since finding a path doesn't really matter on which architecture it is, I've added it to hostmakedepends. if this is wrong please correct me.

Source of solution: https://bugs.archlinux.org/task/35183 

`./xbps-src pkg libvirt` ran successfully and without error