### PR TITLE
gloobus-preview: Update Video Codec Support

### DIFF
--- a/srcpkgs/gloobus-preview/template
+++ b/srcpkgs/gloobus-preview/template
@@ -1,15 +1,14 @@
 # Template file for 'gloobus-preview'
 pkgname=gloobus-preview
 version=2015.12.21
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--prefix=/usr"
-hostmakedepends="automake autoconf libtool pkg-config python3 gettext-devel xz"
+hostmakedepends="automake libtool pkg-config python3 gettext-devel xz"
 makedepends="gettext-devel boost-devel gtk+-devel gtk+3-devel gtksourceview-devel
 	cairo-devel gstreamer1-devel gst-plugins-base1-devel gst-plugins-bad1-devel poppler-glib-devel
 	libspectre-devel djvulibre-devel libgxps-devel freetype-devel glib-devel libX11-devel
 	libgxps-devel libarchive-devel"
-depends="python3 python-dbus gst-plugins-good1 gst-plugins-ugly1 ImageMagick p7zip tar unoconv unrar unzip"
+depends="python3 python-dbus gst-libav gst-plugins-good1 gst-plugins-bad1 gst-plugins-ugly1 ImageMagick p7zip tar unoconv unrar unzip"
 short_desc="A file previewer"
 maintainer="Antonio Malcolm <antonio@antoniomalcolm.com>"
 license="GPL-3"


### PR DESCRIPTION
Making the video codec support complete (via the gstreamer plugins), so videos preview properly.