### PR TITLE
adobe-flash-plugin: fixed URL

### DIFF
--- a/srcpkgs/adobe-flash-plugin/template
+++ b/srcpkgs/adobe-flash-plugin/template
@@ -1,17 +1,17 @@
 # Template file for 'adobe-flash-plugin'
 pkgname=adobe-flash-plugin
-version=11.2.202.548
+version=11.2.202.559
 revision=1
 # The EULA file
 _eula="http://www.adobe.com/products/eulas/pdfs/PlatformClients_PC_WWEULA_Combined_20100108_1657.pdf"
 _eulacksum=3cb0a5f4576be735abcff7189ed18eda17c70b762c3a78a3379b6f44395fbc10
-_url=http://fpdownload.macromedia.com/get/flashplayer/pdc/${version}
+_url=http://fpdownload.adobe.com/get/flashplayer/pdc/${version}
 if [ "$XBPS_MACHINE" = "x86_64" ]; then
 	_disttarball="${_url}/install_flash_player_11_linux.x86_64.tar.gz"
-	_distcksum=62ec1da116e879233ef41d3c77bbe2e7ccb88ab2311d2bcba2e665c94e18e847
+	_distcksum=ebba1e03aa2e191811a6165e2dc1b3cdda49cc855399f07bc9786421c40308b6
 else
 	_disttarball="${_url}/install_flash_player_11_linux.i386.tar.gz"
-	_distcksum=88efdfbed760994383a815c78c8c2d5eaad2abc56557f54bd15f167c0b291294
+	_distcksum=09d4d16f8a508fdb678372ae91ba9ea3c2b22d9c0c72591fd3a2f0d39171a8c5
 fi
 distfiles="${_eula} ${_disttarball}"
 checksum="${_eulacksum} ${_distcksum}"


### PR DESCRIPTION
Despite the `adobe-flash-plugin` being marked as restrictive and [requiring manual building](https://wiki.voidlinux.eu/Flash), the package would always fail to build as the URL was pointing to the wrong location.  This patch points XBPS to the right place and the package can be installed successfully once built.