### PR TITLE
intellij-idea-community-edition: update to 2016.2.1

### DIFF
--- a/srcpkgs/intellij-idea-community-edition/template
+++ b/srcpkgs/intellij-idea-community-edition/template
@@ -1,6 +1,6 @@
 # Template file for 'intellij-idea-community-edition'
 pkgname=intellij-idea-community-edition
-version=2016.1.2b
+version=2016.2.1
 revision=1
 depends="virtual?java-environment giflib libXtst"
 short_desc="Java integrated development environment"
@@ -8,7 +8,7 @@ maintainer="Adrian Siekierka <asiekierka@gmail.com>"
 license="Apache-2.0"
 homepage="http://www.jetbrains.org/"
 distfiles="http://download.jetbrains.com/idea/ideaIC-${version}.tar.gz"
-checksum=9e3e0f4538707da37237106697fff4e0b5ed651085f456671764e1fbc9651bbe
+checksum=42a96ef8f726a178f19e8638e7d3d4f3f9aa787c6321e3ddec52cc779e50be37
 nopie=yes
 only_for_archs="i686 x86_64"
 

--- a/srcpkgs/intellij-idea-community-edition/update
+++ b/srcpkgs/intellij-idea-community-edition/update
@@ -1,2 +1,2 @@
 pattern="ideaIC-\K[\d.]+(?=\.tar)"
-site="https://confluence.jetbrains.com/display/IntelliJIDEA/Previous+IntelliJ+IDEA+Releases"
+site="https://data.services.jetbrains.com/products/releases?code=IIU%2CIIC&latest=true&type=release"


### PR DESCRIPTION
Also changes the update-check config to not use the "Previous releases" page, but the current release