### PR TITLE
New Package: nss-pam-ldap_0.9.6

### DIFF
--- a/srcpkgs/nss-pam-ldapd/files/nslcd/run
+++ b/srcpkgs/nss-pam-ldapd/files/nslcd/run
@@ -1,0 +1,4 @@
+#!/bin/bash
+mkdir /var/run/nslcd
+chown nslcd:nslcd /var/run/nslcd
+chpst -u nslcd:nslcd nslcd -n

--- a/srcpkgs/nss-pam-ldapd/template
+++ b/srcpkgs/nss-pam-ldapd/template
@@ -1,0 +1,20 @@
+# Template file for 'nss-pam-ldapd'
+pkgname=nss-pam-ldapd
+version=0.9.6
+revision=1
+only_for_archs="i686 x86_64 armv6l armv7l aarch64"
+build_style=gnu-configure
+configure_args="--enable-sasl --enable-kerberos --with-pam-seclib-dir=/usr/lib/security/"
+conf_files="/etc/nslcd.conf"
+makedepends="pam-devel libldap-devel libsasl-devel mit-krb5-devel"
+system_accounts="nslcd"
+short_desc="LDAP identity management via nsswitch"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="LGPL-2.1"
+homepage="https://arthurdejong.org/nss-pam-ldapd/"
+distfiles="https://arthurdejong.org/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=101d5a7fa10549cc77be48d07f2b8141f59182f10f2cc0fea93efd13c3a5a6f2
+
+post_install() {
+	vsv nslcd
+}


### PR DESCRIPTION
This package allows systems running glibc to pull user and group information from a remote server.  This is part of the large request from issue #3119.