### PR TITLE
Fix various packages that conflict with inetutils alternatives.

### DIFF
--- a/srcpkgs/net-tools/template
+++ b/srcpkgs/net-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'net-tools'
 pkgname=net-tools
 version=1.60.20150526git
-revision=2
+revision=3
 hostmakedepends="git"
 short_desc="Basic networking tools"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -10,7 +10,7 @@ license="GPL-2"
 
 alternatives="
  ifconfig:ifconfig:/usr/bin/${pkgname}-ifconfig
- ifconfig:ifconfig.8:/usr/share/man/man1/${pkgname}-ifconfig.8"
+ ifconfig:/usr/share/man/man1/ifconfig.1:/usr/share/man/man8/${pkgname}-ifconfig.8"
 
 do_fetch() {
 	git clone git://git.code.sf.net/p/net-tools/code ${pkgname}-${version}

--- a/srcpkgs/traceroute/template
+++ b/srcpkgs/traceroute/template
@@ -1,13 +1,18 @@
 # Template file for 'traceroute'
 pkgname=traceroute
 version=2.1.0
-revision=1
+revision=2
 short_desc="Traces the route taken by packets over an IPv4/IPv6 network"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://traceroute.sourceforge.net"
 distfiles="$SOURCEFORGE_SITE/$pkgname/$pkgname-$version.tar.gz"
 checksum=3669d22a34d3f38ed50caba18cd525ba55c5c00d5465f2d20d7472e5d81603b6
+
+alternatives="
+ traceroute:traceroute:/usr/bin/linux-traceroute
+ traceroute:traceroute.1:/usr/share/man/man1/linux-traceroute.1
+"
 
 do_build() {
 	if [ "$CROSS_BUILD" ]; then
@@ -17,9 +22,9 @@ do_build() {
 	fi
 }
 do_install() {
-	vbin traceroute/traceroute
-	vman traceroute/traceroute.8
+	vbin traceroute/traceroute linux-traceroute
+	vman traceroute/traceroute.8 linux-traceroute.8
 
-	ln -s traceroute $DESTDIR/usr/bin/traceroute6
-	ln -s traceroute.8 $DESTDIR/usr/share/man/man8/traceroute6.8
+	ln -s linux-traceroute $DESTDIR/usr/bin/traceroute6
+	ln -s linux-traceroute.8 $DESTDIR/usr/share/man/man8/traceroute6.8
 }

--- a/srcpkgs/util-linux/template
+++ b/srcpkgs/util-linux/template
@@ -1,7 +1,7 @@
 # Template file for 'util-linux'
 pkgname=util-linux
 version=2.28.2
-revision=2
+revision=3
 short_desc="Miscellaneous linux utilities"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="https://www.kernel.org/pub/linux/utils/util-linux/"
@@ -24,6 +24,11 @@ provides="eject-${version}_1"
 
 # XXX musl needs this for switch_root(8).
 CFLAGS="-D_DIRENT_HAVE_D_TYPE"
+
+alternatives="
+ logger:logger:/usr/bin/${pkgname}-logger
+ logger:logger.1:/usr/share/man/man1/${pkgname}-logger.1
+"
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh
@@ -49,6 +54,8 @@ do_install() {
 	# Correct perms for newgrp, chfn, chsh, wall and write.
 	chmod u+s $DESTDIR/usr/bin/{newgrp,chsh,chfn}
 
+	mv ${DESTDIR}/usr/bin/{logger,${pkgname}-logger}
+	mv ${DESTDIR}/usr/share/man/man1/{logger,${pkgname}-logger}.1
 	# pam login utils.
 	vinstall $FILESDIR/login.pam 644 etc/pam.d login
 	vinstall $FILESDIR/su.pam 644 etc/pam.d su


### PR DESCRIPTION
Here are descriptions of the conflicts and my fixes.

inetutils-ifconfig and net-tools:
Both provide the ifconfig alternative group, but the manpage symlink
in net-tools is broken.  It is named ifconfig.1, and it points to
net-tools-ifconfig.8 in /usr/share/man/man1.
Fixed by pointing the ifconfig.1 symlink to
/usr/share/man/man8/ifconfig.8.

inetutils-syslog:
Provides the logger group, which will clobber logger from util-linux when
installed.  Added the logger alternative group to util-linux.

inetutils-traceroute:
Provides the traceroute group, which clobbers things installed by
the traceroute package.
Renamed traceroute's binary and manpage, and the
traceroute package now provides the alternative group.
