### PR TITLE
google-chrome: add update check

### DIFF
--- a/srcpkgs/google-chrome/update
+++ b/srcpkgs/google-chrome/update
@@ -1,0 +1,3 @@
+# This is the only site I've reliably found the version number on
+site=https://www.whatismybrowser.com/guides/the-latest-version/chrome
+pattern="\K\d+\.\d+\.\d+\.\d+(?=<\/h2>)"


### PR DESCRIPTION
Add an update check for google-chrome.  The whatismybrowser site is the only site I've found that reliably updates the google chrome number and has it in a machine parseable format.