### PR TITLE
epson-inkjet-printer-escpr: update to 1.6.1.

### DIFF
--- a/srcpkgs/epson-inkjet-printer-escpr/template
+++ b/srcpkgs/epson-inkjet-printer-escpr/template
@@ -1,14 +1,15 @@
 # Template file for 'epson-inkject-printer-escpr'
 pkgname=epson-inkjet-printer-escpr
-version=1.4.5
+version=1.6.1
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --with-cupsppddir=/usr/share/ppd --with-cupsfilterdir=/usr/lib/cups/filter"
 hostmakedepends="cups-devel"
 makedepends="cups-devel"
+depends="cups-filters"
 short_desc="Epson Inkjet Printer Driver (ESC/P-R)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX"
-distfiles="https://download3.ebz.epson.net/dsc/f/03/00/03/52/19/465c03d0ac4d2a6408d82b65b7178441a2dffb9c/epson-inkjet-printer-escpr-1.4.5-1lsb3.2.tar.gz"
-checksum=90766deb4c5ca97def703a7bf91a0b0cb312ec9aaa769e036fb05fee2083b580
+distfiles="https://download3.ebz.epson.net/dsc/f/03/00/04/23/02/a5ee7e1622b0ba692bea6763d6d7f4810a8d0808/epson-inkjet-printer-escpr-1.6.1-1lsb3.2.tar.gz"
+checksum=bb7dea7439c571662db9cf7a8834cb87ed69fa249a7945218403187c6097c76f


### PR DESCRIPTION
i added cups-filter as runtime dependency because without it's not possible to print anything 