### PR TITLE
systemtap: update to 2.9.

### DIFF
--- a/srcpkgs/systemtap/template
+++ b/srcpkgs/systemtap/template
@@ -1,6 +1,6 @@
 # Template file for 'systemtap'
 pkgname=systemtap
-version=2.8
+version=2.9
 revision=1
 build_style=gnu-configure
 makedepends="elfutils-devel"
@@ -9,6 +9,5 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-3"
 homepage="https://sourceware.org/systemtap/"
 distfiles="https://sourceware.org/systemtap/ftp/releases/systemtap-${version}.tar.gz"
-checksum=6c9cb5a40256c661114924e84b4ff9038620d0436cd20a5d1bf180503b8b0fcc
-
-broken="http://build.voidlinux.eu/builders/x86_64_builder/builds/13876/steps/shell_3/logs/stdio"
+checksum=04f2c607512f4867f345a3d173940e1023441c5d3560f2e580b4a82dfe4d6353
+only_for_archs="i686 x86_64 armv6l armv7l"


### PR DESCRIPTION
Unbreaks build for glibc based systems. *-musl still broken.