### PR TITLE
Correct bootstrap build issues when building from Arch linux

### DIFF
--- a/common/environment/configure/bootstrap.sh
+++ b/common/environment/configure/bootstrap.sh
@@ -1,4 +1,5 @@
 if [ -z "$CHROOT_READY" ]; then
 	CFLAGS+=" -isystem ${XBPS_MASTERDIR}/usr/include"
 	LDFLAGS+=" -L${XBPS_MASTERDIR}/usr/lib -Wl,-rpath-link=${XBPS_MASTERDIR}/usr/lib"
+	PKG_CONFIG_LIBDIR="${XBPS_MASTERDIR}/usr/lib/pkgconfig"
 fi

--- a/srcpkgs/gcc/patches/gcc-233720-backport.patch
+++ b/srcpkgs/gcc/patches/gcc-233720-backport.patch
@@ -1,0 +1,117 @@
+--- gcc/cp/Make-lang.in	2016/02/25 15:23:47	233719
++++ gcc/cp/Make-lang.in	2016/02/25 15:33:50	233720
+@@ -111,7 +111,7 @@
+ # deleting the $(srcdir)/cp/cfns.h file.
+ $(srcdir)/cp/cfns.h:
+ endif
+-	gperf -o -C -E -k '1-6,$$' -j1 -D -N 'libc_name_p' -L ANSI-C \
++	gperf -o -C -E -k '1-6,$$' -j1 -D -N 'libc_name_p' -L C++ \
+ 		$(srcdir)/cp/cfns.gperf --output-file $(srcdir)/cp/cfns.h
+ 
+ #
+--- gcc/cp/cfns.gperf	2016/02/25 15:23:47	233719
++++ gcc/cp/cfns.gperf	2016/02/25 15:33:50	233720
+@@ -1,3 +1,5 @@
++%language=C++
++%define class-name libc_name
+ %{
+ /* Copyright (C) 2000-2015 Free Software Foundation, Inc.
+ 
+@@ -16,14 +18,6 @@
+ You should have received a copy of the GNU General Public License
+ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+-#ifdef __GNUC__
+-__inline
+-#endif
+-static unsigned int hash (const char *, unsigned int);
+-#ifdef __GNUC__
+-__inline
+-#endif
+-const char * libc_name_p (const char *, unsigned int);
+ %}
+ %%
+ # The standard C library functions, for feeding to gperf; the result is used
+--- gcc/cp/cfns.h	2016/02/25 15:23:47	233719
++++ gcc/cp/cfns.h	2016/02/25 15:33:50	233720
+@@ -1,5 +1,5 @@
+-/* ANSI-C code produced by gperf version 3.0.3 */
+-/* Command-line: gperf -o -C -E -k '1-6,$' -j1 -D -N libc_name_p -L ANSI-C cfns.gperf  */
++/* C++ code produced by gperf version 3.0.4 */
++/* Command-line: gperf -o -C -E -k '1-6,$' -j1 -D -N libc_name_p -L C++ --output-file cfns.h cfns.gperf  */
+ 
+ #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
+       && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
+@@ -28,7 +28,7 @@
+ #error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
+ #endif
+ 
+-#line 1 "cfns.gperf"
++#line 3 "cfns.gperf"
+ 
+ /* Copyright (C) 2000-2015 Free Software Foundation, Inc.
+ 
+@@ -47,25 +47,18 @@
+ You should have received a copy of the GNU General Public License
+ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+-#ifdef __GNUC__
+-__inline
+-#endif
+-static unsigned int hash (const char *, unsigned int);
+-#ifdef __GNUC__
+-__inline
+-#endif
+-const char * libc_name_p (const char *, unsigned int);
+ /* maximum key range = 391, duplicates = 0 */
+ 
+-#ifdef __GNUC__
+-__inline
+-#else
+-#ifdef __cplusplus
+-inline
+-#endif
+-#endif
+-static unsigned int
+-hash (register const char *str, register unsigned int len)
++class libc_name
++{
++private:
++  static inline unsigned int hash (const char *str, unsigned int len);
++public:
++  static const char *libc_name_p (const char *str, unsigned int len);
++};
++
++inline unsigned int
++libc_name::hash (register const char *str, register unsigned int len)
+ {
+   static const unsigned short asso_values[] =
+     {
+@@ -122,14 +115,8 @@
+   return hval + asso_values[(unsigned char)str[len - 1]];
+ }
+ 
+-#ifdef __GNUC__
+-__inline
+-#ifdef __GNUC_STDC_INLINE__
+-__attribute__ ((__gnu_inline__))
+-#endif
+-#endif
+ const char *
+-libc_name_p (register const char *str, register unsigned int len)
++libc_name::libc_name_p (register const char *str, register unsigned int len)
+ {
+   enum
+     {
+--- gcc/cp/except.c	2016/02/25 15:23:47	233719
++++ gcc/cp/except.c	2016/02/25 15:33:50	233720
+@@ -1040,7 +1040,8 @@
+      unless the system headers are playing rename tricks, and if
+      they are, we don't want to be confused by them.  */
+   id = DECL_NAME (fn);
+-  return !!libc_name_p (IDENTIFIER_POINTER (id), IDENTIFIER_LENGTH (id));
++  return !!libc_name::libc_name_p (IDENTIFIER_POINTER (id),
++				   IDENTIFIER_LENGTH (id));
+ }
+ 
+ /* Returns nonzero if an exception of type FROM will be caught by a

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -2,7 +2,7 @@
 pkgname=gcc
 _majorver=4.9
 version=${_majorver}.3
-revision=4
+revision=5
 short_desc="The GNU C Compiler"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://gcc.gnu.org"
@@ -160,6 +160,7 @@ do_configure() {
 		--enable-languages=${_langs} ${_args}
 }
 do_build() {
+	export LD_LIBRARY_PATH="${XBPS_MASTERDIR}/usr/lib"
 	make ${makejobs}
 }
 pre_install() {

--- a/srcpkgs/glibc/template
+++ b/srcpkgs/glibc/template
@@ -1,7 +1,7 @@
 # Template file for 'glibc'
 pkgname=glibc
 version=2.23
-revision=1
+revision=2
 bootstrap=yes
 short_desc="The GNU C library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -105,6 +105,7 @@ do_configure() {
 		--enable-stack-guard-randomization \
 		--without-selinux --without-cvs --without-gd \
 		--disable-lock-elision \
+		--disable-werror \
 		libc_cv_rootsbindir=/usr/bin \
 		libc_cv_rtlddir=${_libdir} libc_cv_slibdir=${_libdir}
 }

--- a/srcpkgs/pkg-config/patches/glib-bugzilla-761550-format-literal-new-gcc.patch
+++ b/srcpkgs/pkg-config/patches/glib-bugzilla-761550-format-literal-new-gcc.patch
@@ -1,0 +1,18 @@
+--- glib/glib/gdate.c.orig	2016-01-24 13:51:38.000000000 -0800
++++ glib/glib/gdate.c	2016-07-10 00:18:28.007331745 -0700
+@@ -2439,6 +2439,9 @@
+  *
+  * Returns: number of characters written to the buffer, or 0 the buffer was too small
+  */
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wformat-nonliteral"
++
+ gsize
+ g_date_strftime (gchar       *s,
+                  gsize        slen,
+@@ -2549,3 +2552,5 @@
+   return retval;
+ #endif
+ }
++
++#pragma GCC diagnostic pop

--- a/srcpkgs/pkg-config/template
+++ b/srcpkgs/pkg-config/template
@@ -1,7 +1,7 @@
 # Template build file for 'pkg-config'
 pkgname=pkg-config
 version=0.29.1
-revision=1
+revision=2
 bootstrap=yes
 build_style=gnu-configure
 configure_args="--with-internal-glib --disable-host-tool"


### PR DESCRIPTION
I decided to attempt to build void linux from Arch linux.  I ran into a number of bootstrapping issues along the way.  I started from https://github.com/voidlinux/void-packages/blob/master/README.md#using-xbps-src-in-a-foreign-linux-distribution and decided to run "bootstrap" instead of "binary-bootstrap".

I found a number of issues that prevented building all of the bootstrap packages.  The most troubling were builds where include files and libraries on the build host (in this case Arch linux) would be found during bootstrapping and be linked into the bootstrap packages.  In other cases the newer version of gcc shipped with Arch would cause build failures due to -Werror (these don't manifest with gcc 4.9.3).  Finally some packages wouldn't build because the $XBPS_MASTERDIR wasn't populated with the c header files in /usr/include.

With these changes I was able to successfully complete "xbps-src bootstrap" on an x86_64 Arch linux system, overcoming all of the above issues.
