### PR TITLE
xbps-src: Preprocess arguments using getopt in order to allow options before and after XBPS_TARGET.

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -408,8 +408,12 @@ export XBPS_MACHINE=$(xbps-uhelper arch)
 # main()
 #
 XBPS_OPTIONS=
+XBPS_OPTSTRING="a:CEfgGhH:Ij:Lm:No:r:tV"
 
-while getopts "a:CEfgGhH:Ij:Lm:No:r:tV" opt; do
+# Preprocess arguments in order to allow options before and after XBPS_TARGET.
+eval set -- $(getopt -- "$XBPS_OPTSTRING" "$@");
+
+while getopts "$XBPS_OPTSTRING" opt; do
     case $opt in
         a) readonly XBPS_CROSS_BUILD="$OPTARG"; XBPS_OPTIONS+=" -a $OPTARG";;
         C) readonly XBPS_KEEP_ALL=1; XBPS_OPTIONS+=" -C";;


### PR DESCRIPTION
This results in a more consistent behavior with other base utils.