### PR TITLE
catalyst: patched for linux4.6 & update to 15.302

### DIFF
--- a/srcpkgs/catalyst/files/4.6-void-user_page.patch
+++ b/srcpkgs/catalyst/files/4.6-void-user_page.patch
@@ -1,0 +1,39 @@
+diff --git a/firegl_public.c b/firegl_public.c
+--- 15.201/common/lib/modules/fglrx/build_mod/firegl_public.c
++++ 15.201b/common/lib/modules/fglrx/build_mod/firegl_public.c
+@@ -3225,7 +3225,11 @@ int ATI_API_CALL KCL_LockUserPages(unsigned long vaddr, unsigned long* page_list
+     int ret;
+ 
+     down_read(&current->mm->mmap_sem);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
++    ret = get_user_pages(vaddr, page_cnt, 1, 0, (struct page **)page_list, NULL);
++#else
+     ret = get_user_pages(current, current->mm, vaddr, page_cnt, 1, 0, (struct page **)page_list, NULL);
++#endif
+     up_read(&current->mm->mmap_sem);
+ 
+     return ret;
+@@ -3243,7 +3247,11 @@ int ATI_API_CALL KCL_LockReadOnlyUserPages(unsigned long vaddr, unsigned long* p
+     int ret;
+ 
+     down_read(&current->mm->mmap_sem);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
++    ret = get_user_pages(vaddr, page_cnt, 0, 0, (struct page **)page_list, NULL);
++#else
+     ret = get_user_pages(current, current->mm, vaddr, page_cnt, 0, 0, (struct page **)page_list, NULL);
++#endif
+     up_read(&current->mm->mmap_sem);
+ 
+     return ret;
+@@ -3254,7 +3262,11 @@ void ATI_API_CALL KCL_UnlockUserPages(unsigned long* page_list, unsigned int pag
+     unsigned int i;
+     for (i=0; i<page_cnt; i++)
+     {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
++        put_page((struct page*)page_list[i]);
++#else
+         page_cache_release((struct page*)page_list[i]);
++#endif
+     }
+ }
+ 

--- a/srcpkgs/catalyst/template
+++ b/srcpkgs/catalyst/template
@@ -1,10 +1,11 @@
 # Template file for 'catalyst'
-_desc="AMD catalyst driver for Linux"
-_release="15.9"
+_release="15.12"
+_build="151217a-297685e"
+_desc="AMD catalyst driver ${_release} for Linux"
 
 pkgname=catalyst
-version=15.201.1151
-revision=7
+version=15.302
+revision=1
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="Proprietary AMD license"
 homepage="http://www.amd.com"
@@ -19,10 +20,10 @@ repository="nonfree"
 create_wrksrc=yes
 nopie=yes
 
-XBPS_FETCH_CMD="wget --referer='http://support.amd.com/en-us/download/desktop?os=Linux+x86' "
+XBPS_FETCH_CMD="wget --referer='http://support.amd.com/en-us/download/desktop?os=Linux+x86_64' "
 
-distfiles="http://www2.ati.com/drivers/linux/amd-catalyst-${_release}-linux-installer-${version}-x86.x86_64.zip"
-checksum=bf3e6e7d5c51db3d075410a3f116f865b82823debc1d66698d187249feec6a91
+distfiles="https://www2.ati.com/drivers/linux/radeon-crimson-${_release}-${version}-${_build}.zip"
+checksum=704f2dfc14681f76dae3b4120c87b1ded33cf43d5a1d800b6de5ca292bb61e58
 
 if [ "$XBPS_MACHINE" = "i686" ]; then
 	_ARCHDIR="x86"
@@ -33,12 +34,11 @@ elif [ "$XBPS_MACHINE" = "x86_64" ]; then
 fi
 
 do_build() {
-	/bin/sh ./*.run --extract fglrx-${version}
 	cd fglrx-${version}
+	/bin/sh ./*.run --extract ./
 
 	patch -Np1 -i ${FILESDIR}/lano1106_fglrx_intel_iommu.patch
 	patch -Np1 -i ${FILESDIR}/lano1106_kcl_agp_13_4.patch
-	patch -Np1 -i ${FILESDIR}/4.2-amd-from_crimson_15.11.patch
 	patch -Np1 -i ${FILESDIR}/4.3-kolasa-seq_printf.patch
 	patch -Np1 -i ${FILESDIR}/4.3-gentoo-mtrr.patch
 	patch -Np1 -i ${FILESDIR}/fglrx_gpl_symbol.patch

--- a/srcpkgs/catalyst/template
+++ b/srcpkgs/catalyst/template
@@ -4,7 +4,7 @@ _release="15.9"
 
 pkgname=catalyst
 version=15.201.1151
-revision=6
+revision=7
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="Proprietary AMD license"
 homepage="http://www.amd.com"
@@ -17,6 +17,7 @@ conflicts="nvidia>=0 xserver-abi-video>19_1"
 short_desc="${_desc} - Utilities"
 repository="nonfree"
 create_wrksrc=yes
+nopie=yes
 
 XBPS_FETCH_CMD="wget --referer='http://support.amd.com/en-us/download/desktop?os=Linux+x86' "
 
@@ -44,6 +45,7 @@ do_build() {
 	[ "$XBPS_MACHINE" = "i686" ] && patch -Np1 -i ${FILESDIR}/crimson_i686_xg.patch
 	patch -Np1 -i ${FILESDIR}/4.4-manjaro-xstate.patch
 	patch -Np1 -i ${FILESDIR}/grsec_arch.patch
+	patch -Np1 -i ${FILESDIR}/4.6-void-user_page.patch
 }
 do_install() {
 	cd fglrx-${version}


### PR DESCRIPTION
Obviously should be an upstream patch, but AMD doesn't care about Linux anyway.
So, here is some ducktape.

Still needs xorg-server-1.7 and xf86-input-evdev-2.10.0 to work. Maybe put them back in the current repo, so users don't have to build it themselves? The archives don't go back that far.