### PR TITLE
New package: autojump-22.3.4

### DIFF
--- a/srcpkgs/autojump/template
+++ b/srcpkgs/autojump/template
@@ -1,0 +1,23 @@
+# Template file for 'autojump'
+pkgname=autojump
+version=22.3.4
+revision=1
+wrksrc=${pkgname}-release-v${version}
+hostmakedepends="python"
+depends="python"
+noarch=yes
+short_desc="A cd command that learns"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="GPL-3"
+homepage="https://github.com/wting/autojump"
+distfiles="https://github.com/wting/autojump/archive/release-v${version}.tar.gz"
+checksum=3fbd83f19e60514887c7efa1ce1b9015179c55c381a8867417eed933f2657984
+
+do_install() {
+	# The install script does some naive checks
+	./install.py -fd ${DESTDIR} -p ${DESTDIR}/usr -z ${DESTDIR}/usr/share/zsh/site-functions/
+}
+
+post_install() {
+	sed -i "s:${DESTDIR}::" ${DESTDIR}/etc/profile.d/autojump.sh
+}

--- a/srcpkgs/autojump/update
+++ b/srcpkgs/autojump/update
@@ -1,0 +1,2 @@
+site=https://github.com/wting/autojump/releases
+pattern='release-\Kv?[0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?'


### PR DESCRIPTION
Resolves #4438.

This has got a fairly convoluted installer, thus the need for the custom do_install().  As this isn't a python module I don't really see much point in building it against anything but the default system python.