### PR TITLE
Preparatory work for monodevelop

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2788,3 +2788,8 @@ libmutter-cogl-path.so mutter-3.22.0_1
 libmutter-cogl.so mutter-3.22.0_1
 libgeoclue-2.so.0 geoclue2-2.4.4_1
 libgepub.so.0 libgepub-0.4_1
+libmono-profiler-gui-thread-check.so.0 gtk-sharp-3.20.4_1
+libatksharpglue-3.so gtk-sharp-3.20.4_1
+libgtksharpglue-3.so gtk-sharp-3.20.4_1
+libgiosharpglue-3.so gtk-sharp-3.20.4_1
+libpangosharpglue-3.so gtk-sharp-3.20.4_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -2793,3 +2793,9 @@ libatksharpglue-3.so gtk-sharp-3.20.4_1
 libgtksharpglue-3.so gtk-sharp-3.20.4_1
 libgiosharpglue-3.so gtk-sharp-3.20.4_1
 libpangosharpglue-3.so gtk-sharp-3.20.4_1
+libpangosharpglue-2.so gtk-sharp2-2.12.42_1
+libatksharpglue-2.so gtk-sharp2-2.12.42_1
+libgladesharpglue-2.so gtk-sharp2-2.12.42_1
+libglibsharpglue-2.so gtk-sharp2-2.12.42_1
+libgtksharpglue-2.so gtk-sharp2-2.12.42_1
+libgdksharpglue-2.so gtk-sharp2-2.12.42_1

--- a/srcpkgs/fsharp/template
+++ b/srcpkgs/fsharp/template
@@ -1,0 +1,26 @@
+# Template file for 'fsharp'
+pkgname=fsharp
+version=4.0.1.20
+revision=1
+only_for_archs="x86_64 i686"
+lib32disabled=yes
+build_style=gnu-configure
+hostmakedepends="autoconf automake pkg-config"
+makedepends="mono"
+depends="mono"
+short_desc="F# compiler, core library and tools"
+maintainer="Simon THOBY <simonthoby@live.fr>"
+license="Apache-2.0"
+homepage="http://fsharp.org"
+distfiles="https://github.com/fsharp/fsharp/archive/4.0.1.20.tar.gz"
+checksum=380fe581d1ad99e32c8dc5974c764d90681f31dcbb1c67eb43870f524a9d0209
+
+# build seems broken so far on musl
+case "$XBPS_TARGET_MACHINE" in
+	*-musl) broken="https://s3.amazonaws.com/archive.travis-ci.org/jobs/184828977/log.txt"
+esac
+
+# I'm afraid fsharp uses the Internet to fetch NuGet packages during the build process.
+pre_configure() {
+	./autogen.sh
+}

--- a/srcpkgs/gtk-sharp/template
+++ b/srcpkgs/gtk-sharp/template
@@ -1,16 +1,21 @@
 # Template file for 'gtk-sharp'
 pkgname=gtk-sharp
-version=2.99.3
+version=3.20.4
 revision=1
 only_for_archs="i686 x86_64"
 lib32disabled=yes
+wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=gnu-configure
 configure_args="--disable-static"
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config autoconf automake libtool"
 makedepends="mono gtk+3-devel libglade-devel"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.mono-project.com/GtkSharp"
 license="LGPL-2.1"
 short_desc="Graphical User Interface Toolkit for mono and .Net (Gtk#)"
-distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=6440f571416267ae0cb5698071d087b31e3084693fa2c829b1db37ca7ea2c3a2
+distfiles="https://github.com/openmedicus/${pkgname}/archive/${pkgname}-${version}.tar.gz"
+checksum=8b52da8784a240f451414b5f8d6a13becd89a0be6cadf2eedbe395e6908dbb74
+
+pre_configure() {
+	./autogen.sh
+}

--- a/srcpkgs/gtk-sharp2/template
+++ b/srcpkgs/gtk-sharp2/template
@@ -1,0 +1,16 @@
+# Template file for 'gtk-sharp2'
+pkgname=gtk-sharp2
+version=2.12.42
+revision=1
+only_for_archs="x86_64 i686"
+build_style=gnu-configure
+wrksrc="gtk-sharp-${version}"
+configure_args="--disable-static"
+hostmakedepends="pkg-config"
+makedepends="mono gtk+-devel libglade-devel"
+maintainer="Simon THOBY <simonthoby@live.fr>"
+homepage="http://www.mono-project.com/GtkSharp"
+license="LGPL-2.1"
+short_desc="Graphical User Interface Toolkit for mono and .Net (Gtk#)"
+distfiles="http://download.mono-project.com/sources/gtk-sharp212/gtk-sharp-${version}.tar.gz"
+checksum=f3b009bb73e3251378063b6f09786609cd4c061f3f8bf552f0ea663245c045c9

--- a/srcpkgs/referenceassemblies-pcl/template
+++ b/srcpkgs/referenceassemblies-pcl/template
@@ -1,0 +1,26 @@
+# Template file for 'referenceassemblies-pcl'
+pkgname=referenceassemblies-pcl
+version=2014.04.14
+revision=1
+repository=nonfree
+wrksrc="PortableReferenceAssemblies-2014-04-14"
+hostmakedepends="wget"
+short_desc=".NET Portable Class Library Reference Assemblies installation"
+maintainer="Simon THOBY <simonthoby@live.fr>"
+license="EULA"
+homepage="https://msdn.microsoft.com/library/gg597391.aspx"
+distfiles="http://download.mono-project.com/repo/debian/pool/main/r/referenceassemblies-pcl/referenceassemblies-pcl_2014.04.14.orig.tar.bz2"
+checksum="f88305669a05657dbce32d5011d6d6d8d24f0dae925e6dac04905fecd6de0530"
+
+pre_configure() {
+	wget https://github.com/directhex/xamarin-referenceassemblies-pcl/blob/centos/EULA.rtf
+}
+
+do_install() {
+	vmkdir usr/lib/mono/xbuild-frameworks/.NETPortable
+	vcopy v4.* usr/lib/mono/xbuild-frameworks/.NETPortable/
+}
+
+pre_install() {
+	vlicense ${wrksrc}/EULA.rtf
+}


### PR DESCRIPTION
All courtesy for mono update goes to @Hoshpak (cf. https://github.com/voidlinux/void-packages/pull/5070).
This is just a minor update (because #5070 was closed and not merged). Most explanations for the first commit are given at #5070.
All of this is just some prep work to add monodevelop.