### PR TITLE
vivaldi: enable start from menu, show menu icon

### DIFF
--- a/srcpkgs/vivaldi/template
+++ b/srcpkgs/vivaldi/template
@@ -1,7 +1,7 @@
 # Template file for 'vivaldi'
 pkgname=vivaldi
 version=1.4.589.11
-revision=1
+revision=2
 _release=1
 only_for_archs="i686 x86_64"
 short_desc="An advanced browser made with the power user in mind"
@@ -31,7 +31,8 @@ do_install() {
 	vcopy opt/ /opt
 	vcopy usr /
 	for res in 24 48 64; do
-		vinstall opt/vivaldi/product_logo_${res}.png 0644\
-		/usr/share/icons/hicolor/${res}x${res}/apps/vivaldi.png
+		vinstall opt/vivaldi/product_logo_${res}.png 0644 \
+		/usr/share/icons/hicolor/${res}x${res}/apps vivaldi.png
 	done
+	ln -sf /opt/vivaldi/vivaldi ${DESTDIR}/usr/bin/vivaldi-stable
 }


### PR DESCRIPTION
Resolves vivaldi no start error ``"/usr/bin/vivaldi-stable" (No such file or directory)`` when clicking on vivaldi shortcut in menu. 
Fix syntax error to correct path/name of vivaldi.png so icon appears in menu. 