### PR TITLE
bitcoin: update to 0.11.2.

### DIFF
--- a/srcpkgs/bitcoin/template
+++ b/srcpkgs/bitcoin/template
@@ -1,7 +1,7 @@
 # Template file for 'bitcoin'
 pkgname=bitcoin
-version=0.10.2
-revision=4
+version=0.11.2
+revision=1
 create_wrksrc=yes
 hostmakedepends="pkg-config yasm"
 makedepends="db-devel protobuf-devel libressl-devel boost-devel miniupnpc-devel"
@@ -10,7 +10,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="MIT"
 homepage="http://www.bitcoin.org/"
 distfiles="https://bitcoin.org/bin/bitcoin-core-${version}/bitcoin-${version}.tar.gz"
-checksum=cddf96c71d0a35524fde93380981cf0cf0b51441454a3a68b9be491b9239bfec
+checksum=a4d2bd642e5f7f1f82dc3f708618ac77e1e45353db7a98bf81c3bdc0e10690d3
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) broken="http://build.voidlinux.eu/builders/armv6l-musl_builder/builds/2804/steps/shell_3/logs/stdio";;
@@ -19,8 +19,8 @@ esac
 if [ -z "$CROSS_BUILD" ]; then
 	# XXX -qt subpkg
 	hostmakedepends+=" automoc4"
-	makedepends+=" qt-devel"
-	configure_args+=" --with-gui=qt4"
+	makedepends+=" qt5-devel qt5-tools-devel"
+	configure_args+=" --with-gui"
 fi
 
 pre_configure() {
@@ -36,7 +36,13 @@ pre_configure() {
 }
 do_configure() {
 	cd ${pkgname}-${version}
-	./configure ${configure_args} --with-incompatible-bdb --with-boost=${XBPS_CROSS_BASE}/usr
+	./configure ${configure_args} \
+		--with-libressl \
+		--with-incompatible-bdb \
+		--disable-ccache \
+		--disable-static \
+		--enable-hardening \
+		--with-boost=${XBPS_CROSS_BASE}/usr
 }
 do_build() {
 	cd ${pkgname}-${version}


### PR DESCRIPTION
Notes on changes:
* `--with-libressl` flag: required in order to configure
* qt5 gui toolkit: now default in bitcoin
* `--with-gui=qt4` ignored anyway when building with qt5 dependencies so replaced it with `--with-gui`