### PR TITLE
qtox: update to 1.2.4

### DIFF
--- a/srcpkgs/qtox/template
+++ b/srcpkgs/qtox/template
@@ -1,6 +1,6 @@
 # Template file for 'qtox'
 pkgname=qtox
-version=1.2.2
+version=1.2.4
 revision=1
 build_style=qmake
 short_desc="QT-based TOX instant messenger client"
@@ -14,7 +14,7 @@ makedepends="toxcore-devel-git filteraudio-devel-git ffmpeg-devel qt5-svg-devel
  sqlcipher-devel"
 depends="qt5-plugin-sqlite"
 distfiles="https://github.com/tux3/qTox/archive/v${version}.tar.gz"
-checksum=6b8a7d9b964e748b2fe5542c05a60aebbef4ad56b407db63e609afa82665fef3
+checksum=af9b1308865dfbba0ed2a4d6a19e676d59794f850a17da86f9ce2bfbb56adfdd
 wrksrc="qTox-${version}"
 
 pre_configure() {

--- a/srcpkgs/toxcore-git/files/toxbootstrapd/run
+++ b/srcpkgs/toxcore-git/files/toxbootstrapd/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd /etc/toxbootstrapd
+exec chpst -u toxbootstrapd DHT_bootstrap

--- a/srcpkgs/toxcore-git/template
+++ b/srcpkgs/toxcore-git/template
@@ -1,8 +1,8 @@
 # Template file for 'toxcore-git'
 pkgname="toxcore-git"
-version="20160118"
+version="20160131"
 revision=1
-_commithash="b9ef24875ce1d9bf5f04f0164ae95f729330a295"
+_commithash="94cc8b11ff473064526737936f64b6f9a19c239d"
 short_desc="Encrypted peer-to-peer instant messenger protocol library"
 maintainer="Spencer Hill <spencernh77@gmail.com>"
 license="GPL-3"
@@ -10,12 +10,20 @@ homepage="https://tox.chat"
 makedepends="libsodium-devel opus-devel libvpx-devel"
 hostmakedepends="autoconf automake libtool pkg-config"
 distfiles="https://github.com/irungentoo/toxcore/archive/${_commithash}.tar.gz"
-checksum=1c3e4824ac273878e1624c766dfb6119623086306f96f609cb73d3abed3321c2
+checksum=4df62a3488429f0b1adbf24312dc39eb140bae88774124072400930967888d19
 wrksrc="toxcore-${_commithash}"
 build_style="gnu-configure"
+configure_args="--enable-daemon"
+system_accounts="toxbootstrapd"
+toxbootstrapd_homedir="/etc/toxbootstrapd"
+make_dirs="/etc/toxbootstrapd 0700 toxbootstrapd toxbootstrapd"
 
 pre_configure() {
 	./autogen.sh
+}
+
+post_install() {
+	vsv toxbootstrapd
 }
 
 # Development package
@@ -28,4 +36,3 @@ toxcore-devel-git_package() {
 		vmove usr/lib/pkgconfig
 	}
 }
-


### PR DESCRIPTION
Also split off the toxcore-git bootstrap daemon and create a runit service for it.