### PR TITLE
environment/build: overwrite __DATE__, __TIME__, and __TIMESTAMP__ macros.

### DIFF
--- a/common/environment/build/timestamp-macros.sh
+++ b/common/environment/build/timestamp-macros.sh
@@ -1,0 +1,1 @@
+../configure/timestamp-macros.sh

--- a/common/environment/configure/timestamp-macros.sh
+++ b/common/environment/configure/timestamp-macros.sh
@@ -1,0 +1,8 @@
+if [ -n "$XBPS_COMMIT_TIMESTAMP" ]; then
+	CFLAGS+=" -Wno-builtin-macro-redefined"
+	CXXFLAGS+=" -Wno-builtin-macro-redefined"
+	for i in "DATE,%b\x20%d\x20%Y" "TIME,%H:%M:%S" "DATETIME,%b\x20%d\x20%Y\x20%H:%M:%S"; do
+		CFLAGS+=" -U__${i%%,*}__ -D__${i%%,*}__=\\\"$(LC_ALL=C date --date "$XBPS_COMMIT_TIMESTAMP" +"${i#*,}")\\\""
+		CXXFLAGS+=" -U__${i%%,*}__ -D__${i%%,*}__=\\\"$(LC_ALL=C date --date "$XBPS_COMMIT_TIMESTAMP" +"${i#*,}")\\\""
+	done
+fi

--- a/common/environment/install/timestamp-macros.sh
+++ b/common/environment/install/timestamp-macros.sh
@@ -1,0 +1,1 @@
+../configure/timestamp-macros.sh

--- a/common/environment/setup/git.sh
+++ b/common/environment/setup/git.sh
@@ -1,0 +1,10 @@
+# If XBPS_USE_BUILD_MTIME is enabled in conf file don't continue.
+# only run this, if XBPS_COMMIT_TIMESTAMP isn't set
+if [ -z "$XBPS_USE_BUILD_MTIME" ] && [ -z "${XBPS_COMMIT_TIMESTAMP}" ]; then
+	if command -v chroot-git &>/dev/null; then
+		GIT_CMD=$(command -v chroot-git)
+	elif command -v git &>/dev/null; then
+		GIT_CMD=$(command -v git)
+	fi
+	export XBPS_COMMIT_TIMESTAMP="$($GIT_CMD -C ${XBPS_SRCPKGDIR}/${basepkg} log --pretty='%ci' --date=iso -n1 .)"
+fi

--- a/common/hooks/pre-pkg/90-set-timestamps.sh
+++ b/common/hooks/pre-pkg/90-set-timestamps.sh
@@ -2,25 +2,9 @@
 #	- sets the timestamps in a package to the commit date
 
 hook() {
-	local GIT_CMD date basepkg
-
-	# If XBPS_USE_BUILD_MTIME is enabled in conf file don't continue.
-	if [ -n "$XBPS_USE_BUILD_MTIME" ]; then
-		return
+	# If XBPS_COMMIT_TIMESTAMP is set, set mtimes to that timestamp.
+	if [ -n "$XBPS_COMMIT_TIMESTAMP" ]; then
+		msg_normal "$pkgver: setting mtimes to %s\n" "$(date --date "$XBPS_COMMIT_TIMESTAMP")"
+		find $PKGDESTDIR -print0 | xargs -0 touch -h --date "$XBPS_COMMIT_TIMESTAMP"
 	fi
-
-	if command -v chroot-git &>/dev/null; then
-		GIT_CMD=$(command -v chroot-git)
-	elif command -v git &>/dev/null; then
-		GIT_CMD=$(command -v git)
-	else
-		msg_error "$pkgver: cannot find chroot-git or git utility, exiting...\n"
-	fi
-	basepkg=$pkgname
-	if [ -L "${XBPS_SRCPKGDIR}/$basepkg" ]; then
-		basepkg=$(readlink "${XBPS_SRCPKGDIR}/$basepkg")
-	fi
-	date=$($GIT_CMD -C ${XBPS_SRCPKGDIR}/${basepkg} log --pretty='%ci' --date=iso -n1 .)
-	msg_normal "$pkgver: setting mtimes to %s\n" "$(date --date "$date")"
-	find $PKGDESTDIR -print0 | xargs -0 touch -h --date "$date"
 }

--- a/common/xbps-src/shutils/chroot.sh
+++ b/common/xbps-src/shutils/chroot.sh
@@ -198,6 +198,7 @@ chroot_handler() {
         action="$arg $action"
         env -i PATH="/usr/bin:/usr/sbin:$PATH" SHELL=/bin/sh \
             HOME=/tmp IN_CHROOT=1 LC_COLLATE=C LANG=en_US.UTF-8 \
+            XBPS_COMMIT_TIMESTAMP="$XBPS_COMMIT_TIMESTAMP" \
             $XBPS_COMMONDIR/chroot-style/${XBPS_CHROOT_CMD:=uunshare}.sh \
             $XBPS_MASTERDIR $XBPS_DISTDIR "$XBPS_HOSTDIR" "$XBPS_CHROOT_CMD_ARGS" \
             /void-packages/xbps-src $action $pkg


### PR DESCRIPTION
This PR overwrites timestamps that depend on timestamps with the
commit date of a package.