### PR TITLE
New package: python-gtkglext-1.1.0

### DIFF
--- a/srcpkgs/python-gtkglext/template
+++ b/srcpkgs/python-gtkglext/template
@@ -1,0 +1,15 @@
+# Template file for 'python-gtkglext'
+pkgname=python-gtkglext
+version=1.1.0
+revision=1
+nocross=yes
+wrksrc=pygtkglext-$version
+build_style=gnu-configure
+hostmakedepends="pkg-config python"
+makedepends="pygtk-devel gtkglext-devel"
+short_desc="Python language bindings for GtkGLExt"
+maintainer="Andrea Brancaleoni <miwaxe@gmail.com>"
+license="LGPL-3"
+homepage="http://gtkglext.sourceforge.net2"
+distfiles="$SOURCEFORGE_SITE/gtkglext/pygtkglext-$version.tar.bz2"
+checksum=7f0104347659a81cd5bd84007b97547d18a8a216f5df2629f379ea7f87a1410a


### PR DESCRIPTION
needed by xpra to enable opengl acceleration