### PR TITLE
New package: libreoffice-5.1.0.3

### DIFF
--- a/srcpkgs/libreoffice/patches/0001-poppler-version.patch
+++ b/srcpkgs/libreoffice/patches/0001-poppler-version.patch
@@ -1,0 +1,16 @@
+--- sdext/source/pdfimport/xpdfwrapper/pdfioutdev_gpl.hxx	2016-02-23 15:45:23.435519407 +0100
++++ sdext/source/pdfimport/xpdfwrapper/pdfioutdev_gpl.hxx	2016-02-23 15:45:39.779520585 +0100
+@@ -54,10 +54,10 @@
+ #if HAVE_POPPLER_VERSION_H
+ #include <cpp/poppler-version.h>
+ #else
+-#define POPPLER_VERSION "0.12.3"
++#define POPPLER_VERSION "0.41.0"
+ #define POPPLER_VERSION_MAJOR 0
+-#define POPPLER_VERSION_MINOR 12
+-#define POPPLER_VERSION_MICRO 3
++#define POPPLER_VERSION_MINOR 41
++#define POPPLER_VERSION_MICRO 0
+ #endif
+ #define POPPLER_CHECK_VERSION(major,minor,micro) \
+   (POPPLER_VERSION_MAJOR > (major) || \

--- a/srcpkgs/libreoffice/patches/0002-std-isnan.patch
+++ b/srcpkgs/libreoffice/patches/0002-std-isnan.patch
@@ -1,0 +1,11 @@
+--- xmloff/source/draw/ximp3dscene.cxx	2016-01-27 01:58:25.000000000 +0100
++++ xmloff/source/draw/ximp3dscene.cxx	2016-02-23 19:01:35.785368122 +0100
+@@ -66,7 +66,7 @@
+             {
+                 ::basegfx::B3DVector aVal;
+                 SvXMLUnitConverter::convertB3DVector(aVal, sValue);
+-                if (!isnan(aVal.getX()) && !isnan(aVal.getY()) && !isnan(aVal.getZ()))
++                if (!std::isnan(aVal.getX()) && !std::isnan(aVal.getY()) && !std::isnan(aVal.getZ()))
+                 {
+                     maDirection = aVal;
+                 }

--- a/srcpkgs/libreoffice/patches/0003-configure_ac-libc-version.patch
+++ b/srcpkgs/libreoffice/patches/0003-configure_ac-libc-version.patch
@@ -1,0 +1,29 @@
+Rip out libc version check.
+Our glibc is newer than 2.1.1
+The musl libc has an entirely unrelated version number
+and of course does not support gnu_get_libc_version()
+
+--- configure.ac	2016-01-27 01:58:25.000000000 +0100
++++ configure.ac	2016-02-23 19:21:58.906456302 +0100
+@@ -9676,21 +9676,6 @@
+ fi
+ AC_SUBST(SYSTEM_LIBEXTTEXTCAT_DATA)
+ 
+-dnl ***************************************
+-dnl testing libc version for Linux...
+-dnl ***************************************
+-if test "$_os" = "Linux"; then
+-    AC_MSG_CHECKING([whether libc is >= 2.1.1])
+-    exec 6>/dev/null # no output
+-    AC_CHECK_LIB(c, gnu_get_libc_version, HAVE_LIBC=yes; export HAVE_LIBC)
+-    exec 6>&1 # output on again
+-    if test "$HAVE_LIBC"; then
+-        AC_MSG_RESULT([yes])
+-    else
+-        AC_MSG_ERROR([no, upgrade libc])
+-    fi
+-fi
+-
+ dnl =========================================
+ dnl Check for the Windows  SDK.
+ dnl =========================================

--- a/srcpkgs/libreoffice/patches/0004-musl-execinfo_h.patch
+++ b/srcpkgs/libreoffice/patches/0004-musl-execinfo_h.patch
@@ -1,0 +1,11 @@
+--- sal/osl/unx/signal.cxx	2016-01-27 01:58:25.000000000 +0100
++++ sal/osl/unx/signal.cxx	2016-02-23 19:33:44.618507179 +0100
+@@ -33,7 +33,7 @@
+ 
+ #endif /* MACOSX */
+ 
+-#ifdef LINUX
++#if defined(LINUX) && defined(__GLIBC__)
+ #include <execinfo.h>
+ #include <link.h>
+ #define INCLUDE_BACKTRACE

--- a/srcpkgs/libreoffice/patches/0005-firebird-glibc.patch
+++ b/srcpkgs/libreoffice/patches/0005-firebird-glibc.patch
@@ -1,0 +1,14 @@
+--- /dev/null	2016-02-21 14:44:37.295798706 +0100
++++ external/firebird/firebird-glibc.patch.0	2016-02-24 15:12:43.055606993 +0100
+@@ -0,0 +1,11 @@
++--- src/common/classes/rwlock.h	2015-03-27 14:47:01.000000000 +0100
+++++ src/common/classes/rwlock.h	2016-02-24 15:11:46.043602883 +0100
++@@ -191,7 +191,7 @@
++ 
++ 	void init()
++ 	{
++-#if defined(LINUX) && !defined(USE_VALGRIND)
+++#if defined(LINUX) && defined(__GLIBC__) && !defined(USE_VALGRIND)
++ 		pthread_rwlockattr_t attr;
++ 		if (pthread_rwlockattr_init(&attr))
++ 			system_call_failed::raise("pthread_rwlockattr_init");

--- a/srcpkgs/libreoffice/patches/0006-firebird-libio.patch
+++ b/srcpkgs/libreoffice/patches/0006-firebird-libio.patch
@@ -1,0 +1,14 @@
+--- /dev/null	2016-02-21 14:44:37.295798706 +0100
++++ external/firebird/firebird-libio.patch.0	2016-02-24 15:39:05.303721064 +0100
+@@ -0,0 +1,11 @@
++--- src/jrd/perf.h	2015-03-27 14:46:58.000000000 +0100
+++++ src/jrd/perf.h	2016-02-24 15:38:06.674716837 +0100
++@@ -31,7 +31,7 @@
++ #ifndef JRD_PERF_H
++ #define JRD_PERF_H
++ 
++-#ifdef LINUX
+++#if defined(LINUX) && defined(__GLIBC__)
++ #include <libio.h>
++ #endif
++ 

--- a/srcpkgs/libreoffice/patches/0007-firebird-patches.patch
+++ b/srcpkgs/libreoffice/patches/0007-firebird-patches.patch
@@ -1,0 +1,11 @@
+--- external/firebird/UnpackedTarball_firebird.mk	2016-01-27 01:58:25.000000000 +0100
++++ external/firebird/UnpackedTarball_firebird.mk	2016-02-24 15:13:34.733610719 +0100
+@@ -19,6 +19,8 @@
+ 	external/firebird/firebird-c++11replfn.patch.0 \
+         external/firebird/firebird.disable-ib-util-not-found.patch.1 \
+ 	external/firebird/firebird-c++14.patch \
++	external/firebird/firebird-glibc.patch.0 \
++	external/firebird/firebird-libio.patch.0 \
+ ))
+ 
+ ifeq ($(OS)-$(COM),WNT-MSC)

--- a/srcpkgs/libreoffice/patches/0008-musl-sys_time_h.patch
+++ b/srcpkgs/libreoffice/patches/0008-musl-sys_time_h.patch
@@ -1,0 +1,12 @@
+--- vcl/inc/headless/svpinst.hxx	2016-01-27 01:58:25.000000000 +0100
++++ vcl/inc/headless/svpinst.hxx	2016-02-24 18:41:32.947510323 +0100
+@@ -32,6 +32,9 @@
+ #include <list>
+ 
+ #include <time.h>
++#if !defined(__GLIBC__)
++#include <sys/time.h>
++#endif
+ 
+ #define VIRTUAL_DESKTOP_WIDTH 1024
+ #define VIRTUAL_DESKTOP_HEIGHT 768

--- a/srcpkgs/libreoffice/patches/0009-musl-unistd_h.patch
+++ b/srcpkgs/libreoffice/patches/0009-musl-unistd_h.patch
@@ -1,0 +1,11 @@
+--- sd/source/ui/remotecontrol/BluetoothServer.cxx	2016-01-27 01:58:25.000000000 +0100
++++ sd/source/ui/remotecontrol/BluetoothServer.cxx	2016-02-25 15:06:53.971708191 +0100
+@@ -21,7 +21,7 @@
+   #include <dbus/dbus.h>
+   #include <errno.h>
+   #include <fcntl.h>
+-  #include <sys/unistd.h>
++  #include <unistd.h>
+   #include <sys/socket.h>
+   #include <bluetooth/bluetooth.h>
+   #include <bluetooth/rfcomm.h>

--- a/srcpkgs/libreoffice/template
+++ b/srcpkgs/libreoffice/template
@@ -1,0 +1,213 @@
+# Template file for 'libreoffice'
+pkgname=libreoffice
+version=5.1.0.3
+revision=1
+build_style=gnu-configure
+configure_args="--disable-werror"
+nopie=yes
+nocross=yes
+#
+# XXX: libwps-0.4.x mit-krb5-devel nasm openjdk sane vlc
+#      hamcrest hyphen iwyu libebook libfreehand libmwaw
+#      lp_solve mdds ogl-math OpenCOLLADA orcus telepathy-glib-devel
+# Missing, required libraries are downloaded and built internally
+#
+hostmakedepends="automake libtool pkg-config bison flex gperf icu
+ perl-Archive-Zip unzip zip wget"
+makedepends="apr-devel boost-devel cups-devel libcurl-devel
+ dbus-glib-devel libjpeg-turbo-devel libpng-devel glu-devel graphite-devel
+ gst-plugins-base1-devel gtk+-devel gtk+3-devel harfbuzz-devel icu-devel
+ libatomic_ops-devel lcms2-devel librsvg-devel libxml2-devel libxslt-devel
+ MesaLib-devel neon-devel nss-devel python3.4-devel libressl-devel libgcrypt-devel
+ libgpg-error-devel poppler-devel postgresql-libs-devel redland-devel
+ unixodbc-devel libXt-devel
+
+ avahi-libs-devel hunspell-devel libabw-devel libcdr-devel libcmis-devel
+ libcppunit-devel libexttextcat-devel liblangtag-devel libmspub-devel
+ glew-devel glyphy-devel libodfgen-devel libpagemaker-devel librevenge-devel
+ libvisio-devel libetonyek-devel libwpd-devel libwpg-devel mythes-devel
+ vigra-devel"
+short_desc="Productivity suite, formerly OpenOffice.org"
+maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
+license="LGPL-3"
+homepage="http://www.libreoffice.org/"
+_baseurl="http://download.documentfoundation.org/${pkgname}/src/${version%.*}"
+distfiles="
+ ${_baseurl}/${pkgname}-${version}.tar.xz
+ ${_baseurl}/${pkgname}-dictionaries-${version}.tar.xz
+ ${_baseurl}/${pkgname}-help-${version}.tar.xz
+ ${_baseurl}/${pkgname}-translations-${version}.tar.xz"
+checksum="
+ b41b03f008dab3439bde31c1918f0477c035eab629166a79eeebb0bb6e8757b3
+ 718822a5ad5400e1026b18453bc38a118851df43e26255c3769078b444ab7a82
+ c2e9dff6a930637ca9b203dc31b7f87b17a03419891201a386e81bfbbdc1b447
+ fd0eeee993b8532288b77a43bfda9db6cdf781df3cb43f753ed01b620e760ee3"
+skip_extraction="
+ ${pkgname}-dictionaries-${version}.tar.xz
+ ${pkgname}-help-${version}.tar.xz
+ ${pkgname}-translations-${version}.tar.xz"
+conflicts="libreoffice-bin>=0"
+
+# Install location: either /usr or e.g. /opt/libreofficeX.Y.Z
+_LO_PREFIX=/opt/${pkgname}${version%.*.*}
+
+if [ -z "$CROSS_BUILD" ]; then
+	# serf can't be cross compiled because of apr-util-devel
+	makedepends+=" serf-devel"
+	# mariadbclient can't currently be cross compiled
+	makedepends+=" libmariadbclient-devel"
+	configure_args+=" --with-system-mariadb"
+fi
+
+case "$XBPS_TARGET_MACHINE" in
+	*-musl)	# use shipped clucene, because CLucene/analysis/cjk/CJKAnalyzer.h
+		# is missing in the musl clucene-devel files
+		;;
+	*)	configure_args+=" --with-system-clucene"
+		makedepends+=" clucene-devel"
+		;;
+esac
+
+post_fetch() {
+	local srcdistdir=${XBPS_SRCDISTDIR}/${pkgname}-${version}
+	mkdir -p ${wrksrc}/external/tarballs
+	ln -sf ${srcdistdir}/${pkgname}-dictionaries-${version}.tar.xz ${wrksrc}/external/tarballs/
+	ln -sf ${srcdistdir}/${pkgname}-help-${version}.tar.xz ${wrksrc}/external/tarballs/
+	ln -sf ${srcdistdir}/${pkgname}-translations-${version}.tar.xz ${wrksrc}/external/tarballs/
+}
+
+pre_configure() {
+	sed -e "/gzip -f/d" \
+		-e "s|.1.gz|.1|g" \
+		-i bin/distro-install-desktop-integration
+	sed -e "/distro-install-file-lists/d" -i Makefile.in
+	chmod +x bin/unpack-sources
+}
+
+do_configure() {
+	# Separate autogen.sh and configure because we need
+	# to patch configure for musl support
+	NOCONFIGURE=1 ./autogen.sh
+
+	# Add linux-musl* as host OS to lines containing linux-gnu*
+	sed -i configure -e 's;linux-gnu\*;linux-gnu*|linux-musl*;g'
+
+	# In theory we could use --with-lang=ALL but then
+	# building the package then takes ages.
+
+	./configure ${configure_args} \
+		--prefix=${_LO_PREFIX} \
+		--with-vendor='VoidLinux' \
+		--with-lang='en-US de es fr it pl pt' \
+		--with-help \
+		--with-alloc=system \
+		--without-java \
+		--without-system-dicts \
+		--disable-odk \
+		--enable-python=system \
+		--enable-gtk3 \
+		--disable-dependency-tracking \
+		--enable-release-build=yes \
+		--disable-dconf \
+		--with-tls=nss \
+		--with-system-cairo \
+		--with-myspell-dicts \
+		--with-system-zlib \
+		--with-system-jpeg \
+		--with-system-expat \
+		--with-system-icu \
+		--with-system-icu-for-build=yes \
+		--with-system-poppler \
+		--with-system-curl \
+		--with-system-boost \
+		--with-system-glew \
+		--with-system-glyphy \
+		--with-system-nss \
+		--with-system-graphite \
+		--with-system-harfbuzz \
+		--with-system-apr \
+		--with-system-serf \
+		--with-system-neon \
+		--with-system-openssl \
+		--with-system-redland \
+		--with-system-libexttextcat \
+		--with-system-libpng \
+		--with-system-liblangtag \
+		--with-system-lcms2 \
+		--with-system-cppunit \
+		--with-system-hunspell \
+		--with-system-libabw \
+		--with-system-libatomic_ops \
+		--with-system-libcdr \
+		--with-system-libcmis \
+		--with-system-libetonyek \
+		--with-system-libmspub \
+		--with-system-libodfgen \
+		--with-system-libpagemaker \
+		--with-system-librevenge \
+		--with-system-libvisio \
+		--with-system-libwpd \
+		--with-system-libwpg \
+		--with-system-libxml \
+		--with-system-mythes \
+		--with-system-odbc \
+		--with-system-openldap \
+		--with-system-openssl \
+		--with-system-postgresql \
+		--with-system-vigra \
+		--with-parallelism=${XBPS_MAKEJOBS}
+}
+
+do_build() {
+	make build
+}
+
+do_install() {
+	local f instbase="${DESTDIR}/${_LO_PREFIX}"
+
+	make DESTDIR="${DESTDIR}" distro-pack-install
+	mkdir -p ${instbase}/share/appdata
+	cp -p sysui/desktop/appstream-appdata/*.xml ${instbase}/share/appdata/
+
+	if [ "${_LO_PREFIX}" != "/usr" ]; then
+		# This symlink is necessary for the desktop menu entries
+		vmkdir usr/bin
+		ln -sf ${_LO_PREFIX}/lib/libreoffice/program/soffice \
+			${DESTDIR}/usr/bin/libreoffice
+
+		if [ -d ${instbase}/share/icons/hicolor/32x32/apps ]; then
+			# Icons
+			vmkdir usr/share/pixmaps
+			for f in $(find ${instbase}/share/icons/hicolor/32x32/apps -type f); do
+				f=${f#${DESTDIR}/}
+ 				ln -sf $f ${DESTDIR}/usr/share/pixmaps/
+			done
+		fi
+
+		if [ -d ${instbase}/lib/libreoffice/share/xdg ]; then
+			# Desktop menu entries
+			vmkdir usr/share/applications
+			for f in $(find ${instbase}/lib/libreoffice/share/xdg -type f); do
+				f=${f#${DESTDIR}/}
+				ln -sf $f ${DESTDIR}/usr/share/applications/libreoffice-$(basename $f)
+			done
+		fi
+
+		if [ -d ${instbase}/share/man/man1 ]; then
+			# Manual pages
+			vmkdir usr/share/man/man1
+			for f in $(find ${instbase}/share/man/man1 -type f); do
+				f=${f#${DESTDIR}/}
+ 				ln -sf $f ${DESTDIR}/usr/share/man/man1/
+			done
+		fi
+	fi
+
+	# Move bash completion to the right place
+	vmkdir usr/share/bash-completion/completions
+	mv ${DESTDIR}/etc/bash_completion.d/libreoffice.sh \
+		${DESTDIR}/usr/share/bash-completion/completions/libreoffice
+
+	# Remove unwanted libreoffice packaging files from the root directory
+	rm -f ${DESTDIR}/gid_Module*
+}


### PR DESCRIPTION
It builds with musl libc. Installed language is just en-US, because
building many or all takes way too long. For i18n support there are
separate packages using the precompiled RPMs from the website.
(I'll create that PR after this one is merged)

Cross compiling does not work yet, but should be possible after some
more tweaking and patching.

Considered WIP because I may be missing some `--with-system-*` options.