### PR TITLE
openimageio: update to 1.5.23.

### DIFF
--- a/srcpkgs/openimageio/template
+++ b/srcpkgs/openimageio/template
@@ -1,6 +1,6 @@
 # Template file for 'openimageio'
 pkgname=openimageio
-version=1.5.22
+version=1.5.23
 revision=1
 wrksrc=oiio-Release-${version}
 build_style=cmake
@@ -17,7 +17,7 @@ maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="BSD"
 homepage="https://sites.google.com/site/openimageio/home"
 distfiles="https://github.com/OpenImageIO/oiio/archive/Release-${version}.tar.gz"
-checksum=48e30ad5dc3745b9dc04a2cf7a372c605a0b07a7b0140980ff8c062df4dcdea4
+checksum=cabdb9b286e723ca273ad484850539016ca45220aeff2cfcab5194d0815b0912
 nocross=yes # -> ilmbase
 
 pre_build() {


### PR DESCRIPTION
im skipping the 1.6 branch for now. has to many portability issues atm.