### PR TITLE
wireshark: update to 2.2.2.

### DIFF
--- a/srcpkgs/wireshark/patches/musl.patch
+++ b/srcpkgs/wireshark/patches/musl.patch
@@ -1,0 +1,10 @@
+--- extcap/androiddump.c.orig	2016-11-17 08:07:21.000000000 +0000
++++ extcap/androiddump.c	2016-11-17 08:07:36.590061623 +0000
+@@ -30,6 +30,7 @@
+ #include <string.h>
+ #include <errno.h>
+ #include <time.h>
++#include <sys/time.h>
+ 
+ #ifdef HAVE_NETINET_IN_H
+ #    include <netinet/in.h>

--- a/srcpkgs/wireshark/template
+++ b/srcpkgs/wireshark/template
@@ -1,7 +1,7 @@
 # Template file for 'wireshark'
 pkgname=wireshark
-version=2.2.1
-revision=2
+version=2.2.2
+revision=1
 build_style=gnu-configure
 configure_args="--with-ssl --with-pcap --with-libcap --with-zlib --with-lua
  --with-krb5 --with-gtk3=yes --without-portaudio CC_FOR_BUILD=cc"
@@ -16,7 +16,7 @@ license="GPL-2"
 # XXX ovh is blocked (repo4.voidlinux.eu can't download this).
 distfiles="http://www.wireshark.org/download/src/${pkgname}-${version}.tar.bz2"
 #distfiles="https://sources.voidlinux.eu/${pkgname}-${version}/${pkgname}-${version}.tar.bz2"
-checksum=900e22af04c8b35e0d02a25a360ab1fb7cfe5ac18fc48a9afd75a7103e569149
+checksum=f9acef5e9a9021a400b4244fafc06969f41ec594ec57fd7f0ff63bafca0055b3
 system_groups="wireshark"
 subpackages="libwireshark libwireshark-devel wireshark-gtk"
 


### PR DESCRIPTION
Fixes CVE-2016-9372, CVE-2016-9374, CVE-2016-9376, CVE-2016-9373,
CVE-2016-9375