### PR TITLE
go-ipfs: update to 0.4.0.

### DIFF
--- a/srcpkgs/fs-repo-migrations/template
+++ b/srcpkgs/fs-repo-migrations/template
@@ -1,0 +1,18 @@
+# Template file for 'fs-repo-migrations'
+pkgname=fs-repo-migrations
+version=1.0.0
+revision=1
+build_style=go
+go_import_path="github.com/ipfs/fs-repo-migrations"
+short_desc="Tool to upgrade the IPFS filesystem repository"
+maintainer="Christopher Brannon <chris@the-brannons.com>"
+license="MIT"
+homepage="https://github.com/ipfs/fs-repo-migrations"
+distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
+checksum=b8cd8ea22f59740be3eb7a5c0c6da769a0b26101d65237da2971ee0670e2e44d
+
+post_install() {
+	vlicense ipfs-1-to-2/go-datastore/LICENSE
+	vdoc README.md
+	vdoc run.md
+}

--- a/srcpkgs/go-ipfs/INSTALL.msg
+++ b/srcpkgs/go-ipfs/INSTALL.msg
@@ -1,0 +1,6 @@
+Please note that go-ipfs 0.4.0 introduces a change that breaks compatibility
+with earlier versions at the networking layer.  Thus, it will be unable to
+communicate with peers running versions of go-ipfs older than 0.4.0.
+If you are upgrading from version 0.3.x, you should install
+the fs-repo-migrations package and run the fs-repo-migrations tool
+to upgrade your IPFS filesystem repository.

--- a/srcpkgs/go-ipfs/template
+++ b/srcpkgs/go-ipfs/template
@@ -1,7 +1,9 @@
 # Template file for 'go-ipfs'
 pkgname=go-ipfs
-version=0.3.11
-revision=3
+version=0.4.1
+revision=1
+create_wrksrc=yes
+build_wrksrc=${pkgname}-${version}
 build_style=go
 go_import_path="github.com/ipfs/${pkgname}"
 go_package="${go_import_path}/cmd/ipfs"
@@ -9,16 +11,24 @@ short_desc="Global versioned P2P merkle DAG file system"
 maintainer="Christopher Brannon <chris@the-brannons.com>"
 license="MIT"
 homepage="https://ipfs.io"
-distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
-checksum=1806fea22ccee0c8005fffdd6391531c8df44f23571b3e9539f6fa3a0d4efb01
-broken=yes
+distfiles="https://${go_import_path}/archive/v${version}.tar.gz
+ http://the-brannons.com/ipfs-gx-deps-20160427.tar.xz"
+checksum="b6bcab4d9da11339523cd178165c24f7784abda9dd820a8f3490c78da67be786
+ 3c6d99f4847eba3d3956d1b2f2eb07e7e0fe108d6711f5353bbf3aaf059e4dde"
 
 do_build() {
-	GO15VENDOREXPERIMENT=0 go get -x ${go_package}
+	local path="${GOPATH}/src/${go_import_path}"
+	mkdir -p "$(dirname ${path})"
+	ln -fs $PWD "${path}"
+	ln -s "${wrksrc}/ipfs-gx-deps-20160427/src/gx" "${GOPATH}/src"
+	cd cmd/ipfs
+	go build
 }
 
-post_install() {
+do_install() {
+	vbin cmd/ipfs/ipfs
 	vinstall misc/completion/ipfs-completion.bash 644 usr/share/bash-completion/completions ipfs
 	vlicense LICENSE
 	vdoc README.md
+	vdoc CHANGELOG.md
 }


### PR DESCRIPTION
The fs-repo-migrations package isn't really a dependency, but
included here because people will need it when upgrading.
Also added two hostmakedepends.