### PR TITLE
wps-office: refactor and update

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2718,6 +2718,8 @@ libgnome-autoar-gtk-0.so.0 gnome-autoar-0.1.1_1
 libxapp.so.1 xapps-1.0.2_1
 libite.so.3 libite-1.8.2_1
 liblog4cplus-1.2.so.5 log4cplus-1.2.0_1
+libpng12.so.0 libpng12-1.2.56_2
+libpng.so.3 libpng12-1.2.56_2
 libcapnp-0.5.3.so capnproto-0.5.3_1
 libcapnp-rpc-0.5.3.so capnproto-0.5.3_1
 libcapnpc-0.5.3.so capnproto-0.5.3_1

--- a/srcpkgs/wps-office/template
+++ b/srcpkgs/wps-office/template
@@ -2,20 +2,17 @@
 _numericVersion=10.1.0.5672
 _releaseIncrement=a21
 _patchLevel=
-_libpngVersion=1.2.56
 
 pkgname=wps-office
 version=${_numericVersion}${_releaseIncrement}
-revision=1
+revision=2
 maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
 homepage="http://wps-community.org"
-license="Kingsoft WPS Community License; zlib"
+license="Kingsoft WPS Community License"
 #Full license is at: http://wps-community.org/license.md (Not downloadable)
 short_desc="Linux office suite with similar appearance to MS Office"
 allow_unknown_shlibs=yes
 nodebug=yes
-hostmakedepends="rsync"
-makedepends="zlib-devel"
 restricted=yes
 nopie=yes
 
@@ -32,32 +29,13 @@ fi
 
 _distTar="${pkgname}_${_numericVersion}~${_releaseIncrement}${_patchLevel}_${_arch}.tar.xz"
 distfiles="${_disturl}/${_distTar}"
-distfiles+=" ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng12/libpng-${_libpngVersion}.tar.xz"
-
-checksum+=" 24ce54581468b937734a6ecc86f7e121bc46a90d76a0d948dca08f32ee000dbe"
 
 do_extract() {
 	vmkdir "opt/kingsoft/wps-office"
 	tar xvf "${XBPS_SRCDISTDIR}/${pkgname}-${version}/${_distTar}" -C "${DESTDIR}/opt/kingsoft/wps-office" --strip-components=1
-
-	# extract libpng
-	tar xvf "${XBPS_SRCDISTDIR}/${pkgname}-${version}/libpng-${_libpngVersion}.tar.xz" --strip-components=1
-}
-
-do_configure() {
-	# This is only for the included libpng
-	./configure --prefix=${DESTDIR}/usr
-}
-
-do_build() {
-	# This is only for the included libpng
-	make
 }
 
 do_install() {
-	# Install the included libpng
-	make install
-
 	# Install the wps-office suites
 	vmkdir usr/bin
 	vmkdir usr/share


### PR DESCRIPTION
Update wps-office to use the packaged libpng instead of the builtin one.