### PR TITLE
calibre: calibre.desktop extended with MimeType, calibre-viewer.deskt…

### DIFF
--- a/srcpkgs/calibre/files/calibre-viewer.desktop
+++ b/srcpkgs/calibre/files/calibre-viewer.desktop
@@ -1,12 +1,12 @@
 [Desktop Entry]
 Encoding=UTF-8
 Type=Application
-Name=Calibre
-Comment=E-book library management
-Comment[de]=E-Book Bibliotheksverwaltung
-TryExec=calibre
-Exec=calibre
-Icon=/usr/share/calibre/images/library.png
+Name=Calibre-viewer
+GenericName=E-book viewer
+Comment=E-book viewer
+TryExec=ebook-viewer
+Exec=ebook-viewer
+Icon=/usr/share/calibre/images/viewer.png
 Terminal=false
 StartupNotify=false
 Categories=Application;Office;Viewer

--- a/srcpkgs/calibre/template
+++ b/srcpkgs/calibre/template
@@ -1,7 +1,7 @@
 # Template file for 'calibre'
 pkgname=calibre
 version=2.56.0
-revision=2
+revision=3
 hostmakedepends="qt5-qmake python-devel pkg-config
  python-dateutil python-lxml python-Pillow
  python-PyQt5-webkit python-apsw python-cssutils python-CherryPy
@@ -47,6 +47,7 @@ do_build() {
 }
 do_install() {
 	vinstall ${FILESDIR}/calibre.desktop 644 usr/share/applications
+	vinstall ${FILESDIR}/calibre-viewer.desktop 644 usr/share/applications
 	python2 setup.py \
 		install --prefix=/usr --staging-root=${DESTDIR}/usr ${make_install_args}
 }


### PR DESCRIPTION
- calibre.desktop extended with supported mime-types
- calibre-viewer.desktop added to support the calibre ebook-viewer directly