### PR TITLE
Add xdotool to depends for clipit

### DIFF
--- a/srcpkgs/clipit/template
+++ b/srcpkgs/clipit/template
@@ -1,10 +1,11 @@
 # Template file for 'clipit'
 pkgname=clipit
 version=1.4.2
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="intltool pkg-config"
 makedepends="gtk+-devel librsvg-devel"
+depends="xdotool"
 short_desc="Lightweight GTK+ clipboard manager"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="GPL-3"


### PR DESCRIPTION
Clipit requires xdotools for the "Automatically paste selected item" setting, else the intended functionality will not work, and it will spit error into the console, listing the missing dependency.