### PR TITLE
perl: remove -specs hardened-cc1

### DIFF
--- a/srcpkgs/perl/template
+++ b/srcpkgs/perl/template
@@ -1,7 +1,7 @@
 # Template build file for 'perl'.
 pkgname=perl
 version=5.22.1
-revision=1
+revision=2
 hostmakedepends="less"
 makedepends="zlib-devel bzip2-devel gdbm-devel db-devel"
 depends="less"
@@ -261,4 +261,9 @@ do_install() {
 	ln -sfr ${DESTDIR}/usr/lib/perl5/core_perl/CORE/libperl.so.${version%.*} \
 		${DESTDIR}/usr/lib/libperl.so.${version%.*}
 	ln -s libperl.so.${version%.*} ${DESTDIR}/usr/lib/libperl.so
+}
+
+post_install() {
+	# remove -specs hardened-cc1
+	sed -i 's/-specs=.*hardened-cc1//g' ${DESTDIR}/usr/lib/perl5/core_perl/Config_heavy.pl
 }


### PR DESCRIPTION
because of broken paths in /usr/lib/perl5/core_perl/Config_heavy.pl

```
/usr/lib/perl5 % grep -ri hardened-
core_perl/Config_heavy.pl:config_arg21='-Doptimize=-specs=/void-packages/common/environment/configure/gccspecs/hardened-cc1  -fstack-protector-strong -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe   -g'
core_perl/Config_heavy.pl:config_args='-des -Dusethreads -Duseshrplib -Dprefix=/usr -Dvendorprefix=/usr -Dprivlib=/usr/share/perl5/core_perl -Darchlib=/usr/lib/perl5/core_perl -Dsitelib=/usr/share/perl5/site_perl -Dsitearch=/usr/lib/perl5/site_perl -Dvendorlib=/usr/share/perl5/vendor_perl -Dvendorarch=/usr/lib/perl5/vendor_perl -Dscriptdir=/usr/bin -Dvendorscript=/usr/bin -Dinc_version_list=none -Dman1ext=1p -Dman3ext=3p -Dman1dir=/usr/share/man/man1 -Dman3dir=/usr/share/man/man3 -Dlibperl=libperl.so.5.22 -Dcccdlflags=-fPIC -Doptimize=-specs=/void-packages/common/environment/configure/gccspecs/hardened-cc1  -fstack-protector-strong -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe   -g'
core_perl/Config_heavy.pl:lddlflags='-shared -specs=/void-packages/common/environment/configure/gccspecs/hardened-cc1 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe -g'
core_perl/Config_heavy.pl:optimize='-specs=/void-packages/common/environment/configure/gccspecs/hardened-cc1 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe -g'
```