### PR TITLE
vim: update to 7.4.1376.

### DIFF
--- a/srcpkgs/vim/template
+++ b/srcpkgs/vim/template
@@ -1,8 +1,8 @@
 # Template file for 'vim'
 pkgname=vim
-version=7.4.1046
+version=7.4.1376
 revision=1
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config glib-devel"
 makedepends="ncurses-devel acl-devel libXt-devel gtk+-devel perl
  ruby-devel python-devel python3.4-devel lua-devel"
 depends="vim-common>=$version"
@@ -11,7 +11,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.vim.org"
 license="Vim"
 distfiles="https://github.com/${pkgname}/${pkgname}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=9fd4f4e40f55ea1402e91f527995c32cdd2366d5db2639c533041b22b408865f
+checksum=ba49441fccc99e5d513ddac911f54bd3caa590a3c2b6b4dfab41a4587602fce2
 
 subpackages="xxd vim-common vim-x11 gvim"
 # XXX vim-huge cannot be cross compiled for now.


### PR DESCRIPTION
`hostmakedepends+="glib-devel"` since the gvim build now uses `glib-compile-resources`.