### PR TITLE
fftw: enable openmp and fix armv7* build

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -896,10 +896,13 @@ libjackserver.so.0 libjack-1.9.7_1
 libjacknet.so.0 libjack-1.9.7_1
 libfftw3_threads.so.3 libfftw-3.3_1
 libfftw3.so.3 libfftw-3.3_1
+libfftw3_omp.so.3 libfftw-3.3.5_1
 libfftw3l_threads.so.3 libfftw-3.3_1
 libfftw3l.so.3 libfftw-3.3_1
+libfftw3l_omp.so.3 libfftw-3.3.5_1
 libfftw3f_threads.so.3 libfftw-3.3_1
 libfftw3f.so.3 libfftw-3.3_1
+libfftw3f_omp.so.3 libfftw-3.3.5_1
 libfluidsynth.so.1 libfluidsynth-1.1.5_1
 liblo.so.7 liblo-0.26_1
 libvamp-sdk.so.2 libvamp-plugin-sdk-2.2_1

--- a/srcpkgs/fftw/template
+++ b/srcpkgs/fftw/template
@@ -1,8 +1,9 @@
 # Template file for 'fftw'
 pkgname=fftw
 version=3.3.5
-revision=1
+revision=2
 hostmakedepends="libtool automake"
+makedepends="libgomp-devel"
 short_desc="Library for computing the discrete Fourier transform (DFT)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
@@ -12,11 +13,18 @@ checksum=8ecfe1b04732ec3f5b7d279fdb8efcad536d555f9d1e8fabd027037d45ea8bcf
 
 pre_configure() {
 	sed -e 's,AM_CONFIG_HEADER,AC_CONFIG_HEADERS,g' -i configure.ac
+	if [ "$CROSS_BUILD" ]; then
+		# Remove test which does not work when cross compiling
+		case "$XBPS_TARGET_MACHINE" in
+		armv[78]*) sed -i configure.ac \
+			-e "/dnl Check for not-always-available (not quite) cycle counters/,+26d"
+		esac
+	fi
 	autoreconf -fi
 }
 
 do_configure() {
-	local CARGS="--enable-shared --enable-threads"
+	local CARGS="--enable-shared --enable-threads --enable-openmp"
 
 	case "$XBPS_TARGET_MACHINE" in
 		i686*|x86_64*) _sse="--enable-sse"; _sse2="--enable-sse2";;


### PR DESCRIPTION
Remove the tests for CNTVCT for armv7 and CNTVCT_E0 for armv8 when
cross-compiling, because they will fail. Not supporting a possibly
available cycle counter may be less than optimal, while it should work.