### PR TITLE
gstreamer*: update to 1.8.0

### DIFF
--- a/srcpkgs/gst-libav/template
+++ b/srcpkgs/gst-libav/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-libav'
 pkgname=gst-libav
 reverts="1:1.4.5_4"
-version=1.6.3
+version=1.8.0
 revision=1
 lib32disabled=yes
 wrksrc="${pkgname}-${version#*:}"
@@ -15,7 +15,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname}/${pkgname}-${version#*:}.tar.xz"
-checksum=857b9c060a0337de38c6d26238c47352433c02eabf26c2f860c854dbc35bd4ab
+checksum=5a1ce28876aee93cb4f3d090f0e807915a5d9bc1325e3480dd302b85aeb4291c
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) # Required by musl for M_SQRT1_2

--- a/srcpkgs/gst-libav/template
+++ b/srcpkgs/gst-libav/template
@@ -27,3 +27,11 @@ pre_configure() {
 	# Fix cross compiling for arm* where os=linuxeabihf
 	sed -i ${wrksrc}/gst-libs/ext/libav/configure -e "s;linux);linux*);"
 }
+
+post_configure() {
+	case "$XBPS_TARGET_MACHINE" in
+		x86_64-musl) # compiling with -O3 triggers a gcc bug
+			sed -i 's/-O3/-O2/g' gst-libs/ext/libav/config.mak
+			;;
+	esac
+}

--- a/srcpkgs/gst-plugins-bad1/template
+++ b/srcpkgs/gst-plugins-bad1/template
@@ -1,8 +1,8 @@
 # Template file for 'gst-plugins-bad1'.
 pkgname=gst-plugins-bad1
 reverts="1:1.4.5_6"
-version=1.6.3
-revision=3
+version=1.8.0
+revision=1
 wrksrc="${pkgname/1/}-${version#*:}"
 lib32disabled=yes
 build_style=gnu-configure
@@ -22,7 +22,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2, LGPL-2.1"
 homepage="http://gstreamer.freedesktop.org"
 distfiles="$homepage/src/${pkgname/1/}/${pkgname/1/}-${version#*:}.tar.xz"
-checksum=971b29101d6a9c5e3fe94d99d977a227f58f0b2d29b6ca2c7f292052542b3a61
+checksum=116376dd1085082422e0b21b0ecd3d1cb345c469c58e32463167d4675f4ca90e
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh

--- a/srcpkgs/gst-plugins-base1/template
+++ b/srcpkgs/gst-plugins-base1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-base1'.
 pkgname=gst-plugins-base1
 reverts="1:1.4.5_3"
-version=1.6.3
+version=1.8.0
 revision=1
 wrksrc="${pkgname/1/}-${version#*:}"
 build_style=gnu-configure
@@ -20,7 +20,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://gstreamer.freedesktop.org/"
 license="GPL-2, LGPL-2.1"
 distfiles="http://gstreamer.freedesktop.org/src/${pkgname/1/}/${pkgname/1/}-${version#*:}.tar.xz"
-checksum=b6154f8fdba4877e95efd94610ef0ada4f0171cd12eb829a3c3c97345d9c7a75
+checksum=abc0acc1d15b4b9c97c65cd9689bd6400081853b9980ea428d3c8572dd791522
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*) CFLAGS="-O2 -msse2";;

--- a/srcpkgs/gst-plugins-good1/template
+++ b/srcpkgs/gst-plugins-good1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-good1'.
 pkgname=gst-plugins-good1
 reverts="1:1.4.5_3"
-version=1.6.3
+version=1.8.0
 revision=1
 wrksrc="${pkgname/1/}-${version#*:}"
 lib32disabled=yes
@@ -23,4 +23,4 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://gstreamer.freedesktop.org/"
 license="LGPL-2.1"
 distfiles="http://gstreamer.freedesktop.org/src/${pkgname/1/}/${pkgname/1/}-${version#*:}.tar.xz"
-checksum=24b19db70b2a83461ebddfe20033db432dadfdb5d4b54ffb1dfa0d830134a177
+checksum=c20c134d47dbc238d921707a3b66da709c2b4dd89f9d267cec13d1ddf16e9f4d

--- a/srcpkgs/gst-plugins-ugly1/template
+++ b/srcpkgs/gst-plugins-ugly1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-ugly1'.
 pkgname=gst-plugins-ugly1
 reverts="1:1.4.5_2"
-version=1.6.3
+version=1.8.0
 revision=1
 lib32disabled=yes
 wrksrc="${pkgname/1/}-${version#*:}"
@@ -18,4 +18,4 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="LGPL-2.1"
 homepage="http://gstreamer.freedesktop.org"
 distfiles="http://gstreamer.freedesktop.org/src/${pkgname/1/}/${pkgname/1/}-${version#*:}.tar.xz"
-checksum=2fecf7b7c7882f8f62f1900048f4013f98c214fb3d3303d8d812245bb41fd064
+checksum=53657ffb7d49ddc4ae40e3f52e56165db4c06eb016891debe2b6c0e9f134eb8c

--- a/srcpkgs/gst1-python/template
+++ b/srcpkgs/gst1-python/template
@@ -1,6 +1,6 @@
 # Template file for 'gst1-python'.
 pkgname=gst1-python
-version=1.6.2
+version=1.8.0
 revision=1
 wrksrc="gst-python-${version}"
 build_style=gnu-configure
@@ -14,7 +14,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="LGPL-2.1"
 homepage="http://gstreamer.freedesktop.org"
 distfiles="$homepage/src/gst-python/gst-python-${version}.tar.xz"
-checksum=4e763e317079f48a2d6f37bd600bc19650d61597fac9f5763dbad293f72f9125
+checksum=ce45ff17c59f86a3a525685e37b95e6a78a019e709f66a5c4b462a7f7a22f6ea
 
 pre_configure() {
 	if [ "$CROSS_BUILD" ]; then

--- a/srcpkgs/gstreamer1/template
+++ b/srcpkgs/gstreamer1/template
@@ -1,7 +1,7 @@
 # Template file for 'gstreamer1'.
 pkgname=gstreamer1
 reverts="1:1.4.5_1"
-version=1.6.3
+version=1.8.0
 revision=1
 wrksrc="gstreamer-${version#*:}"
 build_style=gnu-configure
@@ -14,7 +14,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://gstreamer.freedesktop.org/"
 license="LGPL-2.1"
 distfiles="http://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${version#*:}.tar.xz"
-checksum=22f9568d67b87cf700a111f381144bd37cb93790a77e4e331db01fe854a37f24
+checksum=947a314a212b5d94985d89b43440dbe66b696e12bbdf9a2f78967b98d74abedc
 
 # Package build options
 build_options="gir"


### PR DESCRIPTION
The gst-libav build triggers a gcc bug on musl:

    16700 In file included from libavcodec/hevcdsp_template.c:26:0,
    16701                  from libavcodec/hevcdsp.c:111:
    16702 libavcodec/hevcdsp_template.c: In function 'put_hevc_qpel_hv_8':
    16703 libavcodec/hevcdsp_template.c:655:18: internal compiler error: in vect_analyze_data_ref_accesses, at tree-vect-data-refs.c:2566
    16704  static void FUNC(put_hevc_qpel_hv)(int16_t *dst,
    16705                   ^
    16706 libavcodec/bit_depth_template.c:90:25: note: in definition of macro 'FUNC3'
    16707  #define FUNC3(a, b, c)  a ## _ ## b ## c
    16708                          ^
    16709 libavcodec/bit_depth_template.c:92:18: note: in expansion of macro 'FUNC2'
    16710  #define FUNC(a)  FUNC2(a, BIT_DEPTH,)
    16711                   ^
    16712 libavcodec/hevcdsp_template.c:655:13: note: in expansion of macro 'FUNC'
    16713  static void FUNC(put_hevc_qpel_hv)(int16_t *dst,
    16714              ^
    16715 0x6f0000020375 __libc_start_main
    16716         src/env/__libc_start_main.c:74

I think we've had this before, does anyone remember how it was resolved?
