### PR TITLE
spotify: downgrade to 1.0.28

### DIFF
--- a/srcpkgs/spotify/template
+++ b/srcpkgs/spotify/template
@@ -1,6 +1,6 @@
 # Template build file for 'spotify'.
 pkgname=spotify
-version=1.0.29
+version=1.0.28
 revision=1
 short_desc="Proprietary music streaming client"
 maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
@@ -13,11 +13,11 @@ build_style=fetch
 depends="binutils gtk+ nss GConf libXScrnSaver xz"
 
 if test "${XBPS_TARGET_MACHINE}" = "x86_64"; then
-	_sversion=".92.g67727800-21_amd64"
-	_schecksum="c44fee4e687e73906760e008c863f2166f1f715d130329ef5621047bef548188"
+	_sversion=".89.gf959d4ce-37_amd64"
+	_schecksum="c563f1c0cd7a632802431191714bd23be05009ce93d70571cc217e606575661b"
 else
-	_sversion=".92.g67727800-3_i386"
-	_schecksum="9b888e112f02be43566e343d032552c5e8b82ad8e75adc3f8409dc5f8a87e4b9"
+	_sversion=".89.gf959d4ce-4_i386"
+	_schecksum="d79ffa8e1af22262ab52287a5d8538b74840d7f2f164776309d9f68a38ae0084"
 fi
 
 do_install() {


### PR DESCRIPTION
The new version (1.0.31) segfaults in their alsa output driver and the current version (1.0.29) is no longer available on the download server.