### PR TITLE
New package: pam_radius_auth-1.4.0

### DIFF
--- a/srcpkgs/pam_radius_auth/template
+++ b/srcpkgs/pam_radius_auth/template
@@ -1,0 +1,21 @@
+# Template file for 'pam_radius_auth'
+pkgname=pam_radius_auth
+version=1.4.0
+revision=1
+build_style=gnu-configure
+wrksrc="pam_radius-${version}"
+conf_files="/etc/raddb/server"
+makedepends="pam-devel"
+depends="pam"
+short_desc="PAM to RADIUS authentication module"
+maintainer="Toyam Cox <Vaelatern@gmail.com>"
+license="GPL-2"
+homepage="http://freeradius.org/pam_radius_auth/"
+distfiles="ftp://ftp.freeradius.org/pub/radius/pam_radius-${version}.tar.gz"
+checksum=742d79fc39824726c098e746bd3dc3484f983f5ee082c621c1e848b2c3725305
+
+do_install() {
+	vinstall pam_radius_auth.so 755 /usr/lib/security/
+	vmkdir /etc/raddb
+	vinstall pam_radius_auth.conf 600 /etc/raddb/ server
+}


### PR DESCRIPTION
Software is called `pam_radius_auth`. All two files to be installed are named that way. To download them, you get them from `pam_radius`. I flipped a coin and went with `pam_radius_auth` and hardcoded `pam_radius` where necessary.