### PR TITLE
bash-completion: source from bashrc, not profile

### DIFF
--- a/srcpkgs/bash-completion/template
+++ b/srcpkgs/bash-completion/template
@@ -1,7 +1,7 @@
 # Template file for 'bash-completion'
 pkgname=bash-completion
 version=2.1
-revision=5
+revision=6
 noarch="yes"
 build_style=gnu-configure
 makedepends="bash"
@@ -21,4 +21,7 @@ post_install() {
 	done
 	# remove nmcli provided by NetworkManager.
 	rm -f ${DESTDIR}/usr/share/bash-completion/completions/nmcli
+	# move to bashrc.d to work after su
+	vmkdir /etc/bash/bashrc.d/
+	mv ${DESTDIR}/etc/profile.d/bash_completion.sh ${DESTDIR}/etc/bash/bashrc.d/bash_completion.sh
 }


### PR DESCRIPTION
since we have /etc/bash/bashrc.d/ we could put bash_completion.sh to ensure it's always loaded and not only on login-shells.