### PR TITLE
adobe-flash-plugin: update to 11.2.202.626.

### DIFF
--- a/srcpkgs/adobe-flash-plugin/template
+++ b/srcpkgs/adobe-flash-plugin/template
@@ -1,6 +1,6 @@
 # Template file for 'adobe-flash-plugin'
 pkgname=adobe-flash-plugin
-version=11.2.202.621
+version=11.2.202.626
 revision=1
 # The EULA file
 _eula="http://www.adobe.com/products/eulas/pdfs/PlatformClients_PC_WWEULA_Combined_20100108_1657.pdf"
@@ -8,10 +8,10 @@ _eulacksum=3cb0a5f4576be735abcff7189ed18eda17c70b762c3a78a3379b6f44395fbc10
 _url=http://fpdownload.adobe.com/get/flashplayer/pdc/${version}
 if [ "$XBPS_MACHINE" = "x86_64" ]; then
 	_disttarball="${_url}/install_flash_player_11_linux.x86_64.tar.gz"
-	_distcksum=c8860c0f21bd90b78f023b4ce7a12ab48cc63f20524b2d60fd032755169fa92e
+	_distcksum=14f6f10c664984302e2cb67bda06b8da8358cf4110235a3ad1dff06df22ad0ad
 else
 	_disttarball="${_url}/install_flash_player_11_linux.i386.tar.gz"
-	_distcksum=137c87098f0fa9d02a3ab49e9e07a486e7a09e7b68f151294ee3c957d7d51d45
+	_distcksum=1ec079f9d8578255435e15f704f05e4af69e749a480427af2be64fe447e2ca8c
 fi
 distfiles="${_eula} ${_disttarball}"
 checksum="${_eulacksum} ${_distcksum}"


### PR DESCRIPTION
This addresses how Firefox complains that Shockwave Flash is dangerously old.