### PR TITLE
fish: update to 2.3.1

### DIFF
--- a/srcpkgs/fish-shell/template
+++ b/srcpkgs/fish-shell/template
@@ -1,6 +1,6 @@
 # Template file for 'fish-shell'
 pkgname=fish-shell
-version=2.3.0
+version=2.3.1
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake libtool"
@@ -12,8 +12,8 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://fishshell.com/"
 license="GPL-2"
 short_desc="User friendly shell intended mostly for interactive use"
-distfiles="http://fishshell.com/files/${version}/fish-${version}.tar.gz"
-checksum=912bac47552b1aa0d483a39ade330356632586a8f726c0e805b46d45cfad54e5
+distfiles="https://github.com/fish-shell/fish-shell/releases/download/${version}/fish-${version}.tar.gz"
+checksum=328acad35d131c94118c1e187ff3689300ba757c4469c8cc1eaa994789b98664
 
 if [ -n "$CROSS_BUILD" ]; then
 	case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
2.3.1 is not available from fishshell.com; use the release page instead