### PR TITLE
firefox: enable gtk3 again

### DIFF
--- a/srcpkgs/firefox/template
+++ b/srcpkgs/firefox/template
@@ -1,7 +1,7 @@
 # Template build file for 'firefox'.
 pkgname=firefox
 version=48.0.2
-revision=1
+revision=2
 short_desc="Lightweight gecko-based web browser"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="https://www.mozilla.org/firefox/"
@@ -29,8 +29,9 @@ makedepends="
 depends="nss>=3.21 desktop-file-utils hicolor-icon-theme"
 conflicts="firefox-esr>=0"
 
+build_options_default="gtk3"
 case "$XBPS_TARGET_MACHINE" in
-	x86_64*) build_options_default="rust" ;;
+	x86_64*) build_options_default+=" rust" ;;
 esac
 
 post_extract() {


### PR DESCRIPTION
The rendering bugs we had with gtk3 seem to be fixed.