### PR TITLE
tigervnc: Integrate xorg source build so that Xvnc is built

### DIFF
--- a/srcpkgs/tigervnc/patches/xorg118.patch
+++ b/srcpkgs/tigervnc/patches/xorg118.patch
@@ -1,0 +1,27 @@
+diff -wbBur unix/xserver/hw/vnc/Input.c unix/xserver/hw/vnc/Input.c
+--- unix/xserver/hw/vnc/Input.c	2015-07-11 16:00:36.000000000 +0300
++++ unix/xserver/hw/vnc/Input.c	2015-11-25 19:04:24.278747038 +0300
+@@ -300,6 +300,8 @@
+ #if XORG < 111
+ 	n = GetKeyboardEvents(eventq, dev, action, kc);
+ 	enqueueEvents(dev, n);
++#elif XORG > 117
++	QueueKeyboardEvents(dev, action, kc);
+ #else
+ 	QueueKeyboardEvents(dev, action, kc, NULL);
+ #endif
+diff -wbBur unix/xserver/hw/vnc/xorg-version.h unix/xserver/hw/vnc/xorg-version.h
+--- unix/xserver/hw/vnc/xorg-version.h	2015-07-11 16:00:36.000000000 +0300
++++ unix/xserver/hw/vnc/xorg-version.h	2015-11-25 19:02:47.688751421 +0300
+@@ -48,8 +48,10 @@
+ #define XORG 116
+ #elif XORG_VERSION_CURRENT < ((1 * 10000000) + (17 * 100000) + (99 * 1000))
+ #define XORG 117
++#elif XORG_VERSION_CURRENT < ((1 * 10000000) + (18 * 100000) + (99 * 1000))
++#define XORG 118
+ #else
+-#error "X.Org newer than 1.17 is not supported"
++#error "X.Org newer than 1.18 is not supported"
+ #endif
+ 
+ #endif

--- a/srcpkgs/tigervnc/template
+++ b/srcpkgs/tigervnc/template
@@ -1,17 +1,43 @@
 # Template file for 'tigervnc'
 pkgname=tigervnc
 version=1.6.0
-revision=1
+revision=2
+_xorg_version=1.18.2
 build_style=cmake
 short_desc="VNC client forked from TightVNC"
 maintainer="Evan Deaubl <evan@deaubl.name>"
 license="GPL-2"
-hostmakedepends="cmake"
-makedepends="fltk-devel zlib-devel libXtst-devel libjpeg-turbo-devel $(vopt_if gnutls gnutls-devel)"
+hostmakedepends="automake xorg-util-macros font-util pkg-config libtool xtrans"
+makedepends="fltk-devel zlib-devel libXtst-devel libjpeg-turbo-devel pixman-devel
+	randrproto fontsproto videoproto compositeproto scrnsaverproto
+	resourceproto libxkbfile-devel libXfont-devel gnutls-devel"
+depends="xauth xkeyboard-config"
 conflicts="turbovnc>=0"
 homepage="http://www.tigervnc.org"
-distfiles="https://github.com/TigerVNC/tigervnc/archive/v${version}.tar.gz>tigervnc-${version}.tar.gz"
-checksum=98ffe98fcfe883e6c35aec579295b53d73d2ccf62e0f6e53a73ecad993b096ca
+distfiles="https://github.com/TigerVNC/tigervnc/archive/v${version}.tar.gz>tigervnc-${version}.tar.gz
+	${XORG_SITE}/xserver/xorg-server-${_xorg_version}.tar.bz2"
+checksum="98ffe98fcfe883e6c35aec579295b53d73d2ccf62e0f6e53a73ecad993b096ca
+	022142b07f6477d140dcc915902df326408a53ca3a352426a499f142b25d632d"
 
-build_options="gnutls"
-build_options_default="gnutls"
+post_configure() {
+	cd ${wrksrc}/unix/xserver
+	cp -R ${XBPS_BUILDDIR}/xorg-server-${_xorg_version}/* .
+	patch -p1 <../xserver117.patch
+	autoreconf -fiv
+	./configure --host=${XBPS_CROSS_TRIPLET} --prefix=/usr --with-pic \
+		--without-dtrace --disable-static --disable-dri \
+		--disable-xinerama --disable-xvfb --disable-xnest --disable-xorg \
+		--disable-dmx --disable-xwin --disable-xephyr --disable-kdrive \
+		--disable-config-hal --disable-config-udev --disable-dri2 --enable-glx \
+		--disable-unit-tests --disable-selective-werror
+}
+
+post_build() {
+	cd ${wrksrc}/unix/xserver
+	make LIB_DIR=${wrksrc}/build/common
+}
+
+post_install() {
+	cd ${wrksrc}/unix/xserver/hw/vnc
+	make LIB_DIR=${wrksrc}/build/common DESTDIR=${DESTDIR} install
+}


### PR DESCRIPTION
My previous packaging of tigervnc didn't properly build the Xvnc program because it requires the xorg-server source to build. The build instructions closely mirror the documented instructions at tigervnc.org, plus a patch from the Arch Linux PKGBUILD to properly support xorg-server-1.18 source trees.