### PR TITLE
samba: fix loggers.

### DIFF
--- a/srcpkgs/samba/files/nmbd/log/run
+++ b/srcpkgs/samba/files/nmbd/log/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec logger -p nmbd.notice
+exec logger -p daemon.notice -t nmbd

--- a/srcpkgs/samba/files/smbd/log/run
+++ b/srcpkgs/samba/files/smbd/log/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec logger -p smbd.notice
+exec logger -p daemon.notice -t smbd

--- a/srcpkgs/samba/template
+++ b/srcpkgs/samba/template
@@ -1,7 +1,7 @@
 # Template file for 'samba'
 pkgname=samba
 version=3.6.25
-revision=9
+revision=10
 build_wrksrc=source3
 build_style=gnu-configure
 configure_args="--with-fhs --with-pam --with-pam_smbpass --with-ldap


### PR DESCRIPTION
Syslog is limited to a set of predefined facilities.  The facility
names nmbd and smbd are not on that list, so the loggers were not
actually working till now.