### PR TITLE
libcaca: update source and add x11 driver.

### DIFF
--- a/srcpkgs/libcaca/template
+++ b/srcpkgs/libcaca/template
@@ -1,16 +1,16 @@
 # Template file for 'libcaca'
 pkgname=libcaca
 version=0.99.beta19
-revision=6
+revision=7
 build_style=gnu-configure
 hostmakedepends="libtool automake pkg-config"
 short_desc="Graphics library that outputs text instead of pixels"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-makedepends="ncurses-devel"
+makedepends="libX11-devel ncurses-devel"
 homepage="http://caca.zoy.org/wiki/libcaca"
 license="WTFPL"
-distfiles="http://caca.zoy.org/files/libcaca/libcaca-${version}.tar.gz"
-checksum=128b467c4ed03264c187405172a4e83049342cc8cc2f655f53a2d0ee9d3772f4
+distfiles="https://github.com/cacalabs/libcaca/archive/v${version}.tar.gz"
+checksum=7ed29a00cc7f017424d8b2994f001f137ed5bc4441987b711d78c6734fdf3493
 
 pre_configure() {
 	sed -i -e 's,AM_CONFIG_HEADER,AC_CONFIG_HEADERS,' configure.ac

--- a/srcpkgs/libcaca/template
+++ b/srcpkgs/libcaca/template
@@ -14,7 +14,6 @@ checksum=7ed29a00cc7f017424d8b2994f001f137ed5bc4441987b711d78c6734fdf3493
 
 # package build options
 build_options="x11"
-desc_option_x11="Enable x11 driver"
 
 pre_configure() {
 	sed -i -e 's,AM_CONFIG_HEADER,AC_CONFIG_HEADERS,' configure.ac

--- a/srcpkgs/libcaca/template
+++ b/srcpkgs/libcaca/template
@@ -6,11 +6,15 @@ build_style=gnu-configure
 hostmakedepends="libtool automake pkg-config"
 short_desc="Graphics library that outputs text instead of pixels"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-makedepends="libX11-devel ncurses-devel"
+makedepends="ncurses-devel $(vopt_if x11 libX11-devel)"
 homepage="http://caca.zoy.org/wiki/libcaca"
 license="WTFPL"
 distfiles="https://github.com/cacalabs/libcaca/archive/v${version}.tar.gz"
 checksum=7ed29a00cc7f017424d8b2994f001f137ed5bc4441987b711d78c6734fdf3493
+
+# package build options
+build_options="x11"
+desc_option_x11="Enable x11 driver"
 
 pre_configure() {
 	sed -i -e 's,AM_CONFIG_HEADER,AC_CONFIG_HEADERS,' configure.ac


### PR DESCRIPTION
Download source from official github repository tags and add libX11-devel as build depend for the x11 driver.