### PR TITLE
libvirt: use libtirpc

### DIFF
--- a/srcpkgs/libvirt/template
+++ b/srcpkgs/libvirt/template
@@ -1,7 +1,7 @@
 # Template file for 'libvirt'
 pkgname=libvirt
 version=1.2.21
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--without-hal --with-storage-lvm --with-qemu-user=libvirt
  --with-qemu-group=libvirt --without-netcf --with-interface --disable-static"
@@ -22,13 +22,13 @@ makedepends="readline-devel libcap-ng-devel libnl3-devel attr-devel
  gnutls-devel libsasl-devel libcurl-devel libpcap-devel libxml2-devel
  libparted-devel device-mapper-devel dbus-devel libudev-devel libblkid-devel
  libpciaccess-devel avahi-libs-devel polkit-devel yajl-devel
- python-devel libssh2-devel libcap-ng-devel fuse-devel"
+ python-devel libssh2-devel libcap-ng-devel fuse-devel libtirpc-devel"
 depends="ebtables dnsmasq"
 
 case "$XBPS_TARGET_MACHINE" in
-	i686) configure_args+=" --without-xen"; makedepends+=" libnuma-devel";;
+	i686*) configure_args+=" --without-xen"; makedepends+=" libnuma-devel";;
 	x86_64) configure_args+=" --with-xen"; makedepends+=" libnuma-devel xen-devel";;
-	*-musl) configure_args+=" --without-xen"; makedepends+=" portablexdr-devel";;
+	x86_64-musl) configure_args+=" --without-xen"; makedepends+=" libnuma-devel";;
 	*) configure_args+=" --without-xen";;
 esac
 


### PR DESCRIPTION
portablexdr is flaky and often doesn't work, so use libtirpc instead.