### PR TITLE
zfs: remove zfs-import service

### DIFF
--- a/srcpkgs/zfs/files/zfs-import/finish
+++ b/srcpkgs/zfs/files/zfs-import/finish
@@ -1,5 +1,0 @@
-#!/bin/sh
-set -e
-exec 2>&1
-zfs unshare -a
-zfs unmount -a

--- a/srcpkgs/zfs/files/zfs-import/run
+++ b/srcpkgs/zfs/files/zfs-import/run
@@ -1,4 +1,0 @@
-#!/bin/sh
-exec 2>&1
-zpool import -a || exit 1
-exec chpst -b zfs-import pause

--- a/srcpkgs/zfs/template
+++ b/srcpkgs/zfs/template
@@ -1,7 +1,7 @@
 # Template file for 'zfs'
 pkgname=zfs
 version=0.6.5.7
-revision=1
+revision=2
 patch_args="-Np1"
 wrksrc="${pkgname}-${pkgname}-${version/r/-}"
 build_style=gnu-configure
@@ -33,8 +33,6 @@ post_install() {
 	vmkdir usr/src/${pkgname}-${version/r/-}
 	tar xf ../clean.tar.gz -C ${DESTDIR}/usr/src/${pkgname}-${version/r/-}
 	scripts/dkms.mkconf -v ${version/r/-} -f ${DESTDIR}/usr/src/${pkgname}-${version/r/-}/dkms.conf -n zfs
-
-	vsv zfs-import
 
 	rm -rf ${DESTDIR}/usr/lib/systemd
 	rm -rf ${DESTDIR}/usr/share/initramfs-tools


### PR DESCRIPTION
The service has several flaws:

1) The sequences 'start' and 'start, stop, start' produce different
system states. The first invocation of start will import and mount all
file systems. Stopping the service will unmount them, but not export
them. Running start again will not do anything, leaving the user with
unmounted file systems.

2) It imports all storage pools, not just those that are noted in the
cache. It's usually ill-advised to import all available pools.

3) It is different from all the other file systems and storage layers
that Void supports, which are all handled in stage 1.

This change depends on voidlinux/void-runit#46 for the replacement
solution.