### PR TITLE
perl-Glib: fix cross builds

### DIFF
--- a/srcpkgs/perl-Glib/template
+++ b/srcpkgs/perl-Glib/template
@@ -4,6 +4,7 @@ version=1.321
 revision=1
 wrksrc="Glib-$version"
 build_style=perl-module
+nocross=yes
 hostmakedepends="perl"
 makedepends="perl-ExtUtils-Depends perl-ExtUtils-PkgConfig glib-devel"
 depends="${hostmakedepends/glib-devel/}"


### PR DESCRIPTION
For certain definitions of "fixed".

Builds fail with a myriad of type width errors, then finally with an error trying to load a glib which is the wrong ELFCLASS for the target.