### PR TITLE
google-chrome: Template cleanup and icon fix

### DIFF
--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -5,7 +5,7 @@ _channel=stable
 
 pkgname=google-chrome
 version=${_chromeVersion}.${_chromeRevision}
-revision=1
+revision=2
 maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
 homepage="http://www.google.com/chrome/"
 license="chrome"
@@ -27,6 +27,24 @@ do_extract() {
 	mkdir -p ${DESTDIR}
 	ar x ${XBPS_SRCDISTDIR}/google-chrome-${version}/${_filename}
 }
+
 do_install() {
 	tar xf data.tar.xz -C ${DESTDIR}
+
+	# Install the icons
+	for size in 16 22 24 32 48 64 128 256; do
+		# Create the google chrome xdg directory
+		mkdir -p ${DESTDIR}/usr/share/icons/google/${size}x${size}/apps
+
+		# Copy the google chrome icon
+		mv ${DESTDIR}/opt/google/chrome/product_logo_${size}.png \
+		   ${DESTDIR}/usr/share/icons/google/${size}x${size}/apps/google-chrome.png
+	done
+
+	# Remove unused icons
+	rm ${DESTDIR}/opt/google/chrome/*.xpm
+
+	# Remove the Debian/Ubuntu crontab
+	rm -rf ${DESTDIR}/etc
+	rm -rf ${DESTDIR}/opt/google/chrome/cron
 }


### PR DESCRIPTION
As merged this template contained some leftovers from the *.deb that
this is repackaged from, as well as the icons were not copied into the
correct place to be usable.  This commit fixes both of these issues.