### PR TITLE
google-chrome: move icons to upstream location

### DIFF
--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -5,7 +5,7 @@ _channel=stable
 
 pkgname=google-chrome
 version=${_chromeVersion}.${_chromeRevision}
-revision=2
+revision=3
 maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
 homepage="http://www.google.com/chrome/"
 license="chrome"
@@ -35,11 +35,11 @@ do_install() {
 	# Install the icons
 	for size in 16 22 24 32 48 64 128 256; do
 		# Create the google chrome xdg directory
-		mkdir -p ${DESTDIR}/usr/share/icons/google/${size}x${size}/apps
+		mkdir -p ${DESTDIR}/usr/share/icons/hicolor/${size}x${size}/apps
 
 		# Copy the google chrome icon
 		mv ${DESTDIR}/opt/google/chrome/product_logo_${size}.png \
-		   ${DESTDIR}/usr/share/icons/google/${size}x${size}/apps/google-chrome.png
+		   ${DESTDIR}/usr/share/icons/hicolor/${size}x${size}/apps/google-chrome.png
 	done
 
 	# Remove unused icons


### PR DESCRIPTION
This fixes the issue where certain window managers, most notably cinnamon and xfce wouldn't reliably locate the Google Chrome icon.  The icons now reside in the location as suggested by upstream.