### PR TITLE
neofetch: update to 2.0.2

### DIFF
--- a/srcpkgs/neofetch/template
+++ b/srcpkgs/neofetch/template
@@ -1,6 +1,6 @@
 # Template file for 'neofetch'
 pkgname=neofetch
-version=2.0
+version=2.0.2
 revision=1
 noarch=yes
 build_style=gnu-makefile
@@ -10,7 +10,7 @@ maintainer="Muhammad Herdiansyah <herdiansyah@opmbx.org>"
 homepage="https://github.com/dylanaraps/neofetch"
 license="MIT"
 distfiles="${homepage}/archive/${version}/${pkgname}-${version}.tar.gz"
-checksum=27c208311d5aef8031987b689e3ba3f7663e5487273fa05698132a10a6ef4a48
+checksum=25a174ed41720d7645240cce4ca24f6228097a0daae3afd42563bfcf01584bc9
 
 post_install() {
 	vlicense LICENSE.md


### PR DESCRIPTION
Turns out when you closed a PR you can't reopen it if you force-push it..