### PR TITLE
neovim: update to 0.1.4

### DIFF
--- a/srcpkgs/lua-lpeg/template
+++ b/srcpkgs/lua-lpeg/template
@@ -1,9 +1,9 @@
 # Template file for 'lua-lpeg'
 pkgname=lua-lpeg
 version=1.0.0
-revision=3
-hostmakedepends="lua lua52"
-makedepends="lua-devel lua52-devel"
+revision=4
+hostmakedepends="lua lua51 lua52"
+makedepends="lua-devel lua51-devel lua52-devel"
 depends="lua>=5.3"
 _desc="Pattern-matching library for Lua based on Parsing Expression Grammars"
 short_desc="${_desc} (5.3.x)"
@@ -15,12 +15,17 @@ wrksrc="${pkgname#lua-}-${version}"
 checksum=10190ae758a22a16415429a9eb70344cf29cbda738a6962a9f94a732340abf8e
 
 post_extract() {
-	mkdir -p lua52
-	mv * lua52 || true
-	cp -a lua52 lua53
+	mkdir -p lua51
+	mv * lua51 || true
+	cp -a lua51 lua52
+	cp -a lua51 lua53
 }
 
 do_build() {
+	cd ${wrksrc}/lua51
+	make CC=$CC DLLFLAGS="-I${XBPS_CROSS_BASE}/usr/include/lua5.1 -fPIC" \
+		LUADIR="${XBPS_CROSS_BASE}/usr/include/lua5.1" ${makejobs}
+
 	cd ${wrksrc}/lua52
 	make CC=$CC DLLFLAGS="-I${XBPS_CROSS_BASE}/usr/include/lua5.2 -fPIC" \
 		LUADIR="${XBPS_CROSS_BASE}/usr/include/lua5.2" ${makejobs}
@@ -31,6 +36,10 @@ do_build() {
 }
 
 do_install() {
+	cd ${wrksrc}/lua51
+	vinstall lpeg.so 755 usr/lib/lua/5.1/
+	vinstall re.lua 644 usr/share/lua/5.1/
+
 	cd ${wrksrc}/lua52
 	vinstall lpeg.so 755 usr/lib/lua/5.2/
 	vinstall re.lua 644 usr/share/lua/5.2/
@@ -39,6 +48,16 @@ do_install() {
 	vinstall lpeg.so 755 usr/lib/lua/5.3/
 	vinstall re.lua 644 usr/share/lua/5.3/
 	vlicense lpeg.html
+}
+
+lua51-lpeg_package() {
+	depends="lua51"
+	short_desc="${_desc} (5.1.x)"
+	pkg_install() {
+		vmove usr/lib/lua/5.1
+		vmove usr/share/lua/5.1
+		vlicense ${wrksrc}/lua52/lpeg.html
+	}
 }
 
 lua52-lpeg_package() {

--- a/srcpkgs/lua51-lpeg
+++ b/srcpkgs/lua51-lpeg
@@ -1,0 +1,1 @@
+lua-lpeg

--- a/srcpkgs/lua51-mpack/template
+++ b/srcpkgs/lua51-mpack/template
@@ -1,0 +1,22 @@
+# Template file for 'lua51-mpack'
+pkgname=lua51-mpack
+version=1.0.2
+revision=1
+wrksrc="libmpack-${version}"
+hostmakedepends="libtool"
+makedepends="lua51-devel"
+short_desc="Simple implementation of MessagePack for Lua 5.1"
+maintainer="Steve Prybylski <sa.prybylx@gmail.com>"
+license="MIT"
+homepage="https://github.com/tarruda/libmpack"
+distfiles="${homepage}/archive/${version}.tar.gz"
+checksum=9c570b2aab81b0c56d97cbd8fc483dc431b69510fd9becb4a1845291563e8bc9
+
+do_build() {
+	${CC} ${CFLAGS} -shared -o mpack.so binding/lua/lmpack.c ${LDFLAGS}
+}
+
+do_install() {
+	vinstall mpack.so 755 usr/lib/lua/5.1
+	vlicense LICENSE-MIT
+}

--- a/srcpkgs/neovim/template
+++ b/srcpkgs/neovim/template
@@ -1,17 +1,17 @@
 # Template file for 'neovim'
 pkgname=neovim
-version=0.1.3
+version=0.1.4
 revision=1
 build_style=cmake
-configure_args="-DENABLE_JEMALLOC=0 -DLUA_PRG=/usr/bin/lua5.2"
-hostmakedepends="cmake lua52-lpeg lua52-MessagePack lua52-BitOp"
+configure_args="-DENABLE_JEMALLOC=0"
+hostmakedepends="lua51-lpeg lua51-mpack"
 makedepends="libtermkey-devel libuv-devel libvterm-devel LuaJIT-devel msgpack-devel"
 short_desc="Fork of Vim aiming to improve user experience, plugins and GUIs"
 maintainer="Steve Prybylski <sa.prybylx@gmail.com>"
 license="Apache-2.0, GPL-2"
 homepage="http://neovim.io"
 distfiles="https://github.com/${pkgname}/${pkgname}/archive/v${version}.tar.gz"
-checksum=7a86892d941b8829537ad46864b9a363d009ba56aeefdef2ee15ffa3eee5f92b
+checksum=bb7e359eb83db20c5ec5984b470b249372b6dcd813ae2ccf72c01cce560f93e9
 
 alternatives="
  vi:vi:/usr/bin/nvim


### PR DESCRIPTION
Neovim now depends on `lua-mpack`  (insead `lua-MessagePack`), which is only compatible with Lua 5.1