### PR TITLE
netdata: update to 1.3.0

### DIFF
--- a/srcpkgs/netdata-plugins-nodejs
+++ b/srcpkgs/netdata-plugins-nodejs
@@ -1,0 +1,1 @@
+netdata

--- a/srcpkgs/netdata-plugins-python
+++ b/srcpkgs/netdata-plugins-python
@@ -1,0 +1,1 @@
+netdata

--- a/srcpkgs/netdata/INSTALL
+++ b/srcpkgs/netdata/INSTALL
@@ -1,7 +1,9 @@
 case ${ACTION} in
-    post)
-	chown -R _netdata:_netdata usr/share/netdata/webroot
-	chown root:_netdata usr/libexec/netdata/plugins.d/apps.plugin
-	chmod 4750 usr/libexec/netdata/plugins.d/apps.plugin
-	;;
+	post)
+		chown _netdata:root var/lib/netdata/registry/
+		chown -R _netdata:_netdata usr/share/netdata/web
+		chown root usr/libexec/netdata/plugins.d/apps.plugin
+		chmod 0755 usr/libexec/netdata/plugins.d/apps.plugin
+		setcap cap_dac_read_search,cap_sys_ptrace+ep usr/libexec/netdata/plugins.d/apps.plugin
+		;;
 esac

--- a/srcpkgs/netdata/files/netdata/run
+++ b/srcpkgs/netdata/files/netdata/run
@@ -5,4 +5,4 @@ for f in cache log; do
 	chown -R _netdata:_netdata /var/${f}/netdata
 done
 
-exec netdata -u _netdata -nd
+exec netdata -u _netdata -D

--- a/srcpkgs/netdata/patches/crosstime.patch
+++ b/srcpkgs/netdata/patches/crosstime.patch
@@ -1,9 +1,0 @@
---- src/log.h.orig	2016-04-24 21:25:30.134626548 -0500
-+++ src/log.h	2016-04-24 21:26:22.579967475 -0500
-@@ -1,5 +1,6 @@
- #include <stdio.h>
- #include <stdarg.h>
-+#include <time.h>
- 
- #ifndef NETDATA_LOG_H
- #define NETDATA_LOG_H 1

--- a/srcpkgs/netdata/template
+++ b/srcpkgs/netdata/template
@@ -1,20 +1,40 @@
 # Template file for 'netdata'
 pkgname=netdata
-version=1.1.0
-revision=3
+version=1.3.0
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="zlib-devel"
 system_accounts="_netdata"
 conf_files="/etc/${pkgname}/*.conf"
-configure_args="--with-user=_netdata --with-webdir=/usr/share/${pkgname}/webroot"
+configure_args="--with-user=_netdata"
+makedepends="libuuid-devel zlib-devel"
 short_desc="Real-time performance monitoring, done right"
 maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
 license="GPL-3"
 homepage="http://netdata.firehol.org/"
 distfiles="http://firehol.org/download/netdata/releases/v${version}/${pkgname}-${version}.tar.gz"
-checksum=b1967cf2a9f2ddc5798c0576eb6861d3e5bac0665b50077ce784b671c1e55180
+checksum=696772c5761354d3ff395c1fcf5eb17eab83937a959e3ebf945288ca8b6d0ed5
 
 post_install() {
 	vsv netdata
+}
+
+netdata-plugins-nodejs_package() {
+	short_desc+=" - NodeJS Plugins"
+	depends="${sourcepkg}>=${version}_${revision} nodejs"
+	pkg_install() {
+		vmove usr/libexec/netdata/plugins.d/node.d.plugin
+		vmove usr/libexec/netdata/node.d
+	}
+}
+
+netdata-plugins-python_package() {
+	short_desc+=" - Python Plugins"
+	depends="${sourcepkg}>=${version}_${revision} python"
+	pkg_install() {
+		vmove usr/libexec/netdata/plugins.d/python.d.plugin
+		vmove usr/libexec/netdata/python.d
+		vmove etc/netdata/python.d
+	}
 }


### PR DESCRIPTION
Technically this also depends on python now, but only for additional plugins.  Given that the core system still works without it I have not added python as a hard depends relation to this package.