### PR TITLE
fish: add groff runtime dependency.

### DIFF
--- a/srcpkgs/fish-shell/template
+++ b/srcpkgs/fish-shell/template
@@ -1,11 +1,12 @@
 # Template file for 'fish-shell'
 pkgname=fish-shell
-version=2.3.1
-revision=2
+version=2.4.0
+revision=1
 build_style=gnu-configure
+configure_args="ac_cv_file__proc_self_stat=yes"
 hostmakedepends="automake libtool"
 makedepends="ncurses-devel"
-depends="bc"
+depends="bc groff"
 register_shell="/usr/bin/fish"
 conf_files="/etc/fish/config.fish"
 wrksrc="fish-${version}"
@@ -14,7 +15,7 @@ homepage="http://fishshell.com/"
 license="GPL-2"
 short_desc="User friendly shell intended mostly for interactive use"
 distfiles="https://github.com/fish-shell/fish-shell/releases/download/${version}/fish-${version}.tar.gz"
-checksum=328acad35d131c94118c1e187ff3689300ba757c4469c8cc1eaa994789b98664
+checksum=06bbb2323360439c4044da762d114ec1aa1aba265cec71c0543e6a0095c9efc5
 
 if [ -n "$CROSS_BUILD" ]; then
 	case "$XBPS_TARGET_MACHINE" in
@@ -24,11 +25,8 @@ if [ -n "$CROSS_BUILD" ]; then
 		CXXFLAGS="-D_GNU_SOURCE=1 -D_ISO99_SOURCE=1"
 		;;
 	esac
-	export ac_cv_file__proc_self_stat=yes
 fi
+
 pre_configure() {
-	if [ -n "$CROSS_BUILD" ]; then
-		patch -p0 < ${FILESDIR}/no-glibc-check.patch
-	fi
 	autoreconf -fi
 }


### PR DESCRIPTION
When I press ctrl+c in fish-shell, occurs the error below.

This error doesn't show when groff is installed. 

I added in PR fish-shell how depends on groff

```
⟩ fish: Unknown command 'nroff'
/usr/share/fish/functions/__fish_print_help.fish (line 1): nroff -man -c -t $rLL "$__fish_datadir/man/man1/$item.1" ^/dev/null
                                                           ^
in command substitution
        called on line 0 of file /usr/share/fish/functions/__fish_print_help.fish

in function '__fish_print_help'
        called on line 354 of file ~/.config/fish/functions/fish_prompt.fish
        with parameter list '--tty-width 169 set'

in command substitution
        called on line 352 of file ~/.config/fish/functions/fish_prompt.fish

in function '__dangerous_detach_session'
        called on line 103 of file ~/.config/fish/functions/fish_prompt.fish

in function '__dangerous_on_termination'
        called on standard input
        with parameter list 'SIGINT'

in event handler: signal handler for SIGINT (Quit request from job control (^C))

fish: Unknown command 'nroff'
/usr/share/fish/functions/__fish_print_help.fish (line 1): nroff -man -c -t $rLL "$__fish_datadir/man/man1/$item.1" ^/dev/null
                                                           ^
in command substitution
        called on line 0 of file /usr/share/fish/functions/__fish_print_help.fish

in function '__fish_print_help'
        called on line 354 of file ~/.config/fish/functions/fish_prompt.fish
        with parameter list '--tty-width 169 set'

in command substitution
        called on line 352 of file ~/.config/fish/functions/fish_prompt.fish

in function '__dangerous_detach_session'
        called on line 103 of file ~/.config/fish/functions/fish_prompt.fish

in function '__dangerous_on_termination'
        called on standard input
        with parameter list 'SIGINT'

in event handler: signal handler for SIGINT (Quit request from job control (^C))

fish: Unknown command 'nroff'
/usr/share/fish/functions/__fish_print_help.fish (line 1): nroff -man -c -t $rLL "$__fish_datadir/man/man1/$item.1" ^/dev/null
                                                           ^
in command substitution
        called on line 0 of file /usr/share/fish/functions/__fish_print_help.fish

in function '__fish_print_help'
        called on line 354 of file ~/.config/fish/functions/fish_prompt.fish
        with parameter list '--tty-width 169 set'

in command substitution
        called on line 352 of file ~/.config/fish/functions/fish_prompt.fish

in function '__dangerous_detach_session'
        called on line 103 of file ~/.config/fish/functions/fish_prompt.fish

in function '__dangerous_on_termination'
        called on standard input
        with parameter list 'SIGINT'

in event handler: signal handler for SIGINT (Quit request from job control (^C))

fish: Unknown command 'nroff'
/usr/share/fish/functions/__fish_print_help.fish (line 1): nroff -man -c -t $rLL "$__fish_datadir/man/man1/$item.1" ^/dev/null

in command substitution
        called on line 0 of file /usr/share/fish/functions/__fish_print_help.fish

in function '__fish_print_help'
        called on line 354 of file ~/.config/fish/functions/fish_prompt.fish
        with parameter list '--tty-width 169 set'

in command substitution
        called on line 352 of file ~/.config/fish/functions/fish_prompt.fish

in function '__dangerous_detach_session'
        called on line 103 of file ~/.config/fish/functions/fish_prompt.fish

in function '__dangerous_on_termination'
        called on standard input
        with parameter list 'SIGINT'

in event handler: signal handler for SIGINT (Quit request from job control (^C))

fish: Unknown command 'nroff'
/usr/share/fish/functions/__fish_print_help.fish (line 1): nroff -man -c -t $rLL "$__fish_datadir/man/man1/$item.1" ^/dev/null
                                                           ^
in command substitution
        called on line 0 of file /usr/share/fish/functions/__fish_print_help.fish

in function '__fish_print_help'
        called on line 354 of file ~/.config/fish/functions/fish_prompt.fish
        with parameter list '--tty-width 169 set'

in command substitution
        called on line 352 of file ~/.config/fish/functions/fish_prompt.fish

in function '__dangerous_detach_session'
        called on line 103 of file ~/.config/fish/functions/fish_prompt.fish

in function '__dangerous_on_termination'
        called on standard input
        with parameter list 'SIGINT'

in event handler: signal handler for SIGINT (Quit request from job control (^C))

fish: Unknown command 'nroff'
/usr/share/fish/functions/__fish_print_help.fish (line 1): nroff -man -c -t $rLL "$__fish_datadir/man/man1/$item.1" ^/dev/null
                                                           ^
in command substitution
        called on line 0 of file /usr/share/fish/functions/__fish_print_help.fish

in function '__fish_print_help'
        called on line 354 of file ~/.config/fish/functions/fish_prompt.fish
        with parameter list '--tty-width 169 set'

in command substitution
        called on line 352 of file ~/.config/fish/functions/fish_prompt.fish

in function '__dangerous_detach_session'
        called on line 103 of file ~/.config/fish/functions/fish_prompt.fish

in function '__dangerous_on_termination'
        called on standard input
        with parameter list 'SIGINT'

in event handler: signal handler for SIGINT (Quit request from job control (^C))

fish: Unknown command 'nroff'
/usr/share/fish/functions/__fish_print_help.fish (line 1): nroff -man -c -t $rLL "$__fish_datadir/man/man1/$item.1" ^/dev/null
                                                           ^
in command substitution
        called on line 0 of file /usr/share/fish/functions/__fish_print_help.fish

in function '__fish_print_help'
        called on line 354 of file ~/.config/fish/functions/fish_prompt.fish
        with parameter list '--tty-width 169 set'

in command substitution
        called on line 352 of file ~/.config/fish/functions/fish_prompt.fish

in function '__dangerous_detach_session'
        called on line 103 of file ~/.config/fish/functions/fish_prompt.fish

in function '__dangerous_on_termination'
        called on standard input
        with parameter list 'SIGINT'

in event handler: signal handler for SIGINT (Quit request from job control (^C))

fish: Unknown command 'nroff'
/usr/share/fish/functions/__fish_print_help.fish (line 1): nroff -man -c -t $rLL "$__fish_datadir/man/man1/$item.1" ^/dev/null
                                                           ^
in command substitution
        called on line 0 of file /usr/share/fish/functions/__fish_print_help.fish

in function '__fish_print_help'
        called on line 354 of file ~/.config/fish/functions/fish_prompt.fish
        with parameter list '--tty-width 169 set'

in command substitution
        called on line 352 of file ~/.config/fish/functions/fish_prompt.fish

in function '__dangerous_detach_session'
        called on line 103 of file ~/.config/fish/functions/fish_prompt.fish

in function '__dangerous_on_termination'
        called on standard input
        with parameter list 'SIGINT'

in event handler: signal handler for SIGINT (Quit request from job control (^C))
```