### PR TITLE
glew: also install glewmx

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -683,6 +683,7 @@ libxfce4kbd-private-3.so.0 libxfce4ui-4.12.1_2
 libxml++-2.6.so.2 libxml++-2.32.0_1
 libftgl.so.2 ftgl-2.1.2_1
 libGLEW.so.1.13 glew-1.13.0_1
+libGLEWmx.so.1.13 glew-1.13.0_2
 libsndfile.so.1 libsndfile-1.0.20_1
 libspeex.so.1 libspeex-1.1_1
 libspeexdsp.so.1 speexdsp-1.2rc2_1

--- a/srcpkgs/glew/template
+++ b/srcpkgs/glew/template
@@ -1,7 +1,7 @@
 # Template build file for 'glew'.
 pkgname=glew
 version=1.13.0
-revision=1
+revision=2
 hostmakedepends="pkg-config"
 makedepends="libXext-devel libXmu-devel libXi-devel glu-devel"
 short_desc="The OpenGL Extension Wrangler Library"
@@ -19,7 +19,8 @@ do_build() {
 }
 
 do_install() {
-	make GLEW_DEST=${DESTDIR}/usr install
+	make GLEW_DEST=${DESTDIR}/usr install.all
+	vlicense LICENSE.txt
 }
 
 glew-devel_package() {


### PR DESCRIPTION
use `make install.all` instead of `make install` to also install the glewmx lib (see http://glew.sourceforge.net/build.html)