### PR TITLE
docker: Fix deprecated daemon option (-d)

### DIFF
--- a/srcpkgs/docker/files/docker/run
+++ b/srcpkgs/docker/files/docker/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 [ -r conf ] && . ./conf
 modprobe -q loop || exit 1
-exec chpst -o 1048576 -p 1048576 docker -d $OPTS 2>/dev/null
+exec chpst -o 1048576 -p 1048576 docker daemon $OPTS 2>/dev/null

--- a/srcpkgs/docker/template
+++ b/srcpkgs/docker/template
@@ -1,7 +1,7 @@
 # Template file for 'docker'
 pkgname=docker
 version=1.10.0
-revision=1
+revision=2
 hostmakedepends="git go"
 makedepends="libbtrfs-devel sqlite-devel device-mapper-devel"
 short_desc="Pack, ship and run any application as a lightweight container"


### PR DESCRIPTION
Docker has completely abandoned the `-d` daemon option with their version 1.10.0.
This fixes the runit `run` script with the `daemon` option.