### PR TITLE
rspamd: more run script fixes

### DIFF
--- a/srcpkgs/rspamd/files/rspamd/run
+++ b/srcpkgs/rspamd/files/rspamd/run
@@ -1,3 +1,10 @@
 #!/bin/sh
 [ -r conf ] && . ./conf
-exec rspamd -f ${OPTS}
+: ${RSPAMDUSER:=rspamd}
+: ${RSPAMDGROUP:=rspamd}
+for dir in /var/log/rspamd /run/rspamd; do
+	if [ ! -d $dir ]; then
+		install -d -m 0755 -o $RSPAMDUSER -g $RSPAMDGROUP $dir
+	fi
+done
+exec rspamd -u $RSPAMDUSER -g $RSPAMDGROUP -f ${OPTS}

--- a/srcpkgs/rspamd/template
+++ b/srcpkgs/rspamd/template
@@ -1,7 +1,7 @@
 # Template file for 'rspamd'
 pkgname=rspamd
 version=1.2.8
-revision=2
+revision=3
 build_style=cmake
 configure_args="
  -DRSPAMD_USER=rspamd


### PR DESCRIPTION
The default rspamd config needs a writable log directory and run
directory.

Additionally, rspamd refuses to start if run as root.