### PR TITLE
New package: vscode-1.6.1

### DIFF
--- a/srcpkgs/vscode/patches/enable_extensions_store.patch
+++ b/srcpkgs/vscode/patches/enable_extensions_store.patch
@@ -1,0 +1,39 @@
+--- product.json	2016-10-13 17:20:53.000000000 +0200
++++ product.json.with_extensions	2016-10-24 02:04:55.813371552 +0200
+@@ -1,6 +1,6 @@
+ {
+ 	"nameShort": "Code - OSS",
+-	"nameLong": "Code - OSS",
++	"nameLong": "Visual Studio Code - OSS",
+ 	"applicationName": "code-oss",
+ 	"dataFolderName": ".vscode-oss",
+ 	"win32MutexName": "vscodeoss",
+@@ -12,5 +12,26 @@
+ 	"win32AppUserModelId": "Microsoft.CodeOSS",
+ 	"darwinBundleIdentifier": "com.visualstudio.code.oss",
+ 	"reportIssueUrl": "https://github.com/Microsoft/vscode/issues/new",
+-	"urlProtocol": "code-oss"
++	"urlProtocol": "code-oss",
++	"date": "2016-10-23T21:08:06.500Z",
++	"checksums": {
++		"vs/workbench/workbench.main.js": "OT3FHxXcL2u7H7Gcw03wJg",
++		"vs/workbench/workbench.main.css": "MjpV5nm5RMv/VTYUhsN49Q",
++		"vs/workbench/electron-browser/bootstrap/index.html": "A7FcwiFQwy0ydQR6MrrRrQ",
++		"vs/workbench/electron-browser/bootstrap/index.js": "dkbic1Y0gdcvjbbmYbbATQ"
++	},
++	"welcomePage": "http://go.microsoft.com/fwlink/?LinkId=723048",
++	"quality": "stable",
++	"extensionsGallery": {
++		"serviceUrl": "https://marketplace.visualstudio.com/_apis/public/gallery",
++		"cacheUrl": "https://vscode.blob.core.windows.net/gallery/index",
++		"itemUrl": "https://marketplace.visualstudio.com/items"
++	},
++	"documentationUrl": "http://go.microsoft.com/fwlink/?LinkID=533484#vscode",
++	"releaseNotesUrl": "http://go.microsoft.com/fwlink/?LinkID=533483#vscode",
++	"twitterUrl": "http://go.microsoft.com/fwlink/?LinkID=533687",
++	"requestFeatureUrl": "http://go.microsoft.com/fwlink/?LinkID=533482",
++	"privacyStatementUrl": "http://go.microsoft.com/fwlink/?LinkID=528096&clcid=0x409",
++	"commit": "@COMMIT@",
++	"date": "@DATE@"
+ }
+\ No newline at end of file

--- a/srcpkgs/vscode/template
+++ b/srcpkgs/vscode/template
@@ -1,0 +1,36 @@
+# Template file for 'vscode'
+pkgname=vscode
+version=1.6.1
+revision=1
+nopie=yes
+only_for_archs="x86_64 x86_64-musl"
+hostmakedepends="nodejs git python"
+makedepends="xproto libX11-devel"
+short_desc="Visual Studio Code - text editor built with Electron"
+maintainer="Jannis Christ <hello@jannis.ovh>"
+license="MIT"
+homepage="https://code.visualstudio.com"
+distfiles="https://github.com/Microsoft/vscode/archive/${version}.tar.gz"
+checksum=8041cb7d906b5160dcd269a5310bb55e419911a3fc050bff5bede91696067635
+
+
+pre_build() {
+	npm install -g node-gyp gulp
+}
+
+do_build() {
+	./scripts/npm.sh install
+	node --max_old_space_size=2048 /usr/bin/gulp vscode-linux-x64
+}
+do_install() {
+	cd ..
+	mv VSCode-linux-x64 vscode
+	vmkdir usr/lib
+	vmkdir usr/bin
+	vcopy vscode usr/lib/
+	ln -fs /usr/lib/vscode/bin/code-oss ${DESTDIR}/usr/bin/vscode
+}
+
+post_install() {
+	vlicense ../vscode/resources/app/LICENSE.txt
+}


### PR DESCRIPTION
I made these decisions which could be discussed on:
- named it vscode not _visual-studio-code_. This is also used for the [source repo](https://github.com/Microsoft/vscode)
- copy the whole installation to /usr/lib/vscode because it does not follow the UNIX directory convention and symlink executable to /usr/bin
- name the executable in /usr/bin `vscode` as well, not _code-oss_ as or _code_ as generated because I found this confusing

Fixes #3208
