### PR TITLE
efibootmgr: make modifying of boot records optional, disabled by default.

### DIFF
--- a/srcpkgs/efibootmgr/INSTALL.msg
+++ b/srcpkgs/efibootmgr/INSTALL.msg
@@ -1,11 +1,12 @@
-From now on, efibootmgr automatically generates efi boot entries to
+efibootmgr can automatically generate EFI boot entries to
 directly boot the kernel after every kernel update or installation.
+Enable this by editing /etc/default/efibootmgr-kernel-hook.
 
 The efi variables need to be accessible in order for this to work, so
 add this line to your fstab and reboot or mount manually:
   efivarfs /sys/firmware/efi/efivars efivarfs 0 0
 -----------------------------------------------------------------------
-Kernel cmd options can be configured in /etc/efibootmgr-options.conf,
+Kernel cmd options can be configured in /etc/default/efibootmgr-kernel-hook,
 but you always have to reconfigure the kernel:
 
 	$ xbps-reconfigure -f linux4.8

--- a/srcpkgs/efibootmgr/files/efibootmgr-kernel-hook.confd
+++ b/srcpkgs/efibootmgr/files/efibootmgr-kernel-hook.confd
@@ -1,0 +1,6 @@
+# Options for the kernel hook script installed by the efibootmgr package.
+MODIFY_EFI_ENTRIES=0
+# To allow efibootmgr to modify boot entries, set
+# MODIFY_EFI_ENTRIES=1
+# Kernel command-line options.  Example:
+# OPTIONS="root=/dev/sda3"

--- a/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-install
+++ b/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-install
@@ -7,8 +7,12 @@
 PKGNAME="$1"
 VERSION="$2"
 
-options=$(cat '/etc/efibootmgr-options.conf')
-options="$options initrd=/initramfs-${VERSION}.img"
+. "${ROOTDIR}/etc/default/efibootmgr-kernel-hook"
+if [ "x${MODIFY_EFI_ENTRIES}" != x1 ]; then
+	exit 0
+fi
+
+OPTIONS="${OPTIONS} initrd=/initramfs-${VERSION}.img"
 
 # get major version, e.g. "4.8" for "linux4.8"
 major_version=$(echo $PKGNAME | cut -c 6-)
@@ -27,7 +31,7 @@ if [ "$existing_entry" != "" ]; then
 fi
 
 # create the new entry
-efibootmgr -qC -L "Void Linux with kernel ${major_version}" -l /vmlinuz-${VERSION} -u "${options}"
+efibootmgr -qc -L "Void Linux with kernel ${major_version}" -l /vmlinuz-${VERSION} -u "${OPTIONS}"
 
 # restore the boot order
 efibootmgr -qo $bootorder

--- a/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-remove
+++ b/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-remove
@@ -6,6 +6,11 @@
 #
 PKGNAME="$1"
 
+. "${ROOTDIR}/etc/default/efibootmgr-kernel-hook"
+if [ "x${MODIFY_EFI_ENTRIES}" != x1 ]; then
+	exit 0
+fi
+
 # get major version, e.g. "4.8" for "linux4.8"
 major_version=$(echo $PKGNAME | cut -c 6-)
 

--- a/srcpkgs/efibootmgr/template
+++ b/srcpkgs/efibootmgr/template
@@ -1,7 +1,7 @@
 # Template file for 'efibootmgr'
 pkgname=efibootmgr
 version=0.12
-revision=2
+revision=3
 hostmakedepends="pkg-config"
 makedepends="libefivar-devel zlib-devel pciutils-devel"
 short_desc="Tool to modify UEFI Firmware Boot Manager Variables"
@@ -11,7 +11,7 @@ homepage="https://github.com/rhinstaller/efibootmgr"
 distfiles="https://github.com/rhinstaller/efibootmgr/releases/download/efibootmgr-${version}/efibootmgr-${version}.tar.bz2"
 checksum=a66f5850677e86255d93cb1cead04c3c48a823a2b864c579321f2a07f00256e6
 only_for_archs="i686 i686-musl x86_64 x86_64-musl"
-conf_files="/etc/efibootmgr-options.conf"
+conf_files="/etc/default/efibootmgr-kernel-hook"
 
 do_build() {
 	make EXTRA_CFLAGS="$CFLAGS" ${makejobs}
@@ -23,7 +23,7 @@ do_install() {
 post_install() {
 	vlicense COPYING
 	vmkdir etc/
-	touch ${DESTDIR}/etc/efibootmgr-options.conf
+	vinstall "${FILESDIR}/efibootmgr-kernel-hook.confd" 644 etc/default efibootmgr-kernel-hook
 	vinstall ${FILESDIR}/kernel.d/efibootmgr.post-install 744 \
 		etc/kernel.d/post-install 50-efibootmgr
 	vinstall ${FILESDIR}/kernel.d/efibootmgr.post-remove 744 \


### PR DESCRIPTION
Also changed the name of the config file, since the syntax
is much different.

See issue #5165 for the discussion.