### PR TITLE
obs: update to 0.16.1.

### DIFF
--- a/srcpkgs/obs/template
+++ b/srcpkgs/obs/template
@@ -1,7 +1,7 @@
 # Template file for 'obs'
 pkgname=obs
-version=0.15.4
-revision=2
+version=0.16.1
+revision=1
 wrksrc=obs-studio-${version}
 only_for_archs="i686 x86_64 i686-musl x86_64-musl"
 build_style=cmake
@@ -14,14 +14,13 @@ maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="GPL-2"
 homepage="https://obsproject.com"
 distfiles="https://github.com/jp9000/obs-studio/archive/${version}.tar.gz"
-checksum=e0ea4f6c25e8b101902c057332bdb47dc4e6c6ce4fce0c2411d7a17b25987885
+checksum=d69d4a883fcc5d92ff9dd856bdb0aabb4aa840d809c71bed8b96482b852f6553
 
 obs-devel_package() {
 	short_desc+=" - development files"
 	depends="${sourcepkg}>=${version}_${revision}"
 	pkg_install() {
 		vmove usr/include
-		vmove usr/lib/*.so
 		vmove usr/lib/cmake
 	}
 }


### PR DESCRIPTION
needed to remove `vmove usr/lib/*.so` from the devel package, otherwise obs would pull it in.