### PR TITLE
New package: libpurple-facebook-20160125.92885e0456ed

### DIFF
--- a/srcpkgs/libpurple-facebook/template
+++ b/srcpkgs/libpurple-facebook/template
@@ -1,0 +1,17 @@
+# Template file for 'libpurple-facebook'
+
+pkgname="libpurple-facebook"
+_release_date="20160125"
+_upstream_version="92885e0456ed"
+version="${_release_date}.${_upstream_version}"
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config"
+makedepends="libpurple-devel json-glib-devel"
+short_desc="A Facebook plugin for libpurple"
+maintainer="John Regan <john@jrjrtech.com>"
+license="GPL-2"
+homepage="https://github.com/jgeboski/purple-facebook"
+distfiles="https://github.com/jgeboski/purple-facebook/releases/download/${_upstream_version}/purple-facebook-${_upstream_version}.tar.gz"
+checksum=1ad21397dcb57cf22fdb1a89b9610d5a1d2227ad378331dcbb37950d4026cd26
+wrksrc="purple-facebook-${_upstream_version}"


### PR DESCRIPTION
I know that version number seems pretty weird - but that seems to be how the author does releases: https://github.com/jgeboski/purple-facebook/releases