### PR TITLE
mit-krb5: enable ldap database support

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -531,6 +531,7 @@ libkdb5.so.8 mit-krb5-libs-1.13.1_1
 libkrb5.so.3 mit-krb5-libs-1.8_1
 libkrad.so.0 mit-krb5-libs-1.12.1_1
 libkrb5support.so.0 mit-krb5-libs-1.8_1
+libkdb_ldap.so.1 mit-krb5-libs-1.14.2_2
 libverto.so.0 mit-krb5-libs-1.8_1
 libverto-k5ev.so.0 mit-krb5-libs-1.8_1
 libmenu-cache.so.3 menu-cache-1.0.0_1

--- a/srcpkgs/mit-krb5/template
+++ b/srcpkgs/mit-krb5/template
@@ -1,7 +1,7 @@
 # Template file for 'mit-krb5'
 pkgname=mit-krb5
 version=1.14.2
-revision=1
+revision=2
 short_desc="MIT Kerberos 5 implementation"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="MIT"
@@ -12,7 +12,7 @@ checksum=6bcad7e6778d1965e4ce4af21d2efdc15b274c5ce5c69031c58e4c954cda8b27
 build_style=gnu-configure
 wrksrc="krb5-${version}"
 hostmakedepends="perl flex e2fsprogs-devel"
-makedepends="db-devel e2fsprogs-devel libressl-devel"
+makedepends="db-devel e2fsprogs-devel libressl-devel libldap-devel"
 depends="mit-krb5-client>=${version}_${revision}"
 
 post_extract() {
@@ -21,7 +21,7 @@ post_extract() {
 }
 do_configure() {
 	WARN_CFLAGS= ./src/configure ${configure_args} --sbindir=/usr/bin \
-		--disable-rpath --with-system-et --without-system-verto \
+		--disable-rpath --with-system-et --without-system-verto --with-ldap \
 		--with-system-ss --with-system-db --enable-shared --without-tcl \
 		ac_cv_func_pthread_once=yes ac_cv_func_pthread_rwlock_init=yes \
 		acx_pthread_ok=yes ac_cv_func_regcomp=yes ac_cv_printf_positional=yes \


### PR DESCRIPTION
Since kerberos is often used in conjunction with ldap, it is often preferable to use ldap as the backing database for the master KDC.  This also permits the operation of multi-master KDC environments.