### PR TITLE
numix-themes: update to 2.6.4

### DIFF
--- a/srcpkgs/numix-themes/template
+++ b/srcpkgs/numix-themes/template
@@ -1,6 +1,6 @@
 # Template file for 'numix-themes'
 pkgname=numix-themes
-version=2.5.1
+version=2.6.4
 revision=4
 noarch=yes
 short_desc="A modern flat GTK3/Metacity/Xfwm theme"
@@ -9,11 +9,11 @@ maintainer="Jakub Skrzypnik <jot.skrzyp@gmail.com>"
 license="GPL-3"
 depends="gtk+3 gtk-engine-murrine"
 homepage="https://github.com/numixproject/numix-gtk-theme"
-distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=f3202f016605d499b530d7ddb946b1275801e8498dc7fd607f5e272b7227cc78
+distfiles="${homepage}/archive/${version}.tar.gz"
+checksum=f70cad6608d9a1b4819eaf6b51fc03d5c75971ff8f08080ac2eb9a5d8e386e6f
 
 do_install() {
-	tar xzf v${version}.tar.gz
+	tar xzf ${version}.tar.gz
 	vmkdir usr/share/themes
 	vcopy numix-gtk-theme-${version} usr/share/themes/numix-gtk-theme
 }


### PR DESCRIPTION
Also changed lines 16 and 12 as the upstream tarballs don't have v in there name anymore.