### PR TITLE
New package: lightdm-webkit-greeter_2.0.0

### DIFF
--- a/srcpkgs/lightdm-webkit-greeter/template
+++ b/srcpkgs/lightdm-webkit-greeter/template
@@ -1,0 +1,14 @@
+# Template file for 'lightdm-webkit-greeter'
+pkgname=lightdm-webkit-greeter
+version=2.0.0
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config intltool"
+makedepends="lightdm-devel libxklavier-devel dbus-glib-devel webkitgtk-devel"
+depends="lightdm"
+short_desc="Light Display Manager Webkit Greeter"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="GPL-3"
+homepage="https://launchpad.net/lightdm-webkit-greeter"
+distfiles="https://launchpad.net/${pkgname}/trunk/${version}/+download/${pkgname}-${version}.tar.gz"
+checksum=985068d2c95556c99c744a0e8a770f123034fe4b23e8469c1a153a1f6e687eab


### PR DESCRIPTION
More of the software for #3119.  Adds the webkit greeter which allows log in forms to be basically webpages with carefully formatted webpages.