### PR TITLE
New package: streamlink-0.0.2

### DIFF
--- a/srcpkgs/streamlink/template
+++ b/srcpkgs/streamlink/template
@@ -1,0 +1,19 @@
+# Template file for 'streamlink'
+pkgname=streamlink
+version=0.0.2
+revision=1
+build_style=python3-module
+pycompile_module="streamlink streamlink_cli"
+noarch=yes
+hostmakedepends="python3-setuptools"
+depends="python3-setuptools python3-requests"
+short_desc="Utility extracting streams from services, forked from livestreamer"
+maintainer="wkuipers <wietse@kuiprs.nl>"
+license="BSD"
+homepage="https://streamlink.github.io/"
+distfiles="https://github.com/streamlink/streamlink/releases/download/${version}/streamlink-${version}.tar.gz"
+checksum=c443f46cfca540ecd04b6439e337d466f3bf9fc0df074bcfa69ad27ddb63c7a4
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
Livestreamer is no longer maintained, and streamlink is a livestreamer
fork that is maintained.