### PR TITLE
rxvt-unicode: build with unicode3 by default

### DIFF
--- a/srcpkgs/rxvt-unicode/template
+++ b/srcpkgs/rxvt-unicode/template
@@ -1,7 +1,7 @@
 # Template build file for 'rxvt-unicode'.
 pkgname=rxvt-unicode
 version=9.22
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="
  --with-terminfo=/usr/share/terminfo --enable-256-color
@@ -34,7 +34,7 @@ build_options="gdk_pixbuf perl startup_notification unicode3"
 desc_option_unicode3="Use 21 instead of 16 bits to represent unicode chars"
 
 # Enable startup-notification by default.
-build_options_default="perl startup_notification"
+build_options_default="perl startup_notification unicode3"
 
 if [ "$build_option_gdk_pixbuf" ]; then
 	configure_args+=" --enable-pixbuf"


### PR DESCRIPTION
Using the --enable-unicode3 option allows urxvt to display high-range
unicode characters, including those used by the popular "powerline"
theme.

This time, setting the build option to be enabled by default.