### PR TITLE
wine-gecko: update to 2.47

### DIFF
--- a/srcpkgs/wine-gecko/template
+++ b/srcpkgs/wine-gecko/template
@@ -1,14 +1,14 @@
 # Template file for 'wine-gecko'
 pkgname=wine-gecko
-version=2.40
+version=2.47
 revision=1
 noarch=yes
 build_style=fetch
-checksum=1a29d17435a52b7663cea6f30a0771f74097962b07031947719bb7b46057d302
-distfiles="${SOURCEFORGE_SITE}/wine/wine_gecko-${version}-x86.msi"
+checksum=3b8a361f5d63952d21caafd74e849a774994822fb96c5922b01d554f1677643a
+distfiles="http://dl.winehq.org/wine/${pkgname}/${version}/wine_gecko-${version}-x86.msi"
 homepage="http://wiki.winehq.org/Gecko"
 license="MPL-2"
-short_desc="Mozilla Gecko Layout Engine for WINE to replace Internet Explorer (32bit)"
+short_desc="Mozilla Gecko Layout Engine for WINE (32bit)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 
 do_install() {


### PR DESCRIPTION
The current version of wine in void linux needs this newer version of wine-gecko.
The installer was not available on sourceforge, so I switched to downloading from the wine download site.
