### PR TITLE
libmilter, opendkim, rmilter: force rebuild

### DIFF
--- a/srcpkgs/libmilter/template
+++ b/srcpkgs/libmilter/template
@@ -1,7 +1,7 @@
 # Template file for 'libmilter'
 pkgname=libmilter
 version=1.0.2
-revision=1
+revision=2
 _pkgname=sendmail
 _version=8.15.2
 hostmakedepends="m4"

--- a/srcpkgs/opendkim/template
+++ b/srcpkgs/opendkim/template
@@ -1,7 +1,7 @@
 # Template file for 'opendkim'
 pkgname=opendkim
 version=2.10.3
-revision=1
+revision=2
 build_style="gnu-configure"
 configure_args="--with-milter=${XBPS_CROSS_BASE}/usr"
 makedepends="libbsd-devel libressl-devel libmilter-devel"

--- a/srcpkgs/rmilter/template
+++ b/srcpkgs/rmilter/template
@@ -1,7 +1,7 @@
 # Template file for 'rmilter'
 pkgname=rmilter
 version=1.8.5
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DMILTER_USER=rmilter -DSBINDIR=/usr/bin"
 hostmakedepends="pkg-config bison flex"


### PR DESCRIPTION
It looks like the `libmilter-devel` and `opendkim-devel` symlinks were added in separate commits from the package templates, see #4341

I think this caused the package builds to fail to fail, and the symlinks being added in later commits did not trigger package rebuilds. See https://build.voidlinux.eu/builders/x86_64-musl_builder/builds/12712 (failed build) and https://build.voidlinux.eu/builders/x86_64-musl_builder/builds/12713 (succeeded but no packages built).

Bumping the revision number to force rebuilds.