### PR TITLE
adobe-flash-plugin: update to 11.2.202.632

### DIFF
--- a/srcpkgs/adobe-flash-plugin/template
+++ b/srcpkgs/adobe-flash-plugin/template
@@ -1,6 +1,6 @@
 # Template file for 'adobe-flash-plugin'
 pkgname=adobe-flash-plugin
-version=11.2.202.626
+version=11.2.202.632
 revision=1
 # The EULA file
 _eula="http://www.adobe.com/products/eulas/pdfs/PlatformClients_PC_WWEULA_Combined_20100108_1657.pdf"
@@ -8,10 +8,10 @@ _eulacksum=3cb0a5f4576be735abcff7189ed18eda17c70b762c3a78a3379b6f44395fbc10
 _url=http://fpdownload.adobe.com/get/flashplayer/pdc/${version}
 if [ "$XBPS_MACHINE" = "x86_64" ]; then
 	_disttarball="${_url}/install_flash_player_11_linux.x86_64.tar.gz"
-	_distcksum=14f6f10c664984302e2cb67bda06b8da8358cf4110235a3ad1dff06df22ad0ad
+	_distcksum=8a0cea025f854f2c6e139f623851eee60bb3842d5326fb7502644a1a94a6d1d7
 else
 	_disttarball="${_url}/install_flash_player_11_linux.i386.tar.gz"
-	_distcksum=1ec079f9d8578255435e15f704f05e4af69e749a480427af2be64fe447e2ca8c
+	_distcksum=c455ba9b72318d87434c7199a94ca15dc0f1c7fca590ee3703e013cbdecce942
 fi
 distfiles="${_eula} ${_disttarball}"
 checksum="${_eulacksum} ${_distcksum}"


### PR DESCRIPTION
This addresses Firefox blocking Adobe Flash from running due to being outdated.