### PR TITLE
base-chroot-musl: add kernel-libc-headers

### DIFF
--- a/srcpkgs/base-chroot-musl/template
+++ b/srcpkgs/base-chroot-musl/template
@@ -15,7 +15,7 @@ provides="base-chroot-${version}_${revision}"
 only_for_archs="i686-musl x86_64-musl armv6l-musl armv7l-musl aarch64-musl mips-musl mipsel-musl mipselhf-musl"
 
 depends="
- base-files musl-devel musl-legacy-compat
+ base-files kernel-libc-headers musl-devel musl-legacy-compat
  gcc patch chroot-bash chroot-grep coreutils findutils
  gettext chroot-texinfo sed chroot-gawk diffutils
  make gzip file tar chroot-util-linux chroot-distcc


### PR DESCRIPTION
If you look at the pkgs set up by ./xbps-src binary-bootstrap x86_64-musl,
you will see kernel-libc-headers being installed, so they should be built
as part of base-chroot-musl.