### PR TITLE
rpi-kernel: fix includes for rpi2

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,7 +5,7 @@ _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
 version=4.1.15
-revision=1
+revision=2
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.kernel.org"
@@ -128,9 +128,18 @@ do_install() {
 	chmod og-w -R ${hdrdest}/scripts
 
 	# copy arch includes for external modules
-	mkdir -p ${hdrdest}/arch/arm/mach-bcm2708
+	mkdir -p ${hdrdest}/arch/arm
 	cp -a arch/arm/include ${hdrdest}/arch/arm
-	cp -a arch/arm/mach-bcm2708/include ${hdrdest}/arch/arm/mach-bcm2708
+	case "$XBPS_TARGET_MACHINE" in
+	armv7l*)
+		mkdir -p ${hdrdest}/arch/arm/mach-bcm2709
+		cp -a arch/arm/mach-bcm2709/include ${hdrdest}/arch/arm/mach-bcm2709
+		;;
+	armv6l*)
+		mkdir -p ${hdrdest}/arch/arm/mach-bcm2708
+		cp -a arch/arm/mach-bcm2708/include ${hdrdest}/arch/arm/mach-bcm2708
+		;;
+	esac
 
 	mkdir -p ${hdrdest}/arch/arm/kernel
 


### PR DESCRIPTION
This fixes a problem with building external modules on a Raspberry Pi 2