### PR TITLE
inetutils: fix xinetd configs

### DIFF
--- a/srcpkgs/inetutils/template
+++ b/srcpkgs/inetutils/template
@@ -1,7 +1,7 @@
 # Template file for 'inetutils'
 pkgname=inetutils
 version=1.9.4
-revision=7
+revision=8
 build_style=gnu-configure
 configure_args="--without-wrap --with-pam"
 makedepends="pam-devel readline-devel"
@@ -107,67 +107,67 @@ inetutils-rcp_package() {
 }
 inetutils-rexec_package() {
 	short_desc+=" - rexec client and server (remote exec)"
-	conf_files="/etc/xinet.d/rexec.xinetd"
+	conf_files="/etc/xinetd.d/rexec"
 	pkg_install() {
 		vbin src/rexec
 		vman man/rexec.1
 		vbin src/rexecd
 		vman man/rexecd.8
-		vinstall ${FILESDIR}/rexec.xinetd 644 etc/xinet.d
+		vinstall ${FILESDIR}/rexec.xinetd 644 etc/xinetd.d rexec
 		# TODO: write etc/inet.d/rexec.conf or add an etc/inetd.conf line
 	}
 }
 inetutils-rlogin_package() {
 	short_desc+=" - rlogin client and server (remote login)"
-	conf_files="/etc/xinet.d/rlogin.xinetd"
+	conf_files="/etc/xinetd.d/rlogin"
 	pkg_install() {
 		vbin src/rlogin
 		vman man/rlogin.1
 		vbin src/rlogind
 		vman man/rlogind.8
-		vinstall ${FILESDIR}/rlogin.xinetd 644 etc/xinet.d
+		vinstall ${FILESDIR}/rlogin.xinetd 644 etc/xinetd.d rlogin
 		# TODO: write etc/inet.d/rlogin.conf or add an etc/inetd.conf line
 	}
 }
 inetutils-rsh_package() {
 	short_desc+=" - rsh client and server (remote shell)"
-	conf_files="/etc/xinet.d/rsh.xinetd"
+	conf_files="/etc/xinetd.d/rsh"
 	pkg_install() {
 		vbin src/rsh
 		vman man/rsh.1
 		vbin src/rshd
 		vman man/rshd.8
-		vinstall ${FILESDIR}/rsh.xinetd 644 etc/xinet.d
+		vinstall ${FILESDIR}/rsh.xinetd 644 etc/xinetd.d rsh
 		# TODO: write etc/inet.d/rsh.conf or add an etc/inetd.conf line
 	}
 }
 inetutils-talk_package() {
 	short_desc+=" - talk client and server"
-	conf_files="/etc/xinet.d/talk.xinetd"
+	conf_files="/etc/xinetd.d/talk"
 	pkg_install() {
 		vbin talk/talk
 		vman man/talk.1
 		vbin talkd/talkd
 		vman man/talkd.8
-		vinstall ${FILESDIR}/talk.xinetd 644 etc/xinet.d
+		vinstall ${FILESDIR}/talk.xinetd 644 etc/xinetd.d talk
 		# TODO: write etc/inet.d/talk.conf or add an etc/inetd.conf line
 	}
 }
 inetutils-telnet_package() {
 	short_desc+=" - telnet client and server"
-	conf_files="/etc/xinet.d/telnet.xinetd"
+	conf_files="/etc/xinetd.d/telnet"
 	pkg_install() {
 		vbin telnet/telnet
 		vman man/telnet.1
 		vbin telnetd/telnetd
 		vman man/telnetd.8
-		vinstall ${FILESDIR}/telnet.xinetd 644 etc/xinet.d
+		vinstall ${FILESDIR}/telnet.xinetd 644 etc/xinetd.d telnet
 		# TODO: write etc/inet.d/telnet.conf or add an etc/inetd.conf line
 	}
 }
 inetutils-tftp_package() {
 	short_desc+="- tftp client and server (trivial file transfer protocol)"
-	conf_files="/etc/xinet.d/tftp.xinetd"
+	conf_files="/etc/xinetd.d/tftp"
 	alternatives="
 	 tftp:tftp:/usr/bin/${pkgname}
 	 tftp:tftp.1:/usr/share/man/man1/${pkgname}.1
@@ -177,7 +177,7 @@ inetutils-tftp_package() {
 		vman man/tftp.1 ${pkgname}.1
 		vbin src/tftpd
 		vman man/tftpd.8
-		vinstall ${FILESDIR}/tftp.xinetd 644 etc/xinet.d
+		vinstall ${FILESDIR}/tftp.xinetd 644 etc/xinetd.d tftp
 		# TODO: write etc/inet.d/tftp.conf or add an etc/inetd.conf line
 	}
 }
@@ -227,11 +227,11 @@ inetutils-syslog_package() {
 }
 inetutils-uucpd_package() {
 	short_desc+=" - uucpd daemon (unix to unix copy)"
-	conf_files="/etc/xinet.d/uucp.xinetd"
+	conf_files="/etc/xinetd.d/uucp"
 	pkg_install() {
 		vbin src/uucpd
 		vman man/uucpd.8
-		vinstall ${FILESDIR}/uucp.xinetd 644 etc/xinet.d
+		vinstall ${FILESDIR}/uucp.xinetd 644 etc/xinetd.d uucp
 		# TODO: write etc/inet.d/uucp.conf or add an etc/inetd.conf line
 	}
 }


### PR DESCRIPTION
/etc/xinetd.d, not /etc/xinet.d

Also, according to man 5 xinetd.conf,
config files in a directory processed with includedir, such
as /etc/xinetd.d, will be skipped if their names contain
a dot.  So strip the .xinetd suffix when installing.