### PR TITLE
minidlna: use -S instead of -d, redirect stderr to stdout

### DIFF
--- a/srcpkgs/minidlna/files/minidlnad/run
+++ b/srcpkgs/minidlna/files/minidlnad/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec minidlnad -d 1>&2
+exec minidlnad -S 2>&1

--- a/srcpkgs/minidlna/template
+++ b/srcpkgs/minidlna/template
@@ -1,7 +1,7 @@
 # Template file for 'minidlna'
 pkgname=minidlna
 version=1.1.5
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="
  --sbindir=/usr/bin


### PR DESCRIPTION
1. -S runs minidlnad in the foreground without excessing logging (-d)
2. Redirecting stderr to stdout allows users to log output via svlogd