### PR TITLE
New package: qt-webkit-2.3.4

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -455,7 +455,7 @@ libQtSql.so.4 qt-4.5.3_1
 libQtDeclarative.so.4 qt-4.5.3_1
 libQtDesignerComponents.so.4 qt-designer-4.5.3_1
 libQtDesigner.so.4 qt-designer-4.5.3_1
-libQtWebKit.so.4 qt-4.8.4_4
+libQtWebKit.so.4 qt-webkit-2.3.4_1
 libsysfs.so.2 libsysfs-2.1.0_1
 libsensors.so.4 libsensors-3.1.1_1
 libcap-ng.so.0 libcap-ng-0.6.2_1

--- a/srcpkgs/calligra/template
+++ b/srcpkgs/calligra/template
@@ -1,19 +1,20 @@
 # Template file for 'calligra'
 pkgname=calligra
 version=2.9.11
-revision=2
+revision=3
 build_style=cmake
 configure_args="-Wno-dev -DBUILD_active=OFF -DWITH_Soprano=OFF"
 hostmakedepends="cmake automoc4 perl pkg-config eigen"
 short_desc="Illustration application"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 makedepends="vc phonon-devel libpng-devel sqlite-devel boost-devel exiv2-devel
- qt-devel kdelibs-devel libressl-devel lcms2-devel libwpd-devel libwpg-devel
- libwps-devel libodfgen-devel libvisio-devel libetonyek-devel fontconfig-devel
- libXi-devel poppler-qt4-devel libgomp-devel glew-devel opencolorio-devel
- fftw-devel libopenexr-devel libopenjpeg-devel gsl-devel libcurl-devel
- libkdcraw-devel libokular-devel qca-devel kactivities-devel kdepimlibs-devel
- marble-devel libmysqlclient-devel postgresql-libs-devel freetds-devel"
+ qt-devel qt-webkit-devel kdelibs-devel libressl-devel lcms2-devel libwpd-devel
+ libwpg-devel libwps-devel libodfgen-devel libvisio-devel libetonyek-devel
+ fontconfig-devel libXi-devel poppler-qt4-devel libgomp-devel glew-devel
+ opencolorio-devel fftw-devel libopenexr-devel libopenjpeg-devel gsl-devel
+ libcurl-devel libkdcraw-devel libokular-devel qca-devel kactivities-devel
+ kdepimlibs-devel marble-devel libmysqlclient-devel postgresql-libs-devel
+ freetds-devel"
 license="GPL-2"
 homepage="http://www.calligra-suite.org/"
 distfiles="http://download.kde.org/stable/${pkgname}-${version}/${pkgname}-${version}.tar.xz"

--- a/srcpkgs/clementine/template
+++ b/srcpkgs/clementine/template
@@ -1,11 +1,11 @@
 # Template file for 'clementine'
 pkgname=clementine
 version=1.3.1
-revision=3
+revision=4
 build_style=cmake
 hostmakedepends="git cmake sparsehash pkg-config"
 makedepends="chromaprint-devel boost-devel gst-plugins-base1-devel liblastfm-devel
- qt-devel glew-devel qjson-devel sqlite-devel protobuf-devel libplist-devel
+ qt-devel qt-webkit-devel glew-devel qjson-devel sqlite-devel protobuf-devel libplist-devel
  libusbmuxd-devel libmtp-devel libcdio-devel qca-devel pulseaudio-devel glu-devel
  taglib-devel crypto++-devel libspotify-devel libechonest-devel"
 depends="desktop-file-utils"

--- a/srcpkgs/clipgrab/template
+++ b/srcpkgs/clipgrab/template
@@ -1,17 +1,17 @@
 # Template file for 'clipgrab'
 pkgname=clipgrab
 version=3.6.1
-revision=1
+revision=2
 build_style=qmake
 hostmakedepends="qt-qmake"
-makedepends="qt-devel"
+makedepends="qt-devel qt-webkit-devel"
 depends="ffmpeg desktop-file-utils"
 short_desc="A friendly downloader for YouTube and other sites"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-3"
 homepage="https://www.clipgrab.org"
 distfiles="https://download.clipgrab.org/clipgrab-${version}.tar.gz"
-checksum=4cdf3964f8f208866356497d9f5ee5208b5d7902bcd1fe27ba4d79e7d3b2bade
+checksum=a0878b4cda847472b9c37744e9d7de7068176974d0032d45df3391d7ec799666
 configure_args=clipgrab.pro
 
 do_install() {

--- a/srcpkgs/freecad/template
+++ b/srcpkgs/freecad/template
@@ -1,7 +1,7 @@
 # Template file for 'freecad'
 pkgname=freecad
 version=0.16
-revision=1
+revision=2
 wrksrc="FreeCAD-${version}"
 build_style=cmake
 
@@ -17,9 +17,9 @@ configure_args="
 
 hostmakedepends="python swig pkg-config doxygen graphviz"
 
-makedepends="python-devel oce-devel qt-devel coin3-devel eigen libxerces-c-devel
- libspnav-devel libshiboken-python-devel libpyside-python-devel pyside-tools
- python-matplotlib boost-python coin3-doc"
+makedepends="python-devel oce-devel qt-devel qt-webkit-devel coin3-devel eigen
+ libxerces-c-devel libspnav-devel libshiboken-python-devel libpyside-python-devel
+ pyside-tools python-matplotlib boost-python coin3-doc"
 
 # qt-devel-tools, qt-plugin-sqlite: Help uses qt/assistant, its data in SQLite format
 depends="python-matplotlib python-pyside qt-devel-tools qt-plugin-sqlite python-pivy"

--- a/srcpkgs/gpsbabel/template
+++ b/srcpkgs/gpsbabel/template
@@ -1,14 +1,14 @@
 # Template file for 'gpsbabel'
 pkgname=gpsbabel
 version=1.5.3
-revision=2
+revision=3
 build_style=gnu-configure
 maintainer="Philipp Hirsch <itself@hanspolo.net>"
 homepage="http://www.gpsbabel.org/"
 license="GPL-2"
 short_desc="Converts waypoints, tracks, and routes between popular GPS formats"
 hostmakedepends="perl docbook-xml xmlwf openjdk-jre offo-hyphenation"
-makedepends="qt-devel libusb-compat-devel expat-devel libxslt-devel"
+makedepends="qt-devel qt-webkit-devel libusb-compat-devel expat-devel libxslt-devel"
 depends="desktop-file-utils"
 distfiles="http://arch.p5n.pp.ru/~sergej/dl/${pkgname}-${version}.tar.gz"
 checksum=7599beb312488a96d8b8e646c357fbc122970522a7c9ae0a2777862a0ef39351
@@ -16,7 +16,7 @@ create_wrksrc=yes
 
 replaces="gpsbabel-gui>=0"
 
-do_build(){
+do_build() {
 	. /etc/profile.d/10_openjdk.sh
 	make ${makejobs}
 	make doc
@@ -29,7 +29,7 @@ do_build(){
 	make ${makejobs}
 }
 
-do_install(){
+do_install() {
 	make install DESTDIR=${DESTDIR}
 	vmkdir usr/share/doc/${pkgname}
 	vcopy "README* AUTHORS COPYING gpsbabel.pdf gpsbabel-sample.ini guibabel style" usr/share/doc/${pkgname}

--- a/srcpkgs/k3b/template
+++ b/srcpkgs/k3b/template
@@ -2,11 +2,11 @@
 pkgname=k3b
 _realversion=2.0.3
 version=${_realversion}a
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="cmake qt-qmake automoc4 pkg-config"
 makedepends="kde-runtime-devel libcddb-devel libsamplerate-devel libmad-devel
- ffmpeg-devel taglib-devel libmpcdec-devel libdvdread-devel libXft-devel
+ ffmpeg-devel taglib-devel libmpcdec-devel libdvdread-devel libXft-devel qt-webkit-devel
  kdelibs-devel phonon-devel libmusicbrainz5-devel lame-devel libkcddb-devel"
 short_desc="CD/DVD Kreator for Linux"
 maintainer="Enno Boland <gottox@voidlinux.eu>"

--- a/srcpkgs/kde-runtime/template
+++ b/srcpkgs/kde-runtime/template
@@ -1,13 +1,13 @@
 # Template file for 'kde-runtime'
 pkgname=kde-runtime
 version=4.14.3
-revision=4
+revision=5
 build_style=cmake
 configure_args="-Wno-dev -DKDE4_BUILD_TESTS=OFF DWITH_QNtrack=OFF -DWITH_NepomukCore=OFF"
 # XXX OpenSLP
 hostmakedepends="cmake automoc4 pkg-config"
 makedepends="
- boost-devel glib-devel libressl-devel qt-devel phonon-devel strigi-devel
+ boost-devel glib-devel libressl-devel qt-devel qt-webkit-devel phonon-devel strigi-devel
  libXt-devel attica-devel qca-devel liblzma-devel libssh-devel libgcrypt-devel
  libjpeg-turbo-devel libpng-devel exiv2-devel alsa-lib-devel samba-devel
  pulseaudio-devel libwebp-devel libcanberra-devel NetworkManager-devel

--- a/srcpkgs/kde-workspace/template
+++ b/srcpkgs/kde-workspace/template
@@ -4,7 +4,7 @@ _kappversion=15.04.1
 
 pkgname=kde-workspace
 version=4.11.19
-revision=5
+revision=6
 short_desc="Provides the interface and basic tools for the KDE workspace"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2, LGPL-2.1, FDL"
@@ -21,7 +21,7 @@ configure_args="-Wno-dev -DKDE4_BUILD_TESTS=OFF -DSYSCONF_INSTALL_DIR=/etc
 # XXX prison.
 hostmakedepends="cmake automoc4 pkg-config"
 makedepends="libressl-devel qt-devel phonon-devel libdbusmenu-qt-devel strigi-devel
- kdelibs-devel kactivities-devel xcb-util-keysyms-devel
+ qt-webkit-devel kdelibs-devel kactivities-devel xcb-util-keysyms-devel
  qimageblitz-devel xcb-util-image-devel xcb-util-renderutil-devel boost-devel
  libjpeg-turbo-devel libpng-devel libXcursor-devel libXi-devel libxkbfile-devel
  libXrandr-devel libXfixes-devel libSM-devel libXcomposite-devel libXdamage-devel

--- a/srcpkgs/kdelibs/template
+++ b/srcpkgs/kdelibs/template
@@ -1,7 +1,7 @@
 # Template file for 'kdelibs'
 pkgname=kdelibs
 version=4.14.3
-revision=3
+revision=4
 short_desc="KDE core libraries"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2.0, LGPL-2.1, FDL"
@@ -21,7 +21,7 @@ makedepends="libressl-devel libSM-devel libXext-devel libXScrnSaver-devel
  libpng-devel giflib-devel acl-devel enchant-devel jasper-devel
  liblzma-devel mit-krb5-devel avahi-libs-devel eudev-libudev-devel libxslt-devel
  polkit-qt-devel libdbusmenu-qt-devel attica-devel grantlee-devel qca-devel
- libutempter-devel MesaLib-devel udisks2-devel
+ qt-webkit-devel libutempter-devel MesaLib-devel udisks2-devel
  libopenexr-devel media-player-info shared-mime-info shared-desktop-ontologies"
 depends="docbook-xsl media-player-info shared-mime-info
  shared-desktop-ontologies hicolor-icon-theme ca-certificates"

--- a/srcpkgs/kdepim/template
+++ b/srcpkgs/kdepim/template
@@ -1,21 +1,21 @@
 # Template file for 'kdepim'
 pkgname=kdepim
 version=4.14.3
-revision=1
+revision=2
 build_style=cmake
 configure_args="-Wno-dev -DKDE4_BUILD_TESTS=OFF"
 # XXX dblatex, prison
 hostmakedepends="cmake automoc4 pkg-config"
 makedepends="
- zlib-devel libressl-devel qt-devel phonon-devel kdelibs-devel
- kdepimlibs-devel akonadi-devel grantlee-devel libkgapi-devel
+ zlib-devel libressl-devel qt-devel qt-webkit-devel phonon-devel
+ kdelibs-devel kdepimlibs-devel akonadi-devel grantlee-devel libkgapi-devel
  libsasl-devel libassuan-devel gpgme-devel boost-devel MesaLib-devel
  kdepim-runtime qjson-devel kactivities-devel
  kfilemetadata-devel baloo-devel"
 depends="kdepim-runtime>=${version}"
 short_desc="KDE PIM"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL, LGPL, FDL"
+license="GPL-2, LGPL-2.1, FDL"
 homepage="https://projects.kde.org/projects/kde/kdepimlibs"
 distfiles="http://download.kde.org/stable/${version}/src/${pkgname}-${version}.tar.xz"
 checksum=a3fd17fa2f3b1debc32bd28537402aaf7337582ff2fe39dbadd47d5b3232f944

--- a/srcpkgs/kdeplasma-addons/template
+++ b/srcpkgs/kdeplasma-addons/template
@@ -1,19 +1,19 @@
 # Template file for 'kdeplasma-addons'
 pkgname=kdeplasma-addons
 version=4.14.3
-revision=1
+revision=2
 build_style=cmake
 configure_args="-Wno-dev -DKDE4_BUILD_TESTS=OFF -DSYSCONF_INSTALL_DIR=/etc -DWITH_Nepomuk=OFF"
 # XXX scim, marble.
 hostmakedepends="cmake automoc4 pkg-config"
-makedepends="libressl-devel qt-devel phonon-devel strigi-devel qoauth-devel
- kdelibs-devel kdepimlibs-devel
+makedepends="libressl-devel qt-devel qt-webkit-devel phonon-devel
+ strigi-devel qoauth-devel kdelibs-devel kdepimlibs-devel
  kde-workspace-devel libkexiv2-devel libdbusmenu-qt-devel
  libXtst-devel attica-devel libXrender-devel eigen2 glib-devel ibus-devel
  qimageblitz-devel boost-devel qjson-devel MesaLib-devel marble-devel"
 short_desc="KDE Plasma Add-ons"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL, LGPL, FDL"
+license="GPL-2, LGPL-2.1, FDL"
 homepage="http://www.kde.org"
 distfiles="http://download.kde.org/stable/${version}/src/${pkgname}-${version}.tar.xz"
 checksum=12d58e30362729473db208c0650676dac0fdae8b3f223ce92e8df41e3e928f24

--- a/srcpkgs/kdevelop/template
+++ b/srcpkgs/kdevelop/template
@@ -1,14 +1,14 @@
 # Template file for 'kdevelop'
 pkgname=kdevelop
 version=4.7.3
-revision=1
+revision=2
 
 build_style=cmake
 configure_args="-Wno-dev"
 
 hostmakedepends="qt-qmake automoc4 perl"
-makedepends="kdelibs-devel qt-devel libressl-devel phonon-devel qjson-devel
- kdevplatform-devel kde-workspace-devel okteta-devel boost-devel"
+makedepends="kdelibs-devel qt-devel qt-webkit-devel libressl-devel phonon-devel
+ qjson-devel kdevplatform-devel kde-workspace-devel okteta-devel boost-devel"
 
 # kde-runtime provides khelpcenter, needed to display documentation
 depends="konsole kate kde-runtime"

--- a/srcpkgs/kdevplatform/template
+++ b/srcpkgs/kdevplatform/template
@@ -1,14 +1,14 @@
 # Template file for 'kdevplatform'
 pkgname=kdevplatform
 version=1.7.3
-revision=1
+revision=2
 
 build_style=cmake
 configure_args="-Wno-dev"
 
 hostmakedepends="qt-qmake automoc4 perl"
-makedepends="kdelibs-devel qt-devel libressl-devel phonon-devel grantlee-devel
- boost-devel subversion-devel apr-util-devel qjson-devel"
+makedepends="kdelibs-devel qt-devel qt-webkit-devel libressl-devel phonon-devel
+ grantlee-devel boost-devel subversion-devel apr-util-devel qjson-devel"
 
 short_desc="Libraries for use by KDE development tools"
 maintainer="yopito <pierre.bourgin@free.fr>"

--- a/srcpkgs/ktorrent/template
+++ b/srcpkgs/ktorrent/template
@@ -1,7 +1,7 @@
 # Template file for 'ktorrent'
 pkgname=ktorrent
 version=4.3.1
-revision=1
+revision=2
 short_desc="BitTorrent client based on the KDE platform"
 maintainer="Norbert Vegh <vegh@norvegh.com>"
 license="GPL-2"
@@ -11,5 +11,5 @@ checksum=66094f6833347afb0c49e332f0ec15ec48db652cbe66476840846ffd5ca0e4a1
 build_style=cmake
 hostmakedepends="cmake automoc4"
 configure_args="-DKDE4_BUILD_TESTS=OFF"
-makedepends="kdelibs-devel qt-devel gmp-devel qca-devel libressl-devel phonon-devel
-	libktorrent-devel kdepimlibs-devel boost-devel"
+makedepends="kdelibs-devel qt-devel qt-webkit-devel gmp-devel qca-devel
+ libressl-devel phonon-devel libktorrent-devel kdepimlibs-devel boost-devel"

--- a/srcpkgs/kvirc/template
+++ b/srcpkgs/kvirc/template
@@ -1,11 +1,11 @@
 # Template file for 'kvirc'
 pkgname=kvirc
 version=4.2.0
-revision=9
+revision=10
 build_style=cmake
 configure_args="-DWANT_ENV_FLAGS=1"
 hostmakedepends="automoc4"
-makedepends="zlib-devel qt-devel libressl-devel python-devel kdelibs-devel perl"
+makedepends="zlib-devel qt-devel qt-webkit-devel libressl-devel python-devel kdelibs-devel perl"
 short_desc="Qt-based IRC client"
 maintainer="Andrea Brancaleoni <miwaxe@gmail.com>"
 license="GPL-2"

--- a/srcpkgs/libkgapi/template
+++ b/srcpkgs/libkgapi/template
@@ -1,13 +1,13 @@
 # Template file for 'libkgapi'
 pkgname=libkgapi
 version=2.1.1
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="cmake automoc4 pkg-config"
-makedepends="boost-devel qt-devel phonon-devel kdelibs-devel kdepimlibs-devel qjson-devel"
-short_desc="A KDE-based library for accessing various Google services via their public API"
+makedepends="boost-devel qt-devel qt-webkit-devel phonon-devel kdelibs-devel kdepimlibs-devel qjson-devel"
+short_desc="KDE-based library for accessing various Google services"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL, LGPL, FDL"
+license="GPL-2, LGPL-2.1, FDL"
 homepage="https://projects.kde.org/projects/extragear/libs/libkgapi"
 distfiles="http://download.kde.org/stable/${pkgname}/${version}/src/${pkgname}-${version}.tar.bz2"
 checksum=2d7dcaf5033acac381ea456b7320784898617cdc502587313bd8b653855d02cb

--- a/srcpkgs/marble/template
+++ b/srcpkgs/marble/template
@@ -3,25 +3,25 @@
 
 pkgname=marble
 version=4.14.3
-revision=3
-maintainer="Carlo Dormeletti <carloDOTdormelettiATaliceDOTit>"
+revision=4
+maintainer="Carlo Dormeletti <carlo.dormeletti@alice.it>"
 homepage="hhttps://marble.kde.org"
 license="GPL-3"
 short_desc="Virtual globe and world atlas"
 build_style=cmake
 hostmakedepends="cmake automoc4 pkg-config"
-makedepends="libressl-devel qt-devel kdelibs-devel phonon-devel"
+makedepends="libressl-devel qt-devel qt-webkit-devel kdelibs-devel phonon-devel"
 replaces="libmarble>=0"
 distfiles="http://download.kde.org/stable/${version}/src/marble-${version}.tar.xz"
 checksum="4d6667cf67ae9976e4c1efc306be222d13f2ee5927483325411ae0e9631dc0f0"
 
 marble-devel_package() {
-    replaces="libmarble-devel>=0"
-    short_desc+=" - development files"
-    depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
-    pkg_install() {
-        vmove usr/include
-        vmove "usr/lib/*.so"
-        vmove usr/share/apps/cmake
-    }
+	replaces="libmarble-devel>=0"
+	short_desc+=" - development files"
+	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.so"
+		vmove usr/share/apps/cmake
+	}
 }

--- a/srcpkgs/python-PyQt4/template
+++ b/srcpkgs/python-PyQt4/template
@@ -1,11 +1,11 @@
 # Template file for 'python-PyQt4'
 pkgname=python-PyQt4
 version=4.11.4
-revision=3
+revision=4
 wrksrc="PyQt-x11-gpl-${version}"
 hostmakedepends="pkg-config"
 makedepends="python-devel python3.4-devel python-sip-devel python3.4-sip-devel
- qt-devel dbus-devel python-dbus-devel MesaLib-devel phonon-devel"
+ qt-devel qt-webkit-devel dbus-devel python-dbus-devel MesaLib-devel phonon-devel"
 depends="python-sip"
 pycompile_module="PyQt4"
 short_desc="Python2 bindings for the Qt4 toolkit"

--- a/srcpkgs/python-pyside/template
+++ b/srcpkgs/python-pyside/template
@@ -1,12 +1,12 @@
 # Template file for 'python-pyside'
 pkgname=python-pyside
 version=1.2.2
-revision=3
+revision=4
 wrksrc="pyside-qt4.8+${version}"
 python_versions="2.7 3.4"
 hostmakedepends="cmake"
 makedepends="python-devel python3.4-devel libshiboken-python-devel
- libshiboken-python3.4-devel qt-devel MesaLib-devel phonon-devel"
+ libshiboken-python3.4-devel qt-devel qt-webkit-devel MesaLib-devel phonon-devel"
 depends="python-shiboken"
 pycompile_module="PySide"
 short_desc="LGPL-licensed Python2 bindings for the Qt4 toolkit"
@@ -29,7 +29,7 @@ do_build() {
 		-DBUILD_TESTS=OFF"
 
 	for pyver in $python_versions; do
-		args=
+		unset args
 		if [ "$pyver" = "2.7" ]; then
 			args="-DPYTHON_SUFFIX=-python2.7"
 		fi

--- a/srcpkgs/qt-webkit-devel
+++ b/srcpkgs/qt-webkit-devel
@@ -1,0 +1,1 @@
+qt-webkit

--- a/srcpkgs/qt-webkit/files/fix-execinfo.patch
+++ b/srcpkgs/qt-webkit/files/fix-execinfo.patch
@@ -1,0 +1,20 @@
+--- qtwebkit-2.3.4/Source/WTF/wtf/Assertions.cpp	2014-09-24 13:42:05.000000000 +0200
++++ qtwebkit-2.3.4/Source/WTF/wtf/Assertions.cpp	2016-09-17 23:37:12.846758706 +0200
+@@ -58,7 +58,7 @@
+ #include <windows.h>
+ #endif
+ 
+-#if (OS(DARWIN) || (OS(LINUX) && !defined(__UCLIBC__))) && !OS(ANDROID)
++#if (OS(DARWIN) || (OS(LINUX) && defined(__GLIBC__))) && !OS(ANDROID)
+ #include <cxxabi.h>
+ #include <dlfcn.h>
+ #include <execinfo.h>
+@@ -242,7 +242,7 @@
+ 
+ void WTFGetBacktrace(void** stack, int* size)
+ {
+-#if (OS(DARWIN) || (OS(LINUX) && !defined(__UCLIBC__))) && !OS(ANDROID)
++#if (OS(DARWIN) || (OS(LINUX) && defined(__GLIBC__))) && !OS(ANDROID)
+     *size = backtrace(stack, *size);
+ #elif OS(WINDOWS) && !OS(WINCE)
+     // The CaptureStackBackTrace function is available in XP, but it is not defined

--- a/srcpkgs/qt-webkit/files/fix-gcc6.patch
+++ b/srcpkgs/qt-webkit/files/fix-gcc6.patch
@@ -1,0 +1,14 @@
+--- webkit-qtwebkit-23/Source/JavaScriptCore/runtime/JSObject.cpp.gcc5	2014-09-24 06:42:05.000000000 -0500
++++ webkit-qtwebkit-23/Source/JavaScriptCore/runtime/JSObject.cpp	2015-03-20 08:15:53.192778375 -0500
+@@ -1922,6 +1922,10 @@ void JSObject::putByIndexBeyondVectorLen
+     }
+ }
+ 
++template void JSObject::putByIndexBeyondVectorLengthWithoutAttributes<ContiguousShape>(ExecState* exec, unsigned i, JSValue value);
++template void JSObject::putByIndexBeyondVectorLengthWithoutAttributes<DoubleShape>(ExecState* exec, unsigned i, JSValue value);
++template void JSObject::putByIndexBeyondVectorLengthWithoutAttributes<Int32Shape>(ExecState* exec, unsigned i, JSValue value);
++
+ void JSObject::putByIndexBeyondVectorLengthWithArrayStorage(ExecState* exec, unsigned i, JSValue value, bool shouldThrow, ArrayStorage* storage)
+ {
+     JSGlobalData& globalData = exec->globalData();
+

--- a/srcpkgs/qt-webkit/files/fix-mallinfo.patch
+++ b/srcpkgs/qt-webkit/files/fix-mallinfo.patch
@@ -1,0 +1,11 @@
+--- qtwebkit-2.3.4/Source/WebCore/platform/qt/MemoryUsageSupportQt.cpp	2014-09-24 13:42:05.000000000 +0200
++++ qtwebkit-2.3.4/Source/WebCore/platform/qt/MemoryUsageSupportQt.cpp	2016-09-17 23:48:23.558775636 +0200
+@@ -31,7 +31,7 @@
+ 
+ namespace WebCore {
+ 
+-#if OS(LINUX)
++#if OS(LINUX) && defined(__GLIBC__)
+ static size_t mallocMemoryUsage(bool inuse)
+ {
+     // Return how much memory (in bytes) has been allocated on the system heap.

--- a/srcpkgs/qt-webkit/files/qwebview.patch
+++ b/srcpkgs/qt-webkit/files/qwebview.patch
@@ -1,0 +1,21 @@
+--- qt-everywhere-opensource-src-4.8.7/tools/designer/src/plugins/plugins.pri~	2013-01-09 12:56:08.915412090 +0000
++++ qt-everywhere-opensource-src-4.8.7/tools/designer/src/plugins/plugins.pri	2013-01-09 12:58:06.911391299 +0000
+@@ -1,3 +1,6 @@
++INCLUDEPATH += ../../../../../../qtwebkit-2.3.4/WebKitBuild/Release/include
++LIBS += -L../../../../../../qtwebkit-2.3.4/WebKitBuild/Release/lib
++
+ CONFIG += designer
+ win32|mac: CONFIG+= debug_and_release
+ QTDIR_build:DESTDIR = $$QT_BUILD_TREE/plugins/designer
+--- qt-everywhere-opensource-src-4.8.7/tools/designer/src/plugins/plugins.pro~	2013-01-09 12:55:43.598892405 +0000
++++ qt-everywhere-opensource-src-4.8.7/tools/designer/src/plugins/plugins.pro	2013-01-09 12:55:53.352169136 +0000
+@@ -2,9 +2,4 @@
+ CONFIG += ordered
+
+ REQUIRES = !CONFIG(static,shared|static)
+-contains(QT_CONFIG, qt3support): SUBDIRS += widgets
+-win32: SUBDIRS += activeqt
+-# contains(QT_CONFIG, opengl): SUBDIRS += tools/view3d
+ contains(QT_CONFIG, webkit): SUBDIRS += qwebview
+-contains(QT_CONFIG, phonon): SUBDIRS += phononwidgets
+-contains(QT_CONFIG, declarative): SUBDIRS += qdeclarativeview

--- a/srcpkgs/qt-webkit/template
+++ b/srcpkgs/qt-webkit/template
@@ -1,0 +1,64 @@
+# Template file for 'qt-webkit'
+pkgname=qt-webkit
+version=2.3.4
+revision=1
+_qtver=4.8.7
+wrksrc="qtwebkit-${version}"
+create_wrksrc=yes
+hostmakedepends="automake libtool bison flex gperf ruby pkg-config qt-qmake qt-designer"
+makedepends="MesaLib-devel libjpeg-turbo-devel qt-devel glib-devel fontconfig-devel \
+ gst-plugins-base1-devel sqlite-devel libXrender-devel"
+short_desc="Open source web browser engine (Qt4 port)"
+maintainer="Juergen Buchmueller <pullmoll@t-online.de>"
+license="LGPL-2.1, GPL-3"
+homepage="http://trac.webkit.org/wiki/QtWebKit"
+distfiles="
+ http://download.kde.org/stable/qtwebkit-${version%.*}/${version}/src/qtwebkit-${version}.tar.gz
+ http://download.qt.io/official_releases/qt/${_qtver%.*}/${_qtver}/qt-everywhere-opensource-src-${_qtver}.tar.gz"
+checksum="
+ c6cfa9d068f7eb024fee3f6c24f5b8b726997f669007587f35ed4a97d40097ca
+ e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0"
+conflicts="qt<4.8.7_12"
+
+post_extract() {
+	patch -p1 < ${FILESDIR}/fix-gcc6.patch
+	patch -p1 < ${FILESDIR}/fix-execinfo.patch
+	patch -p1 < ${FILESDIR}/fix-mallinfo.patch
+	patch -p0 < ${FILESDIR}/qwebview.patch
+	mv qt-everywhere-opensource-src-${_qtver} ..
+}
+
+do_configure() {
+	:
+}
+
+do_build() {
+	local opts="--qt --prefix=/usr --no-webkit2"
+	case "$XBPS_TARGET_MACHINE" in
+		i686*)	opts+=" --no-force-sse2" ;;
+	esac
+	export QTDIR=/usr
+	export PATH="/usr/lib/qt/bin:$PATH"
+	Tools/Scripts/build-webkit --makeargs="${makejobs}" ${opts}
+	cd ../qt-everywhere-opensource-src-${_qtver}/tools/designer/src/plugins/qwebview
+	qmake
+	make ${makejobs}
+}
+
+do_install() {
+	make INSTALL_ROOT="${DESTDIR}" -C WebKitBuild/Release install
+	cd ../qt-everywhere-opensource-src-${_qtver}/tools/designer/src/plugins/qwebview
+	make INSTALL_ROOT="${DESTDIR}" install
+}
+
+qt-webkit-devel_package() {
+	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/*.so
+		vmove usr/lib/*.prl
+		vmove usr/lib/pkgconfig
+		vmove usr/share/qt/mkspecs
+	}
+}

--- a/srcpkgs/qt/template
+++ b/srcpkgs/qt/template
@@ -1,7 +1,7 @@
 # Template file for 'qt'
 pkgname=qt
 version=4.8.7
-revision=11
+revision=12
 _distname=qt-everywhere-opensource-src
 patch_args="-Np1"
 wrksrc=${_distname}-${version}
@@ -65,12 +65,7 @@ do_configure() {
 	_opts+=" -graphicssystem raster"
 	_opts+=" -openssl-linked"
 	_opts+=" -xmlpatterns"
-	if [ "${_gccver%%.*}" -gt 5 ]; then
-		# webkit is broken with gcc-6.2.0
-		_opts+=" -no-webkit"
-	else
-		_opts+=" -webkit"
-	fi
+	_opts+=" -no-webkit"
 	_opts+=" -gtkstyle"
 	_opts+=" -system-sqlite"
 	_opts+=" -no-openvg"

--- a/srcpkgs/quassel/template
+++ b/srcpkgs/quassel/template
@@ -1,13 +1,13 @@
 # Template file for 'quassel'
 pkgname=quassel
 version=0.12.4
-revision=1
+revision=2
 build_style=cmake
 _desc="Modern, cross-platform, distributed graphical IRC client"
 short_desc="${_desc} - standalone client"
 maintainer="Toyam Cox <Vaelatern@gmail.com>"
 hostmakedepends="pkg-config"
-makedepends="zlib-devel qt-devel libdbusmenu-qt-devel phonon-devel qca-devel"
+makedepends="zlib-devel qt-devel qt-webkit-devel libdbusmenu-qt-devel phonon-devel qca-devel"
 _common_deps="desktop-file-utils"
 depends="${_common_deps} qt-plugin-sqlite quassel-client-shared>=${version}_${revision}"
 license="GPL-3"

--- a/srcpkgs/tomahawk/template
+++ b/srcpkgs/tomahawk/template
@@ -1,7 +1,7 @@
 # Template file for 'tomahawk'
 pkgname=tomahawk
 version=0.8.4
-revision=5
+revision=6
 build_style=cmake
 build_options="upower hatchet kde xmpp"
 desc_option_hatchet="Enable support for http://hatchet.is"
@@ -16,9 +16,9 @@ configure_args="-DBUILD_RELEASE=ON \
  $(vopt_if kde '-DWITH_KDE4=ON' '-DWITH_KDE4=OFF') \
  $(vopt_if upower '-DWITH_UPOWER=ON' '-DWITH_UPOWER=OFF')"
 hostmakedepends="pkg-config akonadi-devel"
-makedepends="boost-devel qt-devel qjson-devel taglib-devel sparsehash gnutls-devel
- qca-devel Lucene++-devel attica-devel quazip-devel qtkeychain-devel
- phonon-devel liblastfm-devel libechonest-devel libressl-devel
+makedepends="boost-devel qt-devel qt-webkit-devel qjson-devel taglib-devel
+ sparsehash gnutls-devel qca-devel Lucene++-devel attica-devel quazip-devel
+ qtkeychain-devel phonon-devel liblastfm-devel libechonest-devel libressl-devel
  $(vopt_if hatchet websocketpp) $(vopt_if xmpp jreen-devel)
  $(vopt_if kde kde-baseapps-devel) $(vopt_if kde telepathy-qt-devel)"
 depends="virtual?phonon-backend qt-plugin-sqlite $(vopt_if xmpp qca-ossl)"


### PR DESCRIPTION
Instead of the webkit shipped with `qt-4.8.7` (which is impossible to build with gcc6), add a `qt-webkit-2.3.4` package and revbump packages depending on `libQtWebKit.so.4`, adding the new dependency `qt-webkit-devel`.
