### PR TITLE
zfs: remove zfs-import service

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2452,3 +2452,4 @@ libipmiconsole.so.2 freeipmi-1.5.1_1
 libfreeipmi.so.17 freeipmi-1.5.1_1
 libipmidetect.so.0 freeipmi-1.5.1_1
 libsmpeg2-2.0.so.0 smpeg2-2.0.0_1
+libedac.so.1 libedac-0.18_1

--- a/srcpkgs/edac-utils/files/edac/run
+++ b/srcpkgs/edac-utils/files/edac/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+edac-ctl --register-labels
+exec chpst -b edac pause

--- a/srcpkgs/edac-utils/template
+++ b/srcpkgs/edac-utils/template
@@ -1,0 +1,36 @@
+# Template file for 'edac-utils'
+pkgname=edac-utils
+version=0.18
+revision=1
+build_style=gnu-configure
+maintainer="Dominik Honnef <dominik@honnef.co>"
+hostmakedepends=perl
+makedepends=libsysfs-devel
+license="GPL-2"
+homepage="https://github.com/grondo/edac-utils"
+short_desc="Userspace helper for kernel EDAC drivers"
+distfiles="${homepage}/archive/${version}.tar.gz"
+checksum=2a027dbde6c3095807c9fbfa0025bedad38fc839e9967707c1986089ff4c8750
+
+post_install() {
+	rm -r ${DESTDIR}/etc/init.d
+	vsv edac
+}
+
+libedac_package() {
+	short_desc+=" - library files"
+	pkg_install() {
+		vmove usr/lib/*.so.*
+		vmove etc/edac/labels.db
+	}
+}
+
+libedac-devel_package() {
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/lib/libedac.a
+		vmove usr/lib/*.so
+		vmove usr/include
+		vmove usr/share/man/man3
+	}
+}

--- a/srcpkgs/libedac
+++ b/srcpkgs/libedac
@@ -1,0 +1,1 @@
+edac-utils

--- a/srcpkgs/libedac-devel
+++ b/srcpkgs/libedac-devel
@@ -1,0 +1,1 @@
+edac-utils


### PR DESCRIPTION
The service has several flaws:

1) The sequences 'start' and 'start, stop, start' produce different
system states. The first invocation of start will import and mount all
file systems. Stopping the service will unmount them, but not export
them. Running start again will not do anything, leaving the user with
unmounted file systems.

2) It imports all storage pools, not just those that are noted in the
cache. It's usually ill-advised to import all available pools.

3) It is different from all the other file systems and storage layers
that Void supports, which are all handled in stage 1.

This change depends on voidlinux/void-runit#46 for the replacement
solution.