### PR TITLE
python3.4-cairo: set nocross until upstream fixes waf

### DIFF
--- a/srcpkgs/python3.4-cairo/template
+++ b/srcpkgs/python3.4-cairo/template
@@ -2,6 +2,7 @@
 pkgname=python3.4-cairo
 version=1.10.0
 revision=6
+nocross=1
 wrksrc="pycairo-${version}"
 build_style=waf3
 patch_args="-Np1"


### PR DESCRIPTION
This PR deals with #3602 until such time as upstream fixes the laughably outdated version of waf they are shipping.