### PR TITLE
bash: use static readline

### DIFF
--- a/srcpkgs/bash/template
+++ b/srcpkgs/bash/template
@@ -5,12 +5,13 @@ _bash_patchlevel=048
 # Dracut breaks with bash 4.4. See https://github.com/dracutdevs/dracut/issues/118
 reverts=4.4.0_1
 version=${_bash_distver}.${_bash_patchlevel}
-revision=2
+revision=3
 wrksrc=${pkgname}-${_bash_distver}
 build_style=gnu-configure
-configure_args="--without-bash-malloc --with-curses --with-installed-readline"
+configure_args="--without-bash-malloc --with-curses --without-installed-readline"
+make_build_args="TERMCAP_LIB=${XBPS_CROSS_BASE}/usr/lib/libncursesw.a"
 hostmakedepends="bison"
-makedepends="ncurses-devel readline-devel"
+makedepends="ncurses-devel"
 conflicts="chroot-bash>=0"
 register_shell="/bin/bash"
 short_desc="The GNU Bourne Again Shell"


### PR DESCRIPTION
This is a workaround for the problems described in #5204 assuming the bash update is always ordered before the readline update.