### PR TITLE
meld: depend on gsettings-desktop-schemas

### DIFF
--- a/srcpkgs/meld/template
+++ b/srcpkgs/meld/template
@@ -1,11 +1,11 @@
 # Template file for 'meld'
 pkgname=meld
 version=3.15.0
-revision=2
+revision=3
 noarch=yes
 build_style="python-module"
 hostmakedepends="pkg-config intltool gnome-doc-utils python itstool gtk-update-icon-cache"
-depends="python-gobject gtksourceview desktop-file-utils hicolor-icon-theme"
+depends="python-gobject gsettings-desktop-schemas gtksourceview desktop-file-utils hicolor-icon-theme"
 pycompile_module="meld"
 short_desc="Visual diff and merge tool"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"


### PR DESCRIPTION
Without gsettings-desktop-schemas installed meld crashes with:

    (meld:29458): GLib-GIO-ERROR **: Settings schema 'org.gnome.desktop.interface' is not installed
    Trace/breakpoint trap
