### PR TITLE
gst-plugins-bad: add fix-CESA-2016-0002.patch

### DIFF
--- a/srcpkgs/gst-plugins-bad/patches/fix-CESA-2016-0002.patch
+++ b/srcpkgs/gst-plugins-bad/patches/fix-CESA-2016-0002.patch
@@ -1,0 +1,22 @@
+--- gst/vmnc/vmncdec.c
++++ gst/vmnc/vmncdec.c
+@@ -370,7 +370,7 @@ vmnc_handle_wmvi_rectangle (GstVMncDec *
+ 
+   if (dec->imagedata)
+     g_free (dec->imagedata);
+-  dec->imagedata = g_malloc (dec->format.width * dec->format.height *
++  dec->imagedata = g_malloc0 (dec->format.width * dec->format.height *
+       dec->format.bytes_per_pixel);
+   GST_DEBUG_OBJECT (dec, "Allocated image data at %p", dec->imagedata);
+ 
+@@ -901,6 +901,10 @@ vmnc_handle_packet (GstVMncDec * dec, co
+             GST_WARNING_OBJECT (dec, "Rectangle out of range, type %d", r.type);
+             return ERROR_INVALID;
+           }
++        } else if (r.width > 16384 || r.height > 16384) {
++          GST_WARNING_OBJECT (dec, "Width or height too high: %ux%u", r.width,
++              r.height);
++          return ERROR_INVALID;
+         }
+ 
+         switch (r.type) {

--- a/srcpkgs/gst-plugins-bad/template
+++ b/srcpkgs/gst-plugins-bad/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-bad'.
 pkgname=gst-plugins-bad
 version=0.10.23
-revision=19
+revision=20
 lib32disabled=yes
 build_style=gnu-configure
 configure_args="--enable-experimental --disable-static --disable-nsf"


### PR DESCRIPTION
patch taken from the upstream master branch from the following commit
https://cgit.freedesktop.org/gstreamer/gst-plugins-bad/commit/?id=4cb1bcf1422bbcd79c0f683edb7ee85e3f7a31fe
This fixes the vulnerability currently known as CESA-2016-0002, full details available at:
https://scarybeastsecurity.blogspot.de/2016/11/0day-poc-risky-design-decisions-in.html