### PR TITLE
kodi: fix building against curl 7.50.0 (#4497)

### DIFF
--- a/srcpkgs/kodi/patches/fix-curl-750-compatibility.patch
+++ b/srcpkgs/kodi/patches/fix-curl-750-compatibility.patch
@@ -1,0 +1,44 @@
+diff --git a/xbmc/filesystem/CurlFile.h b/xbmc/filesystem/CurlFile.h
+index b4f5046..81a5ae5 100644
+--- a/xbmc/filesystem/CurlFile.h
++++ b/xbmc/filesystem/CurlFile.h
+@@ -24,11 +24,17 @@
+ #include <map>
+ #include <string>
+ #include "utils/HttpHeader.h"
++#include <curl/curlver.h>
+ 
+ namespace XCURL
+ {
++#if LIBCURL_VERSION_NUM >= 0x073200
++  typedef struct Curl_easy CURL_HANDLE;
++  typedef struct Curl_multi CURLM;
++#else
+   typedef void CURL_HANDLE;
+   typedef void CURLM;
++#endif
+   struct curl_slist;
+ }
+ 
+diff --git a/xbmc/filesystem/DllLibCurl.h b/xbmc/filesystem/DllLibCurl.h
+index db97f92..9e78a91 100644
+--- a/xbmc/filesystem/DllLibCurl.h
++++ b/xbmc/filesystem/DllLibCurl.h
+@@ -52,7 +52,7 @@ namespace XCURL
+     virtual CURLMcode multi_fdset(CURLM *multi_handle, fd_set *read_fd_set, fd_set *write_fd_set, fd_set *exc_fd_set, int *max_fd)=0;
+     virtual CURLMcode multi_timeout(CURLM *multi_handle, long *timeout)=0;
+     virtual CURLMsg*  multi_info_read(CURLM *multi_handle, int *msgs_in_queue)=0;
+-    virtual void multi_cleanup(CURL_HANDLE * handle )=0;
++    virtual CURLMcode multi_cleanup(CURLM * handle )=0;
+     virtual struct curl_slist* slist_append(struct curl_slist *, const char *)=0;
+     virtual void  slist_free_all(struct curl_slist *)=0;
+   };
+@@ -77,7 +77,7 @@ namespace XCURL
+     DEFINE_METHOD5(CURLMcode, multi_fdset, (CURLM *p1, fd_set *p2, fd_set *p3, fd_set *p4, int *p5))
+     DEFINE_METHOD2(CURLMcode, multi_timeout, (CURLM *p1, long *p2))
+     DEFINE_METHOD2(CURLMsg*,  multi_info_read, (CURLM *p1, int *p2))
+-    DEFINE_METHOD1(void, multi_cleanup, (CURLM *p1))
++    DEFINE_METHOD1(CURLMcode, multi_cleanup, (CURLM *p1))
+     DEFINE_METHOD2(struct curl_slist*, slist_append, (struct curl_slist * p1, const char * p2))
+     DEFINE_METHOD1(void, slist_free_all, (struct curl_slist * p1))
+     DEFINE_METHOD1(const char *, easy_strerror, (CURLcode p1))

--- a/srcpkgs/kodi/template
+++ b/srcpkgs/kodi/template
@@ -1,7 +1,7 @@
 # Template file for 'kodi'
 pkgname=kodi
 version=16.1
-revision=4
+revision=5
 patch_args="-Np1"
 _codename="Jarvis"
 wrksrc="xbmc-${version}-${_codename}"
@@ -42,7 +42,10 @@ case "$XBPS_MACHINE" in
 	*) hostmakedepends+=" swig openjdk-jre";;
 esac
 
-broken="https://build.voidlinux.eu/builders/x86_64-musl_builder/builds/12849/steps/shell_3/logs/stdio (broken with curl-7.50)"
+# The patch fix-curl-750-compatibility.patch patches the kodi code to build against curl >= 7.50.0
+# since there were some forward declarations that conflicted after the changes in that curl release.
+# The upstream pull request can be found at https://github.com/xbmc/xbmc/pull/10160
+# Any updates to this package should bear the upstream PR in mind.
 
 # XXX http://build.voidlinux.eu/builders/x86_64_builder/builds/10520/steps/shell_3/logs/stdio
 CXXFLAGS="-fpermissive"


### PR DESCRIPTION
Patch taken from xbmc/xbmc#10160 (thanks @fritsch for taking care of it). The patch is from kodi master but the relevant code was not changed since the 16.1 release so it applies cleanly against that version as well. Tested building and running kodi with this patch on my Void i686 VM. Fixes #4497