### PR TITLE
New package: xastir-2.0.6

### DIFF
--- a/srcpkgs/xastir/template
+++ b/srcpkgs/xastir/template
@@ -1,0 +1,13 @@
+# Template file for 'xastir'
+pkgname=xastir
+version=2.0.6
+revision=1
+build_style=gnu-configure
+only_for_archs="i686 x86_64"
+makedepends="libXrender-devel libXt-devel libXp-devel libcurl-devel pcre-devel lesstif-devel libax25-devel"
+short_desc="X Amateur Station Tracking and Information Reporting"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="GPL-2"
+homepage="http://xastir.org"
+distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=e46debd3f67ea5c08e2f85f03e26653871a9cdd6d692c8eeee436c3bc8a8dd43


### PR DESCRIPTION
Some more amatuer radio software.  The build is marked broken on all arm and musl systems.  Years of code cruft mean this is not likely to change anytime soon, however conversations with the upstream project suggest they will consider patching thier build in the next release cycle, which if current rate is any example, should be some time next year.