### PR TITLE
rspamd: remove non-breaking space from run script

### DIFF
--- a/srcpkgs/rspamd/files/rspamd/run
+++ b/srcpkgs/rspamd/files/rspamd/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 [ -r conf ] && . ./conf
-exec rspamd -f ${OPTS}
+exec rspamd -f ${OPTS}

--- a/srcpkgs/rspamd/template
+++ b/srcpkgs/rspamd/template
@@ -1,7 +1,7 @@
 # Template file for 'rspamd'
 pkgname=rspamd
 version=1.2.8
-revision=1
+revision=2
 build_style=cmake
 configure_args="
  -DRSPAMD_USER=rspamd


### PR DESCRIPTION
The run script had a UTF-8 non-breaking space character inside of `rspamd -f`

As far as I know, shell doesn't treat it as a whitespace, so the script fails to run..

The output of xxd, notice there's two bytes being used between `rspamd` and `-f`

```
$ xxd /etc/sv/rspamd/run 
00000000: 2321 2f62 696e 2f73 680a 5b20 2d72 2063  #!/bin/sh.[ -r c
00000010: 6f6e 6620 5d20 2626 202e 202e 2f63 6f6e  onf ] && . ./con
00000020: 660a 6578 6563 2072 7370 616d 64c2 a02d  f.exec rspamd..-
00000030: 6620 247b 4f50 5453 7d0a                 f ${OPTS}.
```