### PR TITLE
glib: fix on demand init for gquark and gtype

### DIFF
--- a/srcpkgs/NetworkManager/template
+++ b/srcpkgs/NetworkManager/template
@@ -1,7 +1,7 @@
 # Template file for 'NetworkManager'
 pkgname=NetworkManager
 version=1.0.12
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--without-dhcpcd --with-dhclient=/usr/bin/dhclient
  --with-system-ca-path=/etc/ssl/certs --enable-more-warnings=no
@@ -42,16 +42,9 @@ make_dirs="
 
 # Package build options
 build_options="gir"
-case "$XBPS_TARGET_MACHINE" in
-	*-musl) # Disable gir for musl (broken on x86_64-musl)
-		# See: https://build.voidlinux.eu/builders/x86_64-musl_builder/builds/12337/steps/shell_3/logs/stdio
-		;;
-	*)	# Enable gir for non-cross builds
-		if [ -z "$CROSS_BUILD" ]; then
-			build_options_default+=" gir"
-		fi
-		;;
-esac
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gir"
+fi
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh

--- a/srcpkgs/glib/patches/gobject_init_on_demand.patch
+++ b/srcpkgs/glib/patches/gobject_init_on_demand.patch
@@ -1,0 +1,91 @@
+Initialize the gobject system on demand, i.e. before it is
+expected to be initialized. Do this only once by checking
+a local static variable gobject_initialized.
+
+--- gobject/gtype.c	2016-08-17 17:20:47.000000000 +0200
++++ gobject/gtype.c	2016-09-01 21:56:31.777406646 +0200
+@@ -209,6 +209,9 @@
+ static gboolean				type_node_is_a_L		(TypeNode		*node,
+ 									 TypeNode		*iface_node);
+ 
++#if !defined(__GLIBC__)
++static void gobject_init (void);
++#endif
+ 
+ /* --- enumeration --- */
+ 
+@@ -2631,7 +2634,10 @@
+ 			     GTypeFlags			 flags)
+ {
+   TypeNode *node;
+-  
++ 
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+   g_return_val_if_fail (type_id > 0, 0);
+   g_return_val_if_fail (type_name != NULL, 0);
+@@ -2749,6 +2755,9 @@
+   TypeNode *pnode, *node;
+   GType type = 0;
+   
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+   g_return_val_if_fail (parent_type > 0, 0);
+   g_return_val_if_fail (type_name != NULL, 0);
+@@ -2804,6 +2813,9 @@
+   TypeNode *pnode, *node;
+   GType type;
+   
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+   g_return_val_if_fail (parent_type > 0, 0);
+   g_return_val_if_fail (type_name != NULL, 0);
+@@ -3319,6 +3331,9 @@
+ {
+   TypeNode *node;
+   
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+   
+   node = lookup_type_node_I (type);
+@@ -4343,6 +4358,9 @@
+ void
+ g_type_init_with_debug_flags (GTypeDebugFlags debug_flags)
+ {
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+ 
+   if (debug_flags)
+@@ -4361,6 +4379,9 @@
+ void
+ g_type_init (void)
+ {
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+ }
+ 
+@@ -4372,6 +4393,12 @@
+   TypeNode *node;
+   GType type;
+ 
++#if !defined(__GLIBC__)
++  static int gobject_initialized = 0;
++  if (gobject_initialized)
++    return;
++  gobject_initialized = 1;
++#endif
+   /* Ensure GLib is initialized first, see
+    * https://bugzilla.gnome.org/show_bug.cgi?id=756139
+    */

--- a/srcpkgs/glib/patches/quark_init_on_demand.patch
+++ b/srcpkgs/glib/patches/quark_init_on_demand.patch
@@ -1,99 +1,77 @@
-Reverting commit https://github.com/GNOME/glib/commit/2fe992b099bfd3fb121a71b7af43e116b2142b5d
-
-musl's does not run ctors in the assumed order that glib-2.46 expects:
-
-- glib_init() should be called before gobject_init_ctor().
+musl does not run ctors in the assumed order that glib-2.46 expects.
+Call g_quark_init() where it is expected to have been called.
 
 
-diff --git glib/glib-init.c glib/glib-init.c
-index e7002e6..24efe9d 100644
---- glib/glib-init.c
-+++ glib/glib-init.c
-@@ -233,7 +233,6 @@ glib_init (void)
+--- glib/gquark.c	2016-08-17 17:20:47.000000000 +0200
++++ glib/gquark.c	2016-08-30 07:49:13.298234757 +0200
+@@ -57,6 +57,9 @@
+ void
+ g_quark_init (void)
  {
-   g_messages_prefixed_init ();
-   g_debug_init ();
--  g_quark_init ();
- }
- 
- #if defined (G_OS_WIN32)
-diff --git glib/glib-init.h glib/glib-init.h
-index b56f7e2..de6be78 100644
---- glib/glib-init.h
-+++ glib/glib-init.h
-@@ -25,8 +25,6 @@
- extern GLogLevelFlags g_log_always_fatal;
- extern GLogLevelFlags g_log_msg_prefix;
- 
- void glib_init (void);
--void g_quark_init (void);
--
- #ifdef G_OS_WIN32
- #include <windows.h>
- 
-diff --git glib/gquark.c glib/gquark.c
-index 9e51a92..d620533 100644
---- glib/gquark.c
-+++ glib/gquark.c
-@@ -40,7 +40,6 @@
- #include "gthread.h"
- #include "gtestutils.h"
- #include "glib_trace.h"
--#include "glib-init.h"
- 
- #define QUARK_BLOCK_SIZE         2048
- #define QUARK_STRING_BLOCK_SIZE (4096 - sizeof (gsize))
-@@ -54,16 +53,6 @@ static gint           quark_seq_id = 0;
- static gchar         *quark_block = NULL;
- static gint           quark_block_offset = 0;
- 
--void
--g_quark_init (void)
--{
--  g_assert (quark_seq_id == 0);
--  quark_ht = g_hash_table_new (g_str_hash, g_str_equal);
--  quarks = g_new (gchar*, QUARK_BLOCK_SIZE);
--  quarks[0] = NULL;
--  quark_seq_id = 1;
--}
--
- /**
-  * SECTION:quarks
-  * @title: Quarks
-@@ -138,9 +127,10 @@ g_quark_try_string (const gchar *string)
++  if (quark_ht)
++    return;
++
+   g_assert (quark_seq_id == 0);
+   quark_ht = g_hash_table_new (g_str_hash, g_str_equal);
+   quarks = g_new (gchar*, QUARK_BLOCK_SIZE);
+@@ -138,9 +141,12 @@
      return 0;
  
    G_LOCK (quark_global);
--  quark = GPOINTER_TO_UINT (g_hash_table_lookup (quark_ht, string));
-+  if (quark_ht)
-+    quark = GPOINTER_TO_UINT (g_hash_table_lookup (quark_ht, string));
++#if !defined(__GLIBC__)
++  g_quark_init ();
++#endif
+   quark = GPOINTER_TO_UINT (g_hash_table_lookup (quark_ht, string));
    G_UNLOCK (quark_global);
--
-+  
+
    return quark;
  }
  
-@@ -179,7 +169,8 @@ quark_from_string (const gchar *string,
- {
-   GQuark quark = 0;
+@@ -209,6 +213,9 @@
+     return 0;
  
--  quark = GPOINTER_TO_UINT (g_hash_table_lookup (quark_ht, string));
-+  if (quark_ht)
-+    quark = GPOINTER_TO_UINT (g_hash_table_lookup (quark_ht, string));
+   G_LOCK (quark_global);
++#if !defined(__GLIBC__)
++  g_quark_init ();
++#endif
+   quark = quark_from_string (string, TRUE);
+   G_UNLOCK (quark_global);
  
-   if (!quark)
+@@ -243,6 +248,9 @@
+     return 0;
+ 
+   G_LOCK (quark_global);
++#if !defined(__GLIBC__)
++  g_quark_init ();
++#endif
+   quark = quark_from_string (string, FALSE);
+   G_UNLOCK (quark_global);
+ 
+@@ -280,6 +286,7 @@
+   GQuark quark;
+   gchar **quarks_new;
+ 
++  g_quark_init ();
+   if (quark_seq_id % QUARK_BLOCK_SIZE == 0)
      {
-@@ -292,6 +283,13 @@ quark_new (gchar *string)
-        */
-       g_atomic_pointer_set (&quarks, quarks_new);
-     }
-+  if (!quark_ht)
-+    {
-+      g_assert (quark_seq_id == 0);
-+      quark_ht = g_hash_table_new (g_str_hash, g_str_equal);
-+      quarks[quark_seq_id] = NULL;
-+      g_atomic_int_inc (&quark_seq_id);
-+    }
+       quarks_new = g_new (gchar*, quark_seq_id + QUARK_BLOCK_SIZE);
+@@ -323,6 +330,9 @@
+     return NULL;
  
-   quark = quark_seq_id;
-   g_atomic_pointer_set (&quarks[quark], string);
+   G_LOCK (quark_global);
++#if !defined(__GLIBC__)
++  g_quark_init ();
++#endif
+   quark = quark_from_string (string, TRUE);
+   result = quarks[quark];
+   G_UNLOCK (quark_global);
+@@ -353,6 +361,9 @@
+     return NULL;
+ 
+   G_LOCK (quark_global);
++#if !defined(__GLIBC__)
++  g_quark_init ();
++#endif
+   quark = quark_from_string (string, FALSE);
+   result = quarks[quark];
+   G_UNLOCK (quark_global);

--- a/srcpkgs/glib/template
+++ b/srcpkgs/glib/template
@@ -1,7 +1,7 @@
 # Template build file for 'glib'
 pkgname=glib
 version=2.48.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-libelf --disable-fam --with-pcre=system --enable-static"
 hostmakedepends="automake libtool pkg-config perl python libxslt docbook-xsl"

--- a/srcpkgs/gobject-introspection/template
+++ b/srcpkgs/gobject-introspection/template
@@ -1,7 +1,7 @@
 # Template file for 'gobject-introspection'
 pkgname=gobject-introspection
 version=1.46.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-tests --disable-static"
 hostmakedepends="pkg-config flex libtool"


### PR DESCRIPTION
Besides the quark init on demand, a similar thing is required for `gobject_init()` in `gobject/gtype.c` for the commands like `g-ir-scan` etc. to work right with musl libc.

This fixes NetworkManager `build_option="gir"` for musl libc.
