### PR TITLE
efibootmgr: add xbps kernel hook

### DIFF
--- a/srcpkgs/efibootmgr/INSTALL.msg
+++ b/srcpkgs/efibootmgr/INSTALL.msg
@@ -1,0 +1,18 @@
+From now on, efibootmgr automatically generates efi boot entries to
+directly boot the kernel after every kernel update or installation.
+
+The efi variables need to be accessible in order for this to work, so
+add this line to your fstab and reboot or mount manually:
+  efivarfs /sys/firmware/efi/efivars efivarfs 0 0
+-----------------------------------------------------------------------
+Kernel cmd options can be configured in /etc/efibootmgr-options.conf,
+but you always have to reconfigure the kernel:
+
+	$ xbps-reconfigure -f linux4.8
+	(or any other kernel version)
+
+This is also required after the first installation of this package.
+-----------------------------------------------------------------------
+The bootorder itself is not changed, so your previous boot loader will
+stay enabled until you can edit the order in your firmware interface or
+using "efibootmgr -o <hexnum>"

--- a/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-install
+++ b/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-install
@@ -1,0 +1,33 @@
+#!/usr/bin/sh
+#
+# Kernel hook for efibootmgr.
+#
+# Arguments passed to this script: $1 pkgname, $2 version.
+#
+PKGNAME="$1"
+VERSION="$2"
+
+options=$(cat '/etc/efibootmgr-options.conf')
+options="$options initrd=/initramfs-${VERSION}.img"
+
+# get major version, e.g. "4.8" for "linux4.8"
+major_version=$(echo $PKGNAME | cut -c 6-)
+
+# look for previous entry for this major kernel version
+existing_entry=$(efibootmgr | grep "Void Linux with kernel ${major_version}")
+
+# get the boot order
+# this is required because when in the next step the existing entry is removed,
+# it is also removed from the order so it needs to be restored later
+bootorder=$(efibootmgr |grep "BootOrder: " |cut -c 12-)
+
+# if existing, remove it
+if [ "$existing_entry" != "" ]; then
+  /etc/kernel.d/post-remove/50-efibootmgr $PKGNAME
+fi
+
+# create the new entry
+efibootmgr -qC -L "Void Linux with kernel ${major_version}" -l /vmlinuz-${VERSION} -u "${options}"
+
+# restore the boot order
+efibootmgr -qo $bootorder

--- a/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-remove
+++ b/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-remove
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# Kernel hook for efibootmgr.
+#
+# Arguments passed to this script: $1 pkgname, $2 version.
+#
+PKGNAME="$1"
+
+# get major version, e.g. "4.8" for "linux4.8"
+major_version=$(echo $PKGNAME | cut -c 6-)
+
+# get hex number of the matching entry
+hexnum=$(efibootmgr | grep "Void Linux with kernel ${major_version}" | cut -c "5-8")
+
+# delete it
+efibootmgr -Bq -b $hexnum

--- a/srcpkgs/efibootmgr/template
+++ b/srcpkgs/efibootmgr/template
@@ -1,7 +1,7 @@
 # Template file for 'efibootmgr'
 pkgname=efibootmgr
 version=0.12
-revision=1
+revision=2
 hostmakedepends="pkg-config"
 makedepends="libefivar-devel zlib-devel pciutils-devel"
 short_desc="Tool to modify UEFI Firmware Boot Manager Variables"
@@ -11,6 +11,7 @@ homepage="https://github.com/rhinstaller/efibootmgr"
 distfiles="https://github.com/rhinstaller/efibootmgr/releases/download/efibootmgr-${version}/efibootmgr-${version}.tar.bz2"
 checksum=a66f5850677e86255d93cb1cead04c3c48a823a2b864c579321f2a07f00256e6
 only_for_archs="i686 i686-musl x86_64 x86_64-musl"
+conf_files="/etc/efibootmgr-options.conf"
 
 do_build() {
 	make EXTRA_CFLAGS="$CFLAGS" ${makejobs}
@@ -18,4 +19,13 @@ do_build() {
 do_install() {
 	vbin src/efibootmgr/efibootmgr
 	vman src/man/man8/efibootmgr.8
+}
+post_install() {
+	vlicense COPYING
+	vmkdir etc/
+	touch ${DESTDIR}/etc/efibootmgr-options.conf
+	vinstall ${FILESDIR}/kernel.d/efibootmgr.post-install 744 \
+		etc/kernel.d/post-install 50-efibootmgr
+	vinstall ${FILESDIR}/kernel.d/efibootmgr.post-remove 744 \
+		etc/kernel.d/post-remove 50-efibootmgr
 }


### PR DESCRIPTION
efibootmgr is tool to manipulate the EFI boot entries but thanks to [EFISTUB](https://wiki.archlinux.org/index.php/EFISTUB) it can also be used to create entries to directly boot the kernel which this hook basically does.

I have to note that efibootmgr assumes for example that the disk is `/dev/sda`, this can only be configured through the execution parameters. If you want to I could modify the script so that these options can be defined by the user in something like `/etc/efibootmgr.conf` instead of just the kernel cmdline options.
