### PR TITLE
fltk-1.3.3: Fl_XFont_On_Demand.patch

### DIFF
--- a/srcpkgs/fltk/patches/Fl_XFont_On_Demand.patch
+++ b/srcpkgs/fltk/patches/Fl_XFont_On_Demand.patch
@@ -1,0 +1,42 @@
+Index: src/fl_font.cxx
+===================================================================
+--- src/fl_font.cxx	(revision 10503)
++++ src/fl_font.cxx	(revision 10504)
+@@ -55,6 +55,12 @@
+ #  include "fl_font_x.cxx"
+ #endif // WIN32
+ 
++#if ! (defined(WIN32) || defined(__APPLE__))
++XFontStruct *fl_X_core_font()
++{
++  return fl_xfont.value();
++}
++#endif
+ 
+ double fl_width(const char* c) {
+   if (c) return fl_width(c, (int) strlen(c));
+Index: src/gl_draw.cxx
+===================================================================
+--- src/gl_draw.cxx	(revision 10503)
++++ src/gl_draw.cxx	(revision 10504)
+@@ -81,7 +81,7 @@
+  * then sorting through them at draw time (for normal X rendering) to find which one can
+  * render the current glyph... But for now, just use the first font in the list for GL...
+  */
+-    XFontStruct *font = fl_xfont;
++    XFontStruct *font = fl_X_core_font();
+     int base = font->min_char_or_byte2;
+     int count = font->max_char_or_byte2-base+1;
+     fl_fontsize->listbase = glGenLists(256);
+Index: FL/x.H
+===================================================================
+--- FL/x.H	(revision 10503)
++++ FL/x.H	(revision 10504)
+@@ -132,6 +132,7 @@
+   XFontStruct *ptr;
+ };
+ extern FL_EXPORT Fl_XFont_On_Demand fl_xfont;
++extern FL_EXPORT XFontStruct* fl_X_core_font();
+ 
+ // this object contains all X-specific stuff about a window:
+ // Warning: this object is highly subject to change!  

--- a/srcpkgs/fltk/template
+++ b/srcpkgs/fltk/template
@@ -1,7 +1,7 @@
 # Template file for 'fltk'
 pkgname=fltk
 version=1.3.3
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--enable-threads --enable-xft --enable-shared"
 makedepends="libjpeg-turbo-devel libpng-devel MesaLib-devel alsa-lib-devel


### PR DESCRIPTION
This patch was merged into fltk subversion, but no release contains it
yet:

http://www.fltk.org/str.php?L3156

Without it, octave will display teh following error message, even with
teh --no-gui option:

```
error: /usr/lib/octave/4.0.0/oct/x86_64-unknown-linux-gnu/PKG_ADD: /usr/lib/octave/4.0.0/oct/x86_64-unknown-linux-gnu/__init_fltk__.oct: failed to load: /usr/lib/libfltk_gl.so.1.3: undefined symbol: _ZN18Fl_XFont_On_Demand5valueEv
error: called from
    /usr/lib/octave/4.0.0/oct/x86_64-unknown-linux-gnu/PKG_ADD at line 3 column 1
```

and fail to add '.' (teh current directory) to teh load path.