### PR TITLE
Add fish's dependency "bc"

### DIFF
--- a/srcpkgs/fish-shell/template
+++ b/srcpkgs/fish-shell/template
@@ -1,10 +1,11 @@
 # Template file for 'fish-shell'
 pkgname=fish-shell
 version=2.3.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake libtool"
 makedepends="ncurses-devel"
+depends="bc"
 register_shell="/usr/bin/fish"
 conf_files="/etc/fish/config.fish"
 wrksrc="fish-${version}"


### PR DESCRIPTION
fish depends on bc for the shipped autocompletion files. See https://github.com/fish-shell/fish-shell/blob/master/fish.spec.in#L16

Without bc, typing `sudo x` and hitting tab to autocomplete from the fish-shell with throw an error from the completion file stating "command bc not found". Manually installing bc fixes this - but it should be a package dependency :)