### PR TITLE
kdepimlibs: add CVE-2016-7966.patch

### DIFF
--- a/srcpkgs/kdepimlibs/patches/CVE-2016-7966.patch
+++ b/srcpkgs/kdepimlibs/patches/CVE-2016-7966.patch
@@ -1,0 +1,79 @@
+--- kpimutils/linklocator.cpp
++++ kpimutils/linklocator.cpp
+@@ -94,6 +94,12 @@
+ }
+ 
+ QString LinkLocator::getUrl()
++{
++    return getUrlAndCheckValidHref();
++}
++
++
++QString LinkLocator::getUrlAndCheckValidHref(bool *badurl)
+ {
+   QString url;
+   if ( atUrl() ) {
+@@ -129,13 +135,26 @@
+ 
+     url.reserve( maxUrlLen() );  // avoid allocs
+     int start = mPos;
++    bool previousCharIsADoubleQuote = false;
+     while ( ( mPos < (int)mText.length() ) &&
+             ( mText[mPos].isPrint() || mText[mPos].isSpace() ) &&
+             ( ( afterUrl.isNull() && !mText[mPos].isSpace() ) ||
+               ( !afterUrl.isNull() && mText[mPos] != afterUrl ) ) ) {
+       if ( !mText[mPos].isSpace() ) {   // skip whitespace
+-        url.append( mText[mPos] );
+-        if ( url.length() > maxUrlLen() ) {
++          if (mText[mPos] == QLatin1Char('>') && previousCharIsADoubleQuote) {
++              //it's an invalid url
++              if (badurl) {
++                  *badurl = true;
++              }
++              return QString();
++          }
++          if (mText[mPos] == QLatin1Char('"')) {
++              previousCharIsADoubleQuote = true;
++          } else {
++              previousCharIsADoubleQuote = false;
++          }
++          url.append( mText[mPos] );
++          if ( url.length() > maxUrlLen() ) {
+           break;
+         }
+       }
+@@ -367,7 +386,12 @@
+     } else {
+       const int start = locator.mPos;
+       if ( !( flags & IgnoreUrls ) ) {
+-        str = locator.getUrl();
++        bool badUrl = false;
++        str = locator.getUrlAndCheckValidHref(&badUrl);
++        if (badUrl) {
++            return locator.mText;
++        }
++
+         if ( !str.isEmpty() ) {
+           QString hyperlink;
+           if ( str.left( 4 ) == QLatin1String("www.") ) {
+
+--- kpimutils/linklocator.h
++++ kpimutils/linklocator.h
+@@ -107,6 +107,7 @@
+       @return The URL at the current scan position, or an empty string.
+     */
+     QString getUrl();
++    QString getUrlAndCheckValidHref(bool *badurl = 0);
+ 
+     /**
+       Attempts to grab an email address. If there is an @ symbol at the
+@@ -155,7 +156,7 @@
+     */
+     static QString pngToDataUrl( const QString & iconPath );
+ 
+-  protected:
++protected:
+     /**
+       The plaintext string being scanned for URLs and email addresses.
+     */
+

--- a/srcpkgs/kdepimlibs/template
+++ b/srcpkgs/kdepimlibs/template
@@ -1,7 +1,7 @@
 # Template file for 'kdepimlibs'
 pkgname=kdepimlibs
 version=4.14.3
-revision=3
+revision=4
 short_desc="KDE PIM Libraries"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2, LGPL-2.1, FDL"


### PR DESCRIPTION
Fixes CVE-2016-7966 using the patch from [176fee25ca79145ab5c8e2275d248f1a46a8d8cf](https://quickgit.kde.org/?p=kdepimlibs.git&a=commitdiff&h=176fee25ca79145ab5c8e2275d248f1a46a8d8cf) as recommended in the [security advisory](https://www.kde.org/info/security/advisory-20161006-1.txt).