### PR TITLE
dvdauthor: add build_options for default video format (NTSC or PAL)

### DIFF
--- a/srcpkgs/dvdauthor/template
+++ b/srcpkgs/dvdauthor/template
@@ -2,11 +2,10 @@
 
 pkgname="dvdauthor"
 version="0.7.1"
-revision=1
+revision=2
 patch_args="-Np1"
 build_style=gnu-configure
 wrksrc="$pkgname"
-configure_args="--enable-localize-filenames"
 hostmakedepends="pkg-config"
 makedepends="libpng-devel freetype-devel fribidi-devel libxml2-devel libdvdnav-devel"
 short_desc="DVD authoring tools, generate a DVD movie from MPEG2 stream"
@@ -15,4 +14,15 @@ license="GPL-2"
 homepage="http://dvdauthor.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/dvdauthor/dvdauthor-${version}.tar.gz"
 checksum="501fb11b09c6eb9c5a229dcb400bd81e408cc78d34eab6749970685023c51fe9"
+
+build_options="NTSC PAL"
+build_options_default="PAL"
+desc_option_NTSC="Enable default video format NTSC"
+desc_option_PAL="Enable default video format PAL"
+vopt_conflict NTSC PAL
+
+configure_args="--enable-localize-filenames \
+	$(vopt_if NTSC '--enable-default-video-format=NTSC' "" ) \
+	$(vopt_if PAL '--enable-default-video-format=PAL' "")"
+
 


### PR DESCRIPTION
dvdauthor requires that a default video format be set, NTSC for the US, Canada, and most of South America,  or PAL for most of Europe and parts of Asia. This can be done at build time or set in the user's environment.