### PR TITLE
kdepimlibs: add CVE-2016-7966_part2.patch

### DIFF
--- a/srcpkgs/kdepimlibs/patches/CVE-2016-7966_part2.patch
+++ b/srcpkgs/kdepimlibs/patches/CVE-2016-7966_part2.patch
@@ -1,0 +1,29 @@
+--- kpimutils/linklocator.cpp
++++ kpimutils/linklocator.cpp
+@@ -389,7 +389,23 @@
+         bool badUrl = false;
+         str = locator.getUrlAndCheckValidHref(&badUrl);
+         if (badUrl) {
+-            return locator.mText;
++            QString resultBadUrl;
++            const int helperTextSize(locator.mText.count());
++            for (int i = 0; i < helperTextSize; ++i) {
++                const QChar chBadUrl = locator.mText[i];
++                if (chBadUrl == QLatin1Char('&')) {
++                    resultBadUrl += QLatin1String("&amp;");
++                } else if (chBadUrl == QLatin1Char('"')) {
++                    resultBadUrl += QLatin1String("&quot;");
++                } else if (chBadUrl == QLatin1Char('<')) {
++                    resultBadUrl += QLatin1String("&lt;");
++                } else if (chBadUrl == QLatin1Char('>')) {
++                    resultBadUrl += QLatin1String("&gt;");
++                } else {
++                    resultBadUrl += chBadUrl;
++                }
++            }
++            return resultBadUrl;
+         }
+ 
+         if ( !str.isEmpty() ) {
+
+

--- a/srcpkgs/kdepimlibs/template
+++ b/srcpkgs/kdepimlibs/template
@@ -1,7 +1,7 @@
 # Template file for 'kdepimlibs'
 pkgname=kdepimlibs
 version=4.14.3
-revision=4
+revision=5
 short_desc="KDE PIM Libraries"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2, LGPL-2.1, FDL"


### PR DESCRIPTION
since the last patch for CVE-2016-7966 did not fix the vulnerability entirely
according to the [information`](https://www.kde.org/info/security/advisory-20161006-1.txt) released by the KDE project, this commit adds the
[second patch]( https://quickgit.kde.org/?p=kdepimlibs.git&a=commitdiff&h=8bbe1bd3fdc55f609340edc667ff154b3d2aaab1) released to fix CVE-2016-7966.