### PR TITLE
spotify: fix download link

### DIFF
--- a/srcpkgs/spotify/template
+++ b/srcpkgs/spotify/template
@@ -1,7 +1,7 @@
 # Template build file for 'spotify'.
 pkgname=spotify
 version=1.0.42
-revision=1
+revision=2
 short_desc="Proprietary music streaming client"
 maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
 homepage="https://www.spotify.com"
@@ -13,11 +13,11 @@ build_style=fetch
 depends="binutils gtk+ nss GConf libXScrnSaver xz"
 
 if test "${XBPS_TARGET_MACHINE}" = "x86_64"; then
-	_sversion=".145.g7a5a182e-37_amd64"
-	_schecksum="3fb12b496b52fcd4e42c95f430b75ef3874ad21564615a460fb5380b9b7a14b3"
+	_sversion=".151.g19de0aa6-74_amd64"
+	_schecksum="905c0c87091855c9d5d354ebeca9fb3951ff60c08f0dfc1c1898bf66cc8acd15"
 else
-	_sversion=".145.g7a5a182e-17_i386"
-	_schecksum="ffc5f2d2e30d6cca17449d1cd07f50085df57a0c3a2943f8ba8608f8b9d01d8a"
+	_sversion=".151.g19de0aa6-27_i386"
+	_schecksum="a7acb3929747e47669bdcb997c820101e79be3dd4dd48a3596873c5e03935a7c"
 fi
 
 do_install() {


### PR DESCRIPTION
Currently on install you get the following:

```
eater@chino ~ $ sudo xbps-install -Syf spotify                                                                                                                                                                                          
[*] Updating `https://repo.voidlinux.eu/current/x86_64-repodata' ...
[*] Updating `https://repo.voidlinux.eu/current/multilib/nonfree/x86_64-repodata' ...
[*] Updating `https://repo.voidlinux.eu/current/multilib/x86_64-repodata' ...
[*] Updating `https://repo.voidlinux.eu/current/nonfree/x86_64-repodata' ...

Name    Action    Version           New version            Download size
spotify reinstall 1.0.42_1          1.0.42_1               -

Size required on disk:          229B
Free space on disk:             23GB


[*] Downloading binary packages

[*] Verifying package integrity
spotify-1.0.42_1: verifying RSA signature...

[*] Running transaction tasks
spotify-1.0.42_1: unpacking ...

[*] Configuring unpacked packages
spotify-1.0.42_1: configuring ...
looking up repository.spotify.com
connecting to repository.spotify.com:80
requesting http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.0.42.145.g7a5a182e-37_amd64.deb
http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.0.42.145.g7a5a182e-37_amd64.deb: Not Found
Failed downloading spotify client
ERROR: spotify-1.0.42_1: [configure] INSTALL script failed to execute the post ACTION: Operation not permitted
```

Since they upped their spotify client revision, this should fix the download urls