### PR TITLE
tcc: change to use http://repo.or.cz/tinycc.git

### DIFF
--- a/srcpkgs/tcc/template
+++ b/srcpkgs/tcc/template
@@ -1,14 +1,27 @@
 # Template file for 'tcc'
-only_for_archs="i686 x86_64"
-
 pkgname=tcc
-version=0.9.26
-revision=2
+version=0.9.26.20160111
+revision=1
+_gitrev=f75f89fc8f2116c4cfe35022c19ed854e6a23b84
+wrksrc=tinycc-${_gitrev:0:7}
+nopie=yes
 build_style=gnu-configure
+only_for_archs="i686 x86_64"
 hostmakedepends="perl"
 short_desc="The Tiny C Compiler"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://bellard.org/tcc/"
 license="LGPL-2.1"
-distfiles="${NONGNU_SITE}/tinycc/tcc-$version.tar.bz2"
-checksum=521e701ae436c302545c3f973a9c9b7e2694769c71d9be10f70a2460705b6d71
+distfiles="http://repo.or.cz/tinycc.git/snapshot/${_gitrev}.tar.gz>${pkgname}-${version}.tar.gz"
+checksum=c3b4b8c65d32870c2c31e779a8d7a28653e04d3365b461372bcb6b4f7710b4b1
+
+pre_configure() {
+	# Replace lib64 with lib
+	sed -i configure -e "s;lib64;lib;g"
+}
+
+do_build() {
+	# Can't use (many of) our CFLAGS or LDFLAGS
+	# because TCC is bootstrapped with the same flags
+	make CFLAGS= LDFLAGS= ${makejobs}
+}


### PR DESCRIPTION
The x86_64 builds ok, while there are probably critical warnings
for the i686 build. Needs testing by someone who knows how to.

Edit: the warnings did appear here, but not on travis-ci. Strange...

Closes #3717