### PR TITLE
libtirpc: actually fix musl

### DIFF
--- a/srcpkgs/libtirpc/patches/fix_missing_rpc_get_default_domain+fix_musl.patch
+++ b/srcpkgs/libtirpc/patches/fix_missing_rpc_get_default_domain+fix_musl.patch
@@ -115,3 +115,23 @@ diff -Naur a/src/rpcdname.c b/src/rpcdname.c
 +		return (0);
 +	return (-1);
 +}
+--- src/rpc_soc.c	2016-01-08 14:58:32.342790730 -0800
++++ src/rpc_soc.c	2016-01-08 15:00:40.997863321 -0800
+@@ -520,6 +520,8 @@
+ 	    (resultproc_t) rpc_wrap_bcast, "udp");
+ }
+ 
++#ifdef HAVE_YP_PROT_H
++
+ /*
+  * Create the client des authentication object. Obsoleted by
+  * authdes_seccreate().
+@@ -552,6 +554,8 @@
+ 	return (dummy);
+ }
+ 
++#endif
++
+ /*
+  * Create a client handle for a unix connection. Obsoleted by clnt_vc_create()
+  */

--- a/srcpkgs/libtirpc/template
+++ b/srcpkgs/libtirpc/template
@@ -1,7 +1,7 @@
 # Template file for 'libtirpc'
 pkgname=libtirpc
 version=0.3.2
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="pkg-config mit-krb5-devel automake libtool"
 makedepends="mit-krb5-devel libgssglue-devel"


### PR DESCRIPTION
There is one (obsolete) function in rcp_soc that is helps provide des authentication functionality, which we disable on musl. Without this patch, the .so is unusable because it needs `authdes_seccreate`.