### PR TITLE
libgit2: update to 0.24.0 (soname bump).

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1226,7 +1226,7 @@ libunwind-x86.so.8 libunwind-1.1_1
 libunwind-arm.so.8 libunwind-1.1_4
 libunwind-mips.so.8 libunwind-1.1_4
 libmicrohttpd.so.12 libmicrohttpd-0.9.48_1
-libgit2.so.23 libgit2-0.23.1_1
+libgit2.so.24 libgit2-0.24.0_1
 libgit2-glib-1.0.so.0 libgit2-glib-0.23.4_1
 libagg.so.2 agg-2.5_1
 libzzip-0.so.13 zziplib-0.13.62_1

--- a/srcpkgs/geany-plugins/template
+++ b/srcpkgs/geany-plugins/template
@@ -1,7 +1,7 @@
 # Template file for 'geany-plugins'
 pkgname=geany-plugins
-version=1.26
-revision=2
+version=1.27.0
+revision=1
 build_style=gnu-configure
 configure_args="--enable-all-plugins"
 hostmakedepends="automake gettext-devel intltool libtool pkg-config vala
@@ -14,7 +14,7 @@ maintainer="Steve Prybylski <sa.prybylx@gmail.com>"
 license="GPL-2"
 homepage="http://plugins.geany.org"
 distfiles="https://github.com/geany/${pkgname}/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=89053aa350756e96788fa36e31c97092f7a96946d347c25af83a22402813723c
+checksum=a347be468775f4ee8c6e8e6dda3b175194d92adec40549726ecfc65a54bb9d75
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh
@@ -50,7 +50,6 @@ geany-plugins-extra_package() {
 
 		vmove usr/lib/geany-plugins/geanylua
 		vmove usr/lib/geany/geanypy
-		vmove usr/share/geany/geanypy
 	}
 }
 

--- a/srcpkgs/libgit2-glib/template
+++ b/srcpkgs/libgit2-glib/template
@@ -1,6 +1,6 @@
 # Template file for 'libgit2-glib'
 pkgname=libgit2-glib
-version=0.23.10
+version=0.24.0
 revision=1
 build_style=gnu-configure
 configure_args="--disable-silent-rules"
@@ -12,7 +12,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="LGPL-2.1"
 homepage="https://github.com/GNOME/${pkgname}"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=bbdde23889c77bf2b0b4f932cffd58a0c6dd8653c0508becf105ab2ea73c485f
+checksum=52f78c075d9b5a2bf3debe9f8740aa9cb95eb094de5840d78fc6dddedb1826d7
 
 pre_configure() {
 	NOCONFIGURE=y sh autogen.sh

--- a/srcpkgs/libgit2/template
+++ b/srcpkgs/libgit2/template
@@ -1,7 +1,7 @@
 # Template file for 'libgit2'
 pkgname=libgit2
-version=0.23.4
-revision=3
+version=0.24.0
+revision=1
 build_style=cmake
 hostmakedepends="cmake python git pkg-config"
 makedepends="zlib-devel libressl-devel http-parser-devel libssh2-devel"
@@ -10,7 +10,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://libgit2.github.com/"
 license="GPL-2 with Linking Exception"
 distfiles="https://github.com/libgit2/libgit2/archive/v${version}.tar.gz"
-checksum=c7f5e2d7381dbc4d7e878013d14f9993ae8a41bd23f032718e39ffba57894029
+checksum=1c6693f943bee3f634b9094376f93e7e03b9ca77354a33f4e903fdcb2ee8b2b0
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl)

--- a/srcpkgs/slcp/template
+++ b/srcpkgs/slcp/template
@@ -1,7 +1,7 @@
 # Template file for 'slcp'
 pkgname=slcp
 version=0.2
-revision=5
+revision=6
 build_style=gnu-makefile
 makedepends="libgit2-devel"
 short_desc="Simple shell prompt written in C"

--- a/srcpkgs/stagit/template
+++ b/srcpkgs/stagit/template
@@ -1,7 +1,7 @@
 # Template file for 'stagit'
 pkgname=stagit
 version=0.2
-revision=1
+revision=2
 create_wrksrc=yes
 build_style=gnu-makefile
 make_install_args="MANPREFIX=/usr/share/man"


### PR DESCRIPTION
libgit2-glib currently broken by incompatible API changes.