### PR TITLE
bitcoin: update to 0.12.0.

### DIFF
--- a/srcpkgs/bitcoin/template
+++ b/srcpkgs/bitcoin/template
@@ -1,16 +1,16 @@
 # Template file for 'bitcoin'
 pkgname=bitcoin
-version=0.11.2
+version=0.12.0
 revision=1
 create_wrksrc=yes
 hostmakedepends="pkg-config yasm"
-makedepends="db-devel protobuf-devel libressl-devel boost-devel miniupnpc-devel"
+makedepends="db-devel protobuf-devel boost-devel miniupnpc-devel libevent-devel qrencode-devel"
 short_desc="Bitcoin is a peer-to-peer network based digital currency"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="MIT"
-homepage="http://www.bitcoin.org/"
+homepage="https://bitcoin.org/"
 distfiles="https://bitcoin.org/bin/bitcoin-core-${version}/bitcoin-${version}.tar.gz"
-checksum=a4d2bd642e5f7f1f82dc3f708618ac77e1e45353db7a98bf81c3bdc0e10690d3
+checksum=0f1cda66c841a548a07cc37e80b0727354b1236d9f374c7d44362acdb85eb3e1
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) broken="http://build.voidlinux.eu/builders/armv6l-musl_builder/builds/2804/steps/shell_3/logs/stdio";;
@@ -18,13 +18,14 @@ esac
 
 if [ -z "$CROSS_BUILD" ]; then
 	# XXX -qt subpkg
-	hostmakedepends+=" automoc4"
 	makedepends+=" qt5-devel qt5-tools-devel"
 	configure_args+=" --with-gui"
 fi
 
 pre_configure() {
 	extra_files="
+		https://patch-diff.githubusercontent.com/raw/bitcoin/bitcoin/pull/7520.patch
+		https://github.com/AliceWonderMiscreations/bitcoin/commit/8b8c753588652c27b7b7f0d56ef962b28f43ff56.patch
 		https://raw.github.com/bitcoin/bitcoin/v${version}/contrib/debian/bitcoin-qt.desktop
 		https://raw.github.com/bitcoin/bitcoin/v${version}/share/pixmaps/bitcoin128.png
 		https://raw.github.com/bitcoin/bitcoin/v${version}/contrib/debian/examples/bitcoin.conf
@@ -36,8 +37,13 @@ pre_configure() {
 }
 do_configure() {
 	cd ${pkgname}-${version}
+  
+	# The following two patches patches fix an error in release 0.12.0 that avoids
+	# building with libressl although it is not even a dependency any more.
+ 	patch -Np1 -i ${wrksrc}/7520.patch
+ 	patch -Np1 -i ${wrksrc}/8b8c753588652c27b7b7f0d56ef962b28f43ff56.patch
+  
 	./configure ${configure_args} \
-		--with-libressl \
 		--with-incompatible-bdb \
 		--disable-ccache \
 		--disable-static \


### PR DESCRIPTION
Notes:
* added qrencode for qr code support
* no longer depends on openssl but on libevent
* official changelog [here](https://bitcoin.org/en/release/v0.12.0)