### PR TITLE
New package: lollypop-0.9.87

### DIFF
--- a/srcpkgs/lollypop/template
+++ b/srcpkgs/lollypop/template
@@ -1,0 +1,17 @@
+# Template file for 'lollypop'
+pkgname=lollypop
+version=0.9.87
+revision=1
+build_style=gnu-configure
+noarch=yes
+nocross=yes
+hostmakedepends="intltool itstool pkg-config glib-devel gobject-introspection python3.4"
+makedepends="gtk+3-devel gobject-introspection totem-pl-parser-devel python3.4-cairo-devel"
+depends="python3.4-dbus python3.4-gobject python3.4-pylast"
+pycompile_module="lollypop"
+short_desc="GNOME music player"
+maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
+license="GPL-3"
+homepage="https://gnumdk.github.io/lollypop-web/"
+distfiles="https://github.com/gnumdk/${pkgname}/releases/download/${version}/${pkgname}-${version}.tar.xz"
+checksum=c66602ca2dc307db09fbf47f18753995159693c773d255797f5f49fcc15f4cc3


### PR DESCRIPTION
Closes #3705 

_Note_: we don't have `python3.4-pylast` and I don't know if using `python3.4-pip`
and running `pip3 install pylast` would be sufficient.