### PR TITLE
jeti-filemanager: update to 1.2.3

### DIFF
--- a/srcpkgs/jeti-filemanager/template
+++ b/srcpkgs/jeti-filemanager/template
@@ -1,6 +1,6 @@
 # Template file for 'jeti-filemanager'
 pkgname=jeti-filemanager
-version=1.2.2
+version=1.2.3
 revision=1
 build_style=gnu-makefile
 homepage="https://github.com/mrshampoo/jeti-filemanager/"
@@ -9,7 +9,7 @@ short_desc="Total Commander filemanager ncurses clone"
 maintainer="Harri Leino <mr.leino@gmail.com>"
 license="GPL-3"
 distfiles="https://github.com/mrshampoo/jeti-filemanager/archive/${version}.tar.gz"
-checksum=c696ee52cb112b4f9f893fc8e97f9f1ef587f4fcd043f6024554e84b9c455c18
+checksum=2813e49a9bdf4065f08c45460fc882fe2da2a7f4490961223d62771945ba94e0
 
 pre_build() {
 	export LIBS="-lncurses $LDFLAGS"


### PR DESCRIPTION
changes done from verison 1.2.2 to 1.2.3

        * bugfix, sound should now work once again!
        * added, posibility to have sound action on startup, quit and fileaction.
        * bugfix, prevented jeti to enter a eternal loop that used up the cpu.
        * if using succless terminal, and it is deklared in the rc, jeti changes the workdir to the latest changed, in case of bringin up a new terminal from jeti, then the workdir of that terminal will be that of jeti. note this will not cynk when opening a terminal from the other window (only the latest)
        * jeti should now remember what file he last enterd