### PR TITLE
adobe-flash-plugin: update to 24.0.0.186

### DIFF
--- a/srcpkgs/adobe-flash-plugin/template
+++ b/srcpkgs/adobe-flash-plugin/template
@@ -1,17 +1,17 @@
 # Template file for 'adobe-flash-plugin'
 pkgname=adobe-flash-plugin
-version=11.2.202.644
+version=24.0.0.186
 revision=1
 # The EULA file
 _eula="http://www.adobe.com/products/eulas/pdfs/PlatformClients_PC_WWEULA_Combined_20100108_1657.pdf"
 _eulacksum=3cb0a5f4576be735abcff7189ed18eda17c70b762c3a78a3379b6f44395fbc10
 _url=http://fpdownload.adobe.com/get/flashplayer/pdc/${version}
 if [ "$XBPS_MACHINE" = "x86_64" ]; then
-	_disttarball="${_url}/install_flash_player_11_linux.x86_64.tar.gz"
-	_distcksum=ad2f70c3f1ba41636445de5e4f1243e38fc469288600cdb4ee26765ee391462d
+	_disttarball="${_url}/flash_player_npapi_linux.x86_64.tar.gz"
+	_distcksum=c721b59102d12597a8592f0e8d2fb3d65ccda33d8e499435fe02871b46874663
 else
-	_disttarball="${_url}/install_flash_player_11_linux.i386.tar.gz"
-	_distcksum=63ca6e1ad1e1b39ae6e35265b628a818dfc4544b1aa857b8a8365d056779f297
+	_disttarball="${_url}/flash_player_npapi_linux.i386.tar.gz"
+	_distcksum=3b5803388f31940484c1020db4c5533aa48cfccab3880eb55a6f25610eb691fd
 fi
 distfiles="${_eula} ${_disttarball}"
 checksum="${_eulacksum} ${_distcksum}"


### PR DESCRIPTION
Provides npapi plugin for mozilla browsers.