### PR TITLE
opam: unbreak build process and add unzip to dependencies

### DIFF
--- a/srcpkgs/opam/patches/fix_url.patch
+++ b/srcpkgs/opam/patches/fix_url.patch
@@ -1,0 +1,11 @@
+--- src_ext/Makefile.orig	2015-04-27 09:46:51.000000000 +0200
++++ src_ext/Makefile	2016-09-15 05:38:45.453896142 +0200
+@@ -2,7 +2,7 @@
+ 
+ SRC_EXTS = extlib re cmdliner graph cudf dose uutf jsonm
+ 
+-URL_extlib = http://ocaml-extlib.googlecode.com/files/extlib-1.5.3.tar.gz
++URL_extlib = http://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ocaml-extlib/extlib-1.5.3.tar.gz
+ MD5_extlib = 3de5f4e0a95fda7b2f3819c4a655b17c
+ 
+ URL_re = https://github.com/ocaml/ocaml-re/archive/ocaml-re-1.2.0.tar.gz

--- a/srcpkgs/opam/template
+++ b/srcpkgs/opam/template
@@ -1,12 +1,12 @@
 # Template file for 'opam'
 pkgname=opam
 version=1.2.2
-revision=3
+revision=4
 build_style=gnu-configure
 disable_parallel_build=yes
 make_build_args="lib-ext all"
 makedepends="ncurses-devel ocaml curl"
-depends="curl patch"
+depends="curl patch unzip"
 short_desc="OCaml package manager"
 maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
 license="LGPL-3"


### PR DESCRIPTION
In opam-1.2.2 there is a broken url in a Makefile, breaking the build process.
This gets fixed in post_extract.

Also, opam depends on unzip, so it is added as a dependency.