### PR TITLE
w_scan: update to 20161022

### DIFF
--- a/srcpkgs/w_scan/patches/fix-uint.patch
+++ b/srcpkgs/w_scan/patches/fix-uint.patch
@@ -15,7 +15,7 @@
  /* AUTOMATICALLY GENERATED - DO NOT EDIT MANUALLY */
  #ifndef W_SCAN_VERSION_H
  #define W_SCAN_VERSION_H
--uint version=20141122;
-+unsigned int version=20141122;
+-uint version=20161022;
++unsigned int version=20161022;
  #endif
  

--- a/srcpkgs/w_scan/template
+++ b/srcpkgs/w_scan/template
@@ -1,14 +1,14 @@
 # Template file for 'w_scan'
 pkgname="w_scan"
-version="20141122"
-revision=2
+version="20161022"
+revision=1
 hostmakedepends="automake libtool"
 short_desc="A universal ATSC and DVB blind scanner"
 maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
 license="GPL-2"
 homepage="http://wirbel.htpc-forum.de/w_scan/index2.html"
 distfiles="http://wirbel.htpc-forum.de/w_scan/w_scan-${version}.tar.bz2"
-checksum="b6d7c9ab997c53a0b0d92e8390f313cc3b82ee8ece1756b4e526119fd5ba09b4"
+checksum="2077af7f8b42b7af038e83abf0565f96f59461bbc5e14c4516b68f50b5c00d79"
 build_style="gnu-configure"
 
 pre_configure() {


### PR DESCRIPTION
- Build and tested on 64bit glibc.
- Builds and executes in 32bit glibc test environment, not fully tested since there is no TV card present.
- Not tested on musl libc. Maybe someone else can check?