### PR TITLE
virtualbox-ose: update to 5.1.4

### DIFF
--- a/srcpkgs/virtualbox-ose/patches/005-gsoap-build.patch
+++ b/srcpkgs/virtualbox-ose/patches/005-gsoap-build.patch
@@ -1,11 +1,11 @@
---- src/VBox/Main/webservice/Makefile.kmk	2013-11-21 19:00:46.812761628 +0100
-+++ src/VBox/Main/webservice/Makefile.kmk	2014-01-04 04:37:05.803599026 +0100
-@@ -683,7 +683,7 @@
- : $(VBOXWEB_GSOAPH_FROM_GSOAP) $(VBOXWEB_GSOAPH_FROM_XSLT) $(VBOX_NSMAP) $(RECOMPILE_ON_MAKEFILE_CURRENT) | $$(dir $$@)
+--- src/VBox/Main/webservice/Makefile.kmk	2016-08-16 22:00:21.000000000 +0200
++++ src/VBox/Main/webservice/Makefile.kmk	2016-08-18 10:05:45.548857031 +0200
+@@ -724,7 +724,7 @@
+ 		$(RECOMPILE_ON_MAKEFILE_CURRENT) | $$(dir $$@)
  	$(call MSG_GENERATE,,lots of files,$(GSOAPH_RELEVANT))
  	$(RM) -f $@
 -	$(REDIRECT) -C $(VBOXWEB_OUT_DIR) -- $(VBOX_SOAPCPP2) $(VBOXWEB_SOAPCPP2_SKIP_FILES) -L -2 -w -I$(VBOX_PATH_GSOAP_IMPORT) $(GSOAPH_RELEVANT)
 +	$(REDIRECT) -C $(VBOXWEB_OUT_DIR) -- $(VBOX_SOAPCPP2) $(VBOXWEB_SOAPCPP2_SKIP_FILES) -z1 -L -2 -w -I$(VBOX_PATH_GSOAP_IMPORT) $(GSOAPH_RELEVANT)
- 	$(APPEND) $@ done
- 
- # copy the generated headers and stuff. This has to be a separate rule if we
+ ifeq ($(KBUILD_TARGET),win) # MSC -Wall workaround.
+ 	$(CP) -f "$(VBOXWEB_SOAP_CLIENT_H)" "$(VBOXWEB_SOAP_CLIENT_H).tmp"
+ 	$(SED) -f $(VBOX_PATH_WEBSERVICE)/stdsoap2.sed --output "$(VBOXWEB_SOAP_CLIENT_H)" "$(VBOXWEB_SOAP_CLIENT_H).tmp"

--- a/srcpkgs/virtualbox-ose/template
+++ b/srcpkgs/virtualbox-ose/template
@@ -1,6 +1,6 @@
 # Template file for 'virtualbox-ose'
 pkgname=virtualbox-ose
-version=5.1.2
+version=5.1.4
 revision=1
 wrksrc="VirtualBox-${version}"
 short_desc="General-purpose full virtualizer for x86 hardware"
@@ -8,7 +8,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://virtualbox.org"
 license="GPL-2, CDDL"
 distfiles="http://download.virtualbox.org/virtualbox/$version/VirtualBox-$version.tar.bz2"
-checksum=03c92e3000d4b905d5b18a6abed757998125a37e5efa7864e62eae2baeabe010
+checksum=b9a14a7771059c55c44b97f8d4eef9bea84544f3e215e0caa563bc35e2f16aaf
 
 nopie=yes
 lib32disabled=yes


### PR DESCRIPTION
This one does not work for me with the brand new linux kernel 4.7.1.
After building the modules and when trying to load the `vboxdrv` module I see this in `dmesg` output:
```
[   79.279972] vboxdrv: Unknown symbol mod_timer_pinned (err 0)
[   79.280032] vboxdrv: Unknown symbol __get_vm_area (err 0)
[   79.280066] vboxdrv: Unknown symbol set_pages_nx (err 0)
[   79.280099] vboxdrv: Unknown symbol smp_call_function (err 0)
[   79.280157] vboxdrv: Unknown symbol map_vm_area (err 0)
[   79.280202] vboxdrv: Unknown symbol set_pages_x (err 0)
```
So either the kernel is too new for vbox, or we do not have set some config options which are required.

Do not merge until this is solved.