### PR TITLE
jbigkit: create shared library + splix: fix PIE

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2617,3 +2617,5 @@ libcourier-unicode.so.3 courier-unicode-1.4_1
 libzstd.so.1 zstd-1.0.0_1
 libudis86.so.0 udis86-devel-1.7.2_3
 libsass.so.0 libsass-3.3.6_1
+libjbig.so.0 jbigkit-libs-2.1_2
+libjbig85.so.0 jbigkit-libs-2.1_2

--- a/srcpkgs/jbigkit-libs
+++ b/srcpkgs/jbigkit-libs
@@ -1,0 +1,1 @@
+jbigkit

--- a/srcpkgs/jbigkit/template
+++ b/srcpkgs/jbigkit/template
@@ -1,37 +1,42 @@
 # Template file for 'jbigkit'
 pkgname=jbigkit
 version=2.1
-revision=1
-build_style=gnu-makefile
+revision=2
+wrksrc="${pkgname}-shared-${version}"
+build_style=gnu-configure
+hostmakedepends="automake libtool"
 short_desc="Data compression library/utilities for bi-level high-resolution images"
 maintainer="Andrea Brancaleoni <miwaxe@gmail.com>"
 license="GPL-3"
 homepage="http://www.cl.cam.ac.uk/~mgk25/jbigkit"
-distfiles="http://www.cl.cam.ac.uk/~mgk25/download/jbigkit-$version.tar.gz"
-checksum=de7106b6bfaf495d6865c7dd7ac6ca1381bd12e0d81405ea81e7f2167263d932
+distfiles="https://github.com/voidlinux/jbigkit-shared/archive/v${version}.tar.gz"
+checksum=bce256a39735145ecfc10d3e446e0b55fed1f7c80cffb6e2601a9090faae92e6
+disable_parallel_build=yes
 
-do_build() {
-	make CC=$CC CFLAGS="${CFLAGS} -I${wrksrc}/libjbig ${LDFLAGS}" ${makejobs}
+pre_configure() {
+	./bootstrap.sh
 }
-do_install() {
-	# Install pbm tools
-	for tool in $(find pbmtools/ -executable -type f); do
-		vbin $tool
-	done
-	# Install man pages
-	for manp in pbmtools/*.{1,5}; do
-		vman $manp
-	done
+
+post_install() {
+	vinstall jbigkit.pc 644 usr/lib/pkgconfig
+	vinstall jbigkit85.pc 644 usr/lib/pkgconfig
+	rm -vf ${DESTDIR}/usr/lib/*.la
+}
+
+jbigkit-libs_package() {
+	short_desc+=" - shared libraries"
+	pkg_install() {
+		vmove usr/lib/*.so.*
+	}
 }
 
 jbigkit-devel_package() {
 	short_desc+=" - development files"
+	depends="${sourcepkg}-libs>=${version}_${revision}"
 	pkg_install() {
-		for lib in libjbig/*.a; do
-			vinstall $lib 644 usr/lib
-		done
-		for header in libjbig/*.h; do
-			vinstall $header 644 usr/include
-		done
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove usr/lib/*.so
+		vmove usr/lib/*.a
 	}
 }

--- a/srcpkgs/splix/template
+++ b/srcpkgs/splix/template
@@ -1,7 +1,7 @@
 # Template file for 'splix-svn'
 pkgname=splix
 version=2.0.0+svn315
-revision=2
+revision=3
 wrksrc="$pkgname-$version.orig"
 build_style=gnu-makefile
 makedepends="cups-devel mit-krb5-devel jbigkit-devel"
@@ -14,6 +14,8 @@ checksum="578a81bd5b1b97756a539c3bb6339fd109d54419887a73e705941da8aa7fac52"
 CXXFLAGS=" -fno-strict-aliasing"
 
 do_build() {
+	sed -i rules.mk \
+		-e's;$(CXX) -o;$(CXX) $(LDFLAGS) -o;'
 	make CC="$CC" CXX="$CXX" LD="$LD" AR="$AR" RANLIB="$RANLIB" \
 		CPP="$CPP" AS="$AS" OBJDUMP="$OBJDUMP" STRIP="true" drv
 	make CC="$CC" CXX="$CXX" LD="$LD" AR="$AR" RANLIB="$RANLIB" \


### PR DESCRIPTION
Created a "fork" of jbigkit-2.1 at github which uses autotools
and libtool to create both, shared and static libraries.

Parallel building fails because test programs which depend on the
libraries are built before these (not yet installed) libs.
Therefore disable_parallel_build=yes