### PR TITLE
geary: update to 0.11.2.

### DIFF
--- a/srcpkgs/geary/template
+++ b/srcpkgs/geary/template
@@ -1,17 +1,17 @@
 # Template file for 'geary'
 pkgname=geary
-version=0.11.0
+version=0.11.2
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config intltool cmake desktop-file-utils gnome-doc-utils"
 makedepends="
  vala-devel webkitgtk-devel libgee08-devel libcanberra-devel libsecret-devel
- libgnome-keyring-devel gmime-devel libunique-devel sqlite-devel libnotify-devel
- libgirepository-devel gcr-devel glib-devel"
-depends="gir-freedesktop hicolor-icon-theme desktop-file-utils"
+ gmime-devel libunique-devel sqlite-devel libnotify-devel libgirepository-devel
+ gcr-devel glib-devel"
+depends="gir-freedesktop hicolor-icon-theme desktop-file-utils gnome-keyring"
 short_desc="A lightweight email program for the GNOME desktop"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-3"
-homepage="http://yorba.org/geary/"
+license="LGPL-2.1"
+homepage="https://wiki.gnome.org/Apps/Geary"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/geary-${version}.tar.xz"
-checksum=c947bb1e70bd3d3f4799e59ddd05b27b08a8132674f64c68c919974595bdcd9f
+checksum=5c9e20ecd53672a42e22a436b9d3b6b9e9bf81ddf77163414a1c55986f9b4631


### PR DESCRIPTION
I made quite a few changes as well:

- homepage now redirects to the gnome wiki page
- license was wrong
- gnome-keyring: I noticed that it's not linked against libgnome-keyring at all so libgnome-keyring-devel is not required, but `gnome-keyring` itself for storing passwords (otherwise I ran into [this](https://forums.freebsd.org/threads/50155/) issue). I guess it's handled by libsecret instead.