### PR TITLE
sessreg: fix musl build again

### DIFF
--- a/srcpkgs/sessreg/template
+++ b/srcpkgs/sessreg/template
@@ -1,7 +1,7 @@
 # Template build file for 'sessreg'.
 pkgname=sessreg
 version=1.1.0
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libX11-devel"
@@ -14,3 +14,9 @@ checksum=551177657835e0902b5eee7b19713035beaa1581bbd3c6506baa553e751e017c
 
 # musl does not define _WTMPX_FILE, use WTMP_FILE instead.
 CFLAGS="-D_WTMPX_FILE=WTMP_FILE -D_PATH_WTMPX=_PATH_WTMP"
+# musl does not define _UTMPX_FILE, use UTMP_FILE instead.
+CFLAGS+=" -D_UTMPX_FILE=UTMP_FILE -D_PATH_UTMPX=_PATH_UTMP"
+
+post_install() {
+	vlicense COPYING
+}


### PR DESCRIPTION
For musl define _PATH_UTMPX analogous to _PATH_WTMPX.

Since musl 1.1.13 there's a stub for `utmpxname()` in `/usr/include/utmpx.h` and thus configure sets `#define HAVE_UTMPXNAME 1` in `config.h`. See http://git.musl-libc.org/cgit/musl/tree/WHATSNEW section *1.1.13 release notes*
