### PR TITLE
pinentry: build pinentry-emacs.

### DIFF
--- a/srcpkgs/pinentry-emacs
+++ b/srcpkgs/pinentry-emacs
@@ -1,0 +1,1 @@
+pinentry

--- a/srcpkgs/pinentry/template
+++ b/srcpkgs/pinentry/template
@@ -1,10 +1,11 @@
 # Template file for 'pinentry'
 pkgname=pinentry
 version=0.9.7
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-rpath --without-libcap --disable-pinentry-gtk
-	--enable-pinentry-curses --enable-fallback-curses --enable-pinentry-gtk2"
+	--enable-pinentry-curses --enable-fallback-curses --enable-pinentry-gtk2
+	--enable-pinentry-emacs"
 hostmakedepends="pkg-config"
 makedepends="ncurses-devel gtk+-devel libassuan-devel libgpg-error-devel"
 short_desc="PIN or passphrase entry dialogs for GnuPG"
@@ -27,5 +28,13 @@ pinentry-gtk_package() {
 	short_desc+=" based on GTK+"
 	pkg_install() {
 		vmove usr/bin/pinentry-gtk-2
+	}
+}
+
+pinentry-emacs_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - Emacs interface"
+	pkg_install() {
+		vmove usr/bin/pinentry-emacs
 	}
 }


### PR DESCRIPTION
This requires some extra code on the emacs side to work.
With 24.5, that's a package from elpa.  So I won't be
the least bit disappointed if this PR gets rejected.