### PR TITLE
zerotier-one: update to 1.1.14

### DIFF
--- a/srcpkgs/zerotier-one/template
+++ b/srcpkgs/zerotier-one/template
@@ -1,6 +1,6 @@
 # Template file for 'zerotier'
 pkgname=zerotier-one
-version=1.1.12
+version=1.1.14
 revision=1
 wrksrc=ZeroTierOne-${version}
 build_style=gnu-makefile
@@ -11,17 +11,10 @@ maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
 license="GPL-3"
 homepage="https://www.zerotier.com/"
 distfiles="https://github.com/zerotier/ZeroTierOne/archive/${version}.tar.gz"
-checksum=95258398c81f3515d7bf2a0ba0cce6c10af3dbdde4bbbf6115be6fd9eb325156
-
-pre_build() {
-	sed -i 's:#include <sys/sysctl.h>::' osdep/BSDEthernetTap.cpp \
-		attic/OSXEthernetTap.cpp.pcap-with-bridge-test \
-		ext/libnatpmp/getgateway.c  osdep/ManagedRoute.cpp  \
-		attic/OSXEthernetTap.cpp.utun-work-in-progress osdep/OSXEthernetTap.cpp
-}
+checksum=d206069ad21c665159cdececb0a20a21758849ad73d91234d709962b26f634af
 
 do_build() {
-	make all ZT_\ENABLE_\NETWORK_\CONTROLLER=1
+	make all ZT_ENABLE_NETWORK_CONTROLLER=1
 }
 
 pre_install() {
@@ -31,9 +24,3 @@ pre_install() {
 post_install() {
 	vsv zerotier
 }
-
-# REMARKS:
-# Variable has backslashes in do_build. Upstream does it this way, don't know why.
-# pre_build() fixes PRed by the-maldridge to upstream. Shouldn't be necessary
-# after next release.
-# One release later, upstream has not merged or commented on the PR.


### PR DESCRIPTION
Remove obsolete sed and remove backslashes which were confirmed by upstream to be a formatting glitch in the readme.