### PR TITLE
ppsspp: update to 1.1.1.

### DIFF
--- a/srcpkgs/ppsspp/template
+++ b/srcpkgs/ppsspp/template
@@ -1,12 +1,12 @@
 # Template file for 'ppsspp'
 pkgname=ppsspp
-version=0.9.9
+version=1.1.1
 revision=1
 build_wrksrc="${pkgname}-${version}"
 build_style=cmake
 configure_args="-DHEADLESS=1"
 hostmakedepends="cmake pkg-config"
-makedepends="zlib-devel libpng-devel SDL-devel"
+makedepends="zlib-devel libpng-devel SDL2-devel"
 depends="desktop-file-utils"
 short_desc="A fast and portable PSP emulator"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -15,21 +15,21 @@ homepage="http://www.ppsspp.org/"
 create_wrksrc=yes
 distfiles="
  https://github.com/hrydgard/ppsspp/archive/v${version}.tar.gz
- https://github.com/hrydgard/ppsspp-ffmpeg/archive/bc6302be.tar.gz
- https://github.com/hrydgard/ppsspp-lang/archive/7876a52f.tar.gz
- https://github.com/hrydgard/native/archive/78941b08.tar.gz"
+ https://github.com/hrydgard/ppsspp-ffmpeg/archive/a7cae9c.tar.gz
+ https://github.com/hrydgard/ppsspp-lang/archive/a86ff6a.tar.gz
+ https://github.com/Kingcom/armips/archive/9b225d9.tar.gz"
 checksum="
- a465159a66d9514dfb037570ee080b6946b571b72cbcdd0b4b3cbc9b05843161
- beedce003bbfa915d7ebbec91adb649bef1f84fb865ae3b72381957bc3bddac2
- 25f6b9497640690f07dc9a1171f3ee9d6ae7dbe9f6008aa95727a0d1b0da0c5f
- e3fe30296832b8fe107d6c901110a37959985777a92c6c5ce811e2b811a94e61"
+ 4bcd1cc1b3b1f50f5ebbde8dfd47aceffebc07624c03ea651e80c87ce5f68cc8
+ b839c78ad1241c51a32f71390352fbe3a923d81292a020440d477cde4da2c595
+ 0b900d829105e9174b3e43af78ae59529bd206ce6ab1c6b5db91741a78fd3920
+ 5d412c47de19d72d97abc960aab846e04d4c3c8c181f392e9013529c4c038ee8"
 nocross=yes
 
 pre_configure() {
 	# copy submodules to right location
-	cp -rup ${wrksrc}/native-*/* ${wrksrc}/${pkgname}-${version}/native
 	cp -rup ${wrksrc}/ppsspp-lang-*/* ${wrksrc}/${pkgname}-${version}/lang
 	cp -rup ${wrksrc}/ppsspp-ffmpeg-*/linux ${wrksrc}/${pkgname}-${version}/ffmpeg
+	cp -rup ${wrksrc}/armips-*/* ${wrksrc}/${pkgname}-${version}/ext/armips
 	# disable git versioning
 	sed 's|find_package(Git)|# &|' -i ${wrksrc}/${pkgname}-${version}/git-version.cmake
 	rm -rf ${pkgname}-${version}/build


### PR DESCRIPTION
[native](https://github.com/hrydgard/native) isn't used anymore and [armips](https://github.com/Kingcom/armips) is now required to build the package.