### PR TITLE
Nettle 3.2

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1153,8 +1153,8 @@ libHX.so.28 libHX-3.14_1
 libxkbcommon.so.0 libxkbcommon-0.2.0_1
 libxkbcommon-x11.so.0 libxkbcommon-x11-0.4.2_1
 libgee-0.8.so.2 libgee08-0.8.2_1
-libnettle.so.4 nettle-2.5_1
-libhogweed.so.2 nettle-2.5_1
+libnettle.so.6 nettle-3.2_1
+libhogweed.so.4 nettle-3.2_1
 libmikmod.so.3 libmikmod-3.2.0_1
 libgtkspell.so.0 gtkspell-2.0.16_1
 libpurple.so.0 libpurple-2.10.6_1

--- a/srcpkgs/gnutls/template
+++ b/srcpkgs/gnutls/template
@@ -1,6 +1,6 @@
 # Template file for 'gnutls'
 pkgname=gnutls
-version=3.3.20
+version=3.3.21
 revision=1
 build_style=gnu-configure
 configure_args="--with-zlib --disable-guile --disable-static
@@ -13,7 +13,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnu.org/software/gnutls/"
 license="GPL-3, LGPL-2.1"
 distfiles="ftp://ftp.gnutls.org/gcrypt/gnutls/v${version%.*}/gnutls-${version}.tar.xz"
-checksum=4c903e5cde7a8f15318af9a7a6c9b7fc8348594b0a1e9ac767636ef2187399ea
+checksum=885ccb46e52f5a9f5aed3edf8aae4d67aa85e41b72471bed93e84fe3f7df3e5e
 
 pre_configure() {
 	autoreconf -fi

--- a/srcpkgs/nettle/template
+++ b/srcpkgs/nettle/template
@@ -1,8 +1,7 @@
 # Template build file for 'nettle'.
 pkgname=nettle
-version=2.7.1
-reverts=3.0_1
-revision=5
+version=3.2
+revision=1
 build_style=gnu-configure
 hostmakedepends="m4"
 makedepends="gmp-devel"
@@ -12,7 +11,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.lysator.liu.se/~nisse/nettle/"
 license="GPL-2"
 distfiles="${GNU_SITE}/$pkgname/$pkgname-${version}.tar.gz"
-checksum=bc71ebd43435537d767799e414fce88e521b7278d48c860651216e1fc6555b40
+checksum=ea4283def236413edab5a4cf9cf32adf540c8df1b9b67641cfc2302fca849d97
 
 nettle-devel_package() {
 	depends="gmp-devel ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/qemu/template
+++ b/srcpkgs/qemu/template
@@ -1,7 +1,7 @@
 # Template file for 'qemu'
 pkgname=qemu
 version=2.5.0
-revision=1
+revision=2
 short_desc="Open Source Processor Emulator"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://qemu.org"

--- a/srcpkgs/rdfind/template
+++ b/srcpkgs/rdfind/template
@@ -1,7 +1,7 @@
 # Template file for 'rdfind'
 pkgname=rdfind
 version=1.3.4
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="nettle-devel"
 short_desc="A program that finds duplicate files"


### PR DESCRIPTION
GnuTLS 3.3 can use Nettle 3 since mid-2015, and recent security fixes are a good reason to do so.

GnuTLS 3.4 is declared stable now, too, but will require rebuilding ~35 packages.