### PR TITLE
memtest86+: fix compilation for gcc-4.7.2 and later, fix PCI scan

### DIFF
--- a/srcpkgs/memtest86+/patches/00.memtest86+-5.01-no-scp.patch
+++ b/srcpkgs/memtest86+/patches/00.memtest86+-5.01-no-scp.patch
@@ -1,0 +1,10 @@
+--- Makefile.orig
++++ Makefile
+@@ -21,7 +21,6 @@ OBJS= head.o reloc.o main.o test.o init.o lib.o patn.o screen_buffer.o \
+       
+ 
+ all: clean memtest.bin memtest 
+-		 scp memtest.bin root@192.168.0.12:/srv/tftp/mt86plus
+ 
+ # Link it statically once so I know I don't have undefined
+ # symbols and then link it dynamically so I have full

--- a/srcpkgs/memtest86+/patches/01.memtest86+-5.01-no-optimization.patch
+++ b/srcpkgs/memtest86+/patches/01.memtest86+-5.01-no-optimization.patch
@@ -1,0 +1,18 @@
+Patch to get memtest86+ working with gcc 4.7.2 or later and PCI scan fix
+these patches were taken from Mageia
+upstream report containing link to the patches:
+http://forum.canardpc.com/threads/83443-Memtest86-V5.01-crashes-with-gcc-4.7.2-or-later
+
+Patch source: http://pkgs.fedoraproject.org/cgit/rpms/memtest86+.git/
+
+--- Makefile~	2014-01-08 01:30:11.355900076 +0000
++++ Makefile	2014-01-08 01:31:19.387555469 +0000
+@@ -12,7 +12,7 @@
+ AS=as -32
+ CC=gcc
+ 
+-CFLAGS= -Wall -march=i486 -m32 -O1 -fomit-frame-pointer -fno-builtin \
++CFLAGS= -Wall -march=i486 -m32 -O0 -fomit-frame-pointer -fno-builtin \
+ 	-ffreestanding -fPIC $(SMP_FL) -fno-stack-protector 
+ 	
+ OBJS= head.o reloc.o main.o test.o init.o lib.o patn.o screen_buffer.o \

--- a/srcpkgs/memtest86+/patches/02.memtest86+-5.01-compile-fix.patch
+++ b/srcpkgs/memtest86+/patches/02.memtest86+-5.01-compile-fix.patch
@@ -1,0 +1,27 @@
+Patch to get memtest86+ working with gcc 4.7.2 or later and PCI scan fix
+these patches were taken from Mageia
+upstream report containing link to the patches:
+http://forum.canardpc.com/threads/83443-Memtest86-V5.01-crashes-with-gcc-4.7.2-or-later
+
+Patch source: http://pkgs.fedoraproject.org/cgit/rpms/memtest86+.git/
+
+--- io.h~	2013-08-10 02:01:58.000000000 +0000
++++ io.h	2014-01-08 01:29:12.404465515 +0000
+@@ -31,7 +31,7 @@
+  */
+ 
+ #define __OUT1(s,x) \
+-extern inline void __out##s(unsigned x value, unsigned short port) {
++static inline void __out##s(unsigned x value, unsigned short port) {
+ 
+ #define __OUT2(s,s1,s2) \
+ __asm__ __volatile__ ("out" #s " %" s1 "0,%" s2 "1"
+@@ -43,7 +43,7 @@
+ __OUT1(s##c_p,x) __OUT2(s,s1,"") : : "a" (value), "id" (port)); SLOW_DOWN_IO; }
+ 
+ #define __IN1(s) \
+-extern inline RETURN_TYPE __in##s(unsigned short port) { RETURN_TYPE _v;
++static inline RETURN_TYPE __in##s(unsigned short port) { RETURN_TYPE _v;
+ 
+ #define __IN2(s,s1,s2) \
+ __asm__ __volatile__ ("in" #s " %" s2 "1,%" s1 "0"

--- a/srcpkgs/memtest86+/patches/03.memtest86+-5.01-crash-fix.patch
+++ b/srcpkgs/memtest86+/patches/03.memtest86+-5.01-crash-fix.patch
@@ -1,0 +1,100 @@
+Patch to get memtest86+ working with gcc 4.7.2 or later and PCI scan fix
+these patches were taken from Mageia
+upstream report containing link to the patches:
+http://forum.canardpc.com/threads/83443-Memtest86-V5.01-crashes-with-gcc-4.7.2-or-later
+
+Patch source: http://pkgs.fedoraproject.org/cgit/rpms/memtest86+.git/
+
+--- controller.c.orig
++++ controller.c
+@@ -2,6 +2,8 @@
+  * MemTest86+ V5 Specific code (GPL V2.0)
+  * By Samuel DEMEULEMEESTER, sdemeule@memtest.org
+  * http://www.canardpc.com - http://www.memtest.org
++ *
++ * Edited by David McInnis Oct 4, 2014
+  */
+ 
+ //#include "defs.h"
+@@ -292,7 +294,7 @@ static void setup_nhm(void)
+ 
+ 	/* First, locate the PCI bus where the MCH is located */
+ 
+-	for(i = 0; i < sizeof(possible_nhm_bus); i++) {
++	for(i = 0; i < sizeof(possible_nhm_bus) / sizeof(possible_nhm_bus[0]); i++) {
+ 		pci_conf_read( possible_nhm_bus[i], 3, 4, 0x00, 2, &vid);
+ 		pci_conf_read( possible_nhm_bus[i], 3, 4, 0x02, 2, &did);
+ 		vid &= 0xFFFF;
+@@ -327,7 +329,7 @@ static void setup_nhm32(void)
+ 	ctrl.mode = ECC_NONE;
+ 
+ 	/* First, locate the PCI bus where the MCH is located */
+-	for(i = 0; i < sizeof(possible_nhm_bus); i++) {
++	for(i = 0; i < sizeof(possible_nhm_bus) / sizeof(possible_nhm_bus[0]); i++) {
+ 		pci_conf_read( possible_nhm_bus[i], 3, 4, 0x00, 2, &vid);
+ 		pci_conf_read( possible_nhm_bus[i], 3, 4, 0x02, 2, &did);
+ 		vid &= 0xFFFF;
+@@ -1424,7 +1426,7 @@ static void poll_fsb_amd64(void) {
+ 	unsigned long dramchr;
+ 	float clockratio;
+ 	double dramclock;
+-	unsigned int dummy[3];
++	unsigned int dummy[4];
+ 	int ram_type;
+ 
+ 	float coef = 10;
+@@ -2851,13 +2853,13 @@ static void poll_timings_nf4ie(void) {
+ 
+ static void poll_timings_i875(void) {
+ 
+-	ulong dev6, dev62;
++	ulong dev6;
+ 	ulong temp;
+ 	float cas;
+ 	int rcd, rp, ras, chan;
+ 	long *ptr, *ptr2;
+ 
+-	pci_conf_read( 0, 6, 0, 0x40, 4, &dev62);
++	pci_conf_read( 0, 6, 0, 0x40, 4, &dev6);
+ 	ptr2=(long*)(dev6+0x68);
+ 
+ 	/* Read the MMR Base Address & Define the pointer */
+--- init.c.orig
++++ init.c
+@@ -7,6 +7,8 @@
+  *
+  * Released under version 2 of the Gnu Public License.
+  * By Chris Brady
++ *
++ * Edited by David McInnis October 4, 2014
+  */
+  
+ 
+@@ -914,7 +916,6 @@ void cpu_type(void)
+ 			default:
+ 				cprint(0, COL_MID, "Unknown Intel");
+  				break;
+-			break;
+ 		    }
+ 
+ 		}
+--- main.c.orig
++++ main.c
+@@ -422,7 +422,7 @@ void test_start(void)
+ 		//initialise_cpus();
+ 		btrace(my_cpu_num, __LINE__, "BeforeInit", 1, 0, 0);
+ 		/* Draw the screen and get system information */
+-	  init();
++		init();
+ 
+ 		/* Set defaults and initialize variables */
+ 		set_defaults();
+@@ -737,7 +737,7 @@ void test_start(void)
+ 			    /* Do the same test for each CPU */
+ 			    if (++cpu_sel >= act_cpus) 
+ 			    	{
+-	            cpu_sel = 0;
++				cpu_sel = 0;
+ 			        next_test();
+ 			    	} else {
+ 			        continue;

--- a/srcpkgs/memtest86+/patches/04.memtest86+-5.01-fgnu89-inline.patch
+++ b/srcpkgs/memtest86+/patches/04.memtest86+-5.01-fgnu89-inline.patch
@@ -1,0 +1,15 @@
+"Fix compilation of inline assembly with new gcc"
+
+Patch source: http://pkgs.fedoraproject.org/cgit/rpms/memtest86+.git/
+
+--- Makefile.orig
++++ Makefile
+@@ -13,7 +13,7 @@ AS=as -32
+ CC=gcc
+ 
+ CFLAGS= -Wall -march=i486 -m32 -O0 -fomit-frame-pointer -fno-builtin \
+-	-ffreestanding -fPIC $(SMP_FL) -fno-stack-protector 
++	-ffreestanding -fPIC $(SMP_FL) -fno-stack-protector -fgnu89-inline
+ 	
+ OBJS= head.o reloc.o main.o test.o init.o lib.o patn.o screen_buffer.o \
+       config.o cpuid.o linuxbios.o pci.o memsize.o spd.o error.o dmi.o controller.o \

--- a/srcpkgs/memtest86+/template
+++ b/srcpkgs/memtest86+/template
@@ -1,7 +1,7 @@
 # Template file for 'memtest86+'
 pkgname=memtest86+
 version=5.01
-revision=3
+revision=4
 homepage="http://www.memtest.org"
 distfiles="http://www.memtest.org/download/$version/$pkgname-$version.tar.gz"
 short_desc="An Advanced Memory Diagnostic Tool"
@@ -17,9 +17,6 @@ if [ "$XBPS_MACHINE" = "x86_64" ]; then
 	makedepends="gcc-multilib"
 fi
 
-pre_build() {
-	sed '/scp memtest.*/d' -i Makefile
-}
 do_build() {
 	make
 }


### PR DESCRIPTION
With the help of Fedora project packaging (http://pkgs.fedoraproject.org/cgit/rpms/memtest86+.git/). Fix #3526 