### PR TITLE
xorg-server: enable security extension

### DIFF
--- a/srcpkgs/xorg-server/template
+++ b/srcpkgs/xorg-server/template
@@ -1,7 +1,7 @@
 # Template build file for 'xorg-server'.
 pkgname=xorg-server
 version=1.18.4
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--enable-ipv6 --enable-record --enable-xorg
  --enable-xnest --enable-xephyr --enable-composite --enable-xvfb
@@ -13,7 +13,7 @@ configure_args="--enable-ipv6 --enable-record --enable-xorg
  --enable-kdrive --enable-kdrive-evdev --enable-kdrive-kbd
  --disable-linux-acpi --disable-linux-apm --enable-xwayland
  --enable-suid-wrapper --with-shared-memory-dir=/dev/shm
- --without-systemd-daemon"
+ --without-systemd-daemon --enable-xcsecurity"
 short_desc="The X11 server from X.org"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://xorg.freedesktop.org"


### PR DESCRIPTION
This option used to be in the template, but was removed again. I wasn't able to find out why.

afaict it's default on most distros, and I use it a whole lot myself.