### PR TITLE
dovecot-plugin-pigeonhole: build for current dovecot version

### DIFF
--- a/srcpkgs/dovecot-plugin-pigeonhole/template
+++ b/srcpkgs/dovecot-plugin-pigeonhole/template
@@ -1,15 +1,15 @@
 # Template file for 'dovecot-plugin-pigeonhole'
 pkgname=dovecot-plugin-pigeonhole
 # make sure this matches the current dovecot
-_dovecot_ver=2.2.19
+_dovecot_ver=2.2.21
 version=0.4.9
-revision=2
+revision=3
 wrksrc="dovecot-2.2-pigeonhole-${version}"
 build_style=gnu-configure
 configure_args="--prefix=/usr
-  --with-dovecot=${XBPS_CROSS_BASE}/usr/lib/dovecot 
-  --with-moduledir=/usr/lib/dovecot/modules
-  --disable-static"
+ --with-dovecot=${XBPS_CROSS_BASE}/usr/lib/dovecot
+ --with-moduledir=/usr/lib/dovecot/modules
+ --disable-static"
 # Hack around dovecot-config for cross building.
 make_build_args="LIBDOVECOT_INCLUDE=-I${XBPS_CROSS_BASE}/usr/include/dovecot
  LIBS=-L${XBPS_CROSS_BASE}/usr/lib/dovecot"


### PR DESCRIPTION
Current version of dovecot in the repo is not ABI compatible to the one the pigeonhole plugin is built against. Setting _dovecot_ver fixes this