### PR TITLE
ntpd: redirect output to /dev/null

### DIFF
--- a/srcpkgs/ntp/files/isc-ntpd/run
+++ b/srcpkgs/ntp/files/isc-ntpd/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ntpd -g -u ntpd:ntpd -n 2>&1
+exec ntpd -g -u ntpd:ntpd -n >/dev/null 2>&1

--- a/srcpkgs/ntp/template
+++ b/srcpkgs/ntp/template
@@ -1,7 +1,7 @@
 # Template file for 'ntp'
 pkgname=ntp
 version=4.2.8p8
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-crypto --enable-linuxcap --enable-ipv6 --enable-ntp-signd
  --enable-all-clocks ol_cv_pthread_select_yields=yes"


### PR DESCRIPTION
ntpd currently prints it output to tty which is not necessary since ntpd
itself already logs to syslog if a syslog daemon is running. By redirecting
output of the process to /dev/null (stdout and stderr), this is avoided.