### PR TITLE
wps-office: update to 10.1.0.5672a21

### DIFF
--- a/srcpkgs/wps-office/template
+++ b/srcpkgs/wps-office/template
@@ -1,7 +1,7 @@
 # Template file for 'wps-office'
-_numericVersion=10.1.0.5503
-_releaseIncrement=a20
-_patchLevel=p2
+_numericVersion=10.1.0.5672
+_releaseIncrement=a21
+_patchLevel=
 _libpngVersion=1.2.56
 
 pkgname=wps-office
@@ -24,10 +24,10 @@ _disturl="http://kdl.cc.ksosoft.com/wps-community/download/${_releaseIncrement}"
 only_for_archs="i686 x86_64"
 if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 	_arch=x86_64
-	checksum=9a43a32db385a604e9959487abc330bb4602724527c9bca229a0ddf98f462e41
+	checksum=9f49052cc98958b5d60d08e2f0c81dc53f754aba1654f1407b02397a67b22356
 elif [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
 	_arch=x86
-	checksum=6f71131835d743594e0c89a4b34a4d924d72f48b0c02f7ea6fe7270f273f71e9
+	checksum=27d50098eac5de3c5b9774ba9046f66aaae20430d35264b7848de372150064b6
 fi
 
 _distTar="${pkgname}_${_numericVersion}~${_releaseIncrement}${_patchLevel}_${_arch}.tar.xz"


### PR DESCRIPTION
There's no patchlevel for this release, but the token is retained to account for future releases.