### PR TITLE
kdelibs: add security fix CVE-2016-6232.patch

### DIFF
--- a/srcpkgs/kdelibs/patches/CVE-2016-6232.patch
+++ b/srcpkgs/kdelibs/patches/CVE-2016-6232.patch
@@ -1,0 +1,32 @@
+--- kdecore/io/karchive.cpp
++++ kdecore/io/karchive.cpp
+@@ -800,6 +800,7 @@
+ void KArchiveDirectory::copyTo(const QString& dest, bool recursiveCopy ) const
+ {
+   QDir root;
++  const QString destDir(QDir(dest).absolutePath()); // get directory path without any "." or ".."
+ 
+   QList<const KArchiveFile*> fileList;
+   QMap<qint64, QString> fileToDir;
+@@ -809,10 +810,19 @@
+   QStack<QString> dirNameStack;
+ 
+   dirStack.push( this );     // init stack at current directory
+-  dirNameStack.push( dest ); // ... with given path
++  dirNameStack.push(destDir);   // ... with given path
+   do {
+     const KArchiveDirectory* curDir = dirStack.pop();
+-    const QString curDirName = dirNameStack.pop();
++
++    // extract only to specified folder if it is located within archive's extraction folder
++    // otherwise put file under root position in extraction folder
++    QString curDirName = dirNameStack.pop();
++    if (!QDir(curDirName).absolutePath().startsWith(destDir)) {
++        qWarning() << "Attempted export into folder" << curDirName
++            << "which is outside of the extraction root folder" << destDir << "."
++            << "Changing export of contained files to extraction root folder.";
++        curDirName = destDir;
++    }
+     root.mkdir(curDirName);
+ 
+     const QStringList dirEntries = curDir->entries();

--- a/srcpkgs/kdelibs/template
+++ b/srcpkgs/kdelibs/template
@@ -1,7 +1,7 @@
 # Template file for 'kdelibs'
 pkgname=kdelibs
 version=4.14.3
-revision=2
+revision=3
 short_desc="KDE core libraries"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2.0, LGPL-2.1, FDL"


### PR DESCRIPTION
Fix for CVE-2016-6232, taken from the kdelibs4 Debian package, patch originally from upstream (karchive) commit 0cb243f64eef45565741b27364cece7d5c349c37.