### PR TITLE
Noto fonts update and reorganization

### DIFF
--- a/srcpkgs/noto-fonts-cjk/template
+++ b/srcpkgs/noto-fonts-cjk/template
@@ -1,0 +1,21 @@
+# Template build file for 'noto-fonts-cjk'
+pkgname=noto-fonts-cjk
+version=20150616
+revision=1
+noarch="yes"
+_githash=f36eda03dfa5582a6d49abbfb5c83d0209584158
+wrksrc="noto-cjk-${_githash}"
+depends="font-util"
+font_dirs="/usr/share/fonts/noto"
+short_desc="Google Noto CJK Fonts"
+maintainer="Peter Bui <pnutzh4x0r@gmail.com>"
+license="OFL-1.1"
+homepage="https://www.google.com/get/noto/"
+distfiles="https://github.com/googlei18n/noto-cjk/archive/${_githash}.tar.gz"
+checksum=f55d7dfeb6e5f01d3414fa0827c4864fb7628d088c99e30cba7757c502549550
+conflicts="google-fonts-ttf>=0"
+
+do_install() {
+	vmkdir usr/share/fonts/noto
+	install -m644 Noto*.ttc ${DESTDIR}/usr/share/fonts/noto
+}

--- a/srcpkgs/noto-fonts-emoji/template
+++ b/srcpkgs/noto-fonts-emoji/template
@@ -1,0 +1,21 @@
+# Template build file for 'noto-fonts-emoji'.
+pkgname=noto-fonts-emoji
+version=20161020
+revision=1
+noarch="yes"
+_githash=f09b63d1ecfe19b93021b0a283f1aa539b7230a9
+wrksrc="noto-emoji-${_githash}"
+depends="font-util"
+font_dirs="/usr/share/fonts/noto"
+short_desc="Google Noto Emoji Fonts"
+maintainer="Peter Bui <pnutzh4x0r@gmail.com>"
+license="OFL-1.1"
+homepage="https://www.google.com/get/noto/"
+distfiles="https://github.com/googlei18n/noto-emoji/archive/${_githash}.tar.gz"
+checksum=32926d0483fd7d6ca962876530b9faaae3e49ee05ae5bc417e5f2db2622ba6a5
+conflicts="google-fonts-ttf>=0"
+
+do_install() {
+	vmkdir usr/share/fonts/noto
+	install -m644 fonts/Noto*.ttf ${DESTDIR}/usr/share/fonts/noto
+}

--- a/srcpkgs/noto-fonts-ttf/template
+++ b/srcpkgs/noto-fonts-ttf/template
@@ -1,21 +1,21 @@
 # Template build file for 'noto-fonts-ttf'.
 pkgname=noto-fonts-ttf
-version=20161003
+version=20161206
 revision=1
 noarch="yes"
-_githash=3dfd3e923e661c1bdd95ecacc04394c3e35d119e
+_githash=8aaee12142a4e78511e2aa9a1f65f90b38384429
 wrksrc="noto-fonts-${_githash}"
 depends="font-util"
-font_dirs="/usr/share/fonts/TTF"
-short_desc="TrueType fonts from Google Noto project"
+font_dirs="/usr/share/fonts/noto"
+short_desc="Google Noto TTF Fonts"
 maintainer="Peter Bui <pnutzh4x0r@gmail.com>"
 license="OFL-1.1"
 homepage="https://www.google.com/get/noto/"
 distfiles="https://github.com/googlei18n/noto-fonts/archive/${_githash}.tar.gz"
-checksum=02075aaee1f83c876f0d9ef66563218be9871980e642aaf3beb037bee22005d2
+checksum=6d773c43d0f86ea6e140acd7b0b78cc16c689607b2e3ea2860986143b181210b
 conflicts="google-fonts-ttf>=0"
 
 do_install() {
-	vmkdir usr/share/fonts/TTF
-	install -m644 hinted/Noto*.ttf ${DESTDIR}/usr/share/fonts/TTF
+	vmkdir usr/share/fonts/noto
+	install -m644 hinted/Noto*.ttf ${DESTDIR}/usr/share/fonts/noto
 }


### PR DESCRIPTION
This updates noto-fonts-ttf to the latest commit, adds the complementary Noto CJK and Noto Emoji fonts as separate packages, and places all of the Noto fonts into `/usr/share/fonts/noto` folder (mimicking the Cantarell font package).

The source tarball for the Noto CJK fonts is huge (750MB), but the final xbps package comes out to (75MB).  I'd understand if we did not want to put a big file like this in the repository.