### PR TITLE
libdbus-c++: unbreak musl

### DIFF
--- a/srcpkgs/libdbus-c++/patches/fix-mutex-init.patch
+++ b/srcpkgs/libdbus-c++/patches/fix-mutex-init.patch
@@ -1,0 +1,18 @@
+Use a portable way to initialize a recursive mutex.
+
+--- src/eventloop.cpp	2011-11-28 16:03:19.000000000 +0100
++++ src/eventloop.cpp	2015-12-20 11:17:56.774568824 +0100
+@@ -85,8 +85,11 @@
+ {
+   if (recursive)
+   {
+-    pthread_mutex_t recmutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+-    _mutex = recmutex;
++    pthread_mutexattr_t attr;
++    pthread_mutexattr_init(&attr);
++    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
++    pthread_mutex_init(&_mutex, &attr);
++    pthread_mutexattr_destroy(&attr);
+   }
+   else
+   {

--- a/srcpkgs/libdbus-c++/patches/musl-ssize_t.patch
+++ b/srcpkgs/libdbus-c++/patches/musl-ssize_t.patch
@@ -1,0 +1,11 @@
+--- include/dbus-c++/pipe.h	2011-11-28 16:03:19.000000000 +0100
++++ include/dbus-c++/pipe.h	2015-12-20 11:28:15.238535382 +0100
+@@ -29,6 +29,8 @@
+ 
+ /* STD */
+ #include <cstdlib>
++/* ssize_t */
++#include <fcntl.h>
+ 
+ namespace DBus
+ {

--- a/srcpkgs/libdbus-c++/patches/musl-uint.patch
+++ b/srcpkgs/libdbus-c++/patches/musl-uint.patch
@@ -1,0 +1,13 @@
+--- tools/generate_proxy.cpp	2011-11-28 16:03:19.000000000 +0100
++++ tools/generate_proxy.cpp	2015-12-20 11:30:56.002526689 +0100
+@@ -26,6 +26,10 @@
+ #include <cstdlib>
+ #include <algorithm>
+ 
++#if !defined(__GLIBC__)
++typedef unsigned int uint;
++#endif
++
+ #include "generator_utils.h"
+ #include "generate_proxy.h"
+ 

--- a/srcpkgs/libdbus-c++/template
+++ b/srcpkgs/libdbus-c++/template
@@ -1,7 +1,7 @@
 # Template file for 'libdbus-c++'
 pkgname=libdbus-c++
 version=0.9.0
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-glib --disable-ecore"
 hostmakedepends="autoconf automake pkg-config"


### PR DESCRIPTION
I found a way to replace the non-portable mutex init through PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP  with this code fragment at http://stackoverflow.com/a/7963765