### PR TITLE
New package: salt-2015.8.3

### DIFF
--- a/srcpkgs/salt/files/salt-api/run
+++ b/srcpkgs/salt/files/salt-api/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec salt-api

--- a/srcpkgs/salt/files/salt-master/run
+++ b/srcpkgs/salt/files/salt-master/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec salt-master

--- a/srcpkgs/salt/files/salt-minion/run
+++ b/srcpkgs/salt/files/salt-minion/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec salt-minion

--- a/srcpkgs/salt/files/salt-syndic/run
+++ b/srcpkgs/salt/files/salt-syndic/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec salt-syndic

--- a/srcpkgs/salt/template
+++ b/srcpkgs/salt/template
@@ -1,0 +1,26 @@
+# Template file for 'salt'
+pkgname=salt
+version=2015.8.3
+revision=1
+build_style=python-module
+noarch=yes
+pycompile_module="salt"
+conf_files="/etc/salt/*"
+hostmakedepends="python python-devel"
+makedepends="python-devel"
+depends="python python-yaml python-MarkupSafe python-Jinja2 python-requests python-pyzmq python-crypto python-M2Crypto python-tornado python-msgpack dmidecode pciutils"
+short_desc="Remote execution system, and configuration manager"
+maintainer="Toyam Cox <Vaelatern@gmail.com>"
+license="Apache-2.0"
+homepage="http://saltstack.org/"
+distfiles="$PYPI_SITE/s/salt/salt-${version}.tar.gz"
+checksum=2e9a262789b018f3443513105c0c6ae98934c9bc105a04cf9e5c073ef706218a
+
+post_install() {
+	vmkdir /etc/salt 0750
+	vcopy conf/* /etc/salt/
+	vsv salt-api
+	vsv salt-master
+	vsv salt-minion
+	vsv salt-syndic
+}


### PR DESCRIPTION
The inclusion of `python-devel` is only because the Manual indicates it is necessary for cross compilation.
I chose not to split into client and server packages because the difference is 1 executable and 1 service folder. Also, neither Gentoo nor Arch split them into different packages.
This is a tool similar to ansible, puppet, and chef. I'm working on including explicit void support (mainly identifying a void system and using xbps) in the Salt code.