### PR TITLE
Update qtox, and toxcore to their respective new versions.

### DIFF
--- a/srcpkgs/qtox/template
+++ b/srcpkgs/qtox/template
@@ -1,7 +1,7 @@
 # Template file for 'qtox'
 pkgname=qtox
-version=1.2
-revision=3
+version=1.2.2
+revision=1
 build_style=qmake
 short_desc="QT-based TOX instant messenger client"
 maintainer="Spencer Hill <spencernh77@gmail.com>"
@@ -10,9 +10,11 @@ homepage="https://wiki.tox.chat/clients/qtox"
 hostmakedepends="qt5-qmake"
 makedepends="toxcore-devel-git filteraudio-devel-git ffmpeg-devel qt5-svg-devel
  qt5-tools-devel libopencv-devel libopenal-devel libsodium-devel
- libXScrnSaver-devel gdk-pixbuf-devel gtk+-devel libvpx-devel qrencode-devel"
+ libXScrnSaver-devel gdk-pixbuf-devel gtk+-devel libvpx-devel qrencode-devel
+ sqlcipher-devel"
+depends="qt5-plugin-sqlite"
 distfiles="https://github.com/tux3/qTox/archive/v${version}.tar.gz"
-checksum=f6d4aafa1ffa5cdadb1fbee1f5bce41cd8a638e510c42726ba665524e8320d54
+checksum=6b8a7d9b964e748b2fe5542c05a60aebbef4ad56b407db63e609afa82665fef3
 wrksrc="qTox-${version}"
 
 pre_configure() {

--- a/srcpkgs/toxcore-git/template
+++ b/srcpkgs/toxcore-git/template
@@ -1,8 +1,8 @@
 # Template file for 'toxcore-git'
 pkgname="toxcore-git"
-version="20151211"
-revision=2
-_commithash="1c8109e524870bb51622c098ce08533535cb3eab"
+version="20160118"
+revision=1
+_commithash="b9ef24875ce1d9bf5f04f0164ae95f729330a295"
 short_desc="Encrypted peer-to-peer instant messenger protocol library"
 maintainer="Spencer Hill <spencernh77@gmail.com>"
 license="GPL-3"
@@ -10,7 +10,7 @@ homepage="https://tox.chat"
 makedepends="libsodium-devel opus-devel libvpx-devel"
 hostmakedepends="autoconf automake libtool pkg-config"
 distfiles="https://github.com/irungentoo/toxcore/archive/${_commithash}.tar.gz"
-checksum=386e39d4d29e6313682c9403dcbe60bbb5a47f5f22d174a6c6eed45170fbb6a0
+checksum=1c3e4824ac273878e1624c766dfb6119623086306f96f609cb73d3abed3321c2
 wrksrc="toxcore-${_commithash}"
 build_style="gnu-configure"
 


### PR DESCRIPTION
Toxcore 20151225
qtox 1.2.2

These are grouped to prevent needing to rebuild utox and qtox once toxcore pushes.