### PR TITLE
terraform: update to version 0.8.1

### DIFF
--- a/srcpkgs/terraform/template
+++ b/srcpkgs/terraform/template
@@ -1,6 +1,6 @@
 # Template file for 'terraform'
 pkgname=terraform
-version=0.8.0
+version=0.8.1
 revision=1
 build_style=go
 short_desc="A tool for building, changing, and combining infrastructure"
@@ -9,7 +9,7 @@ license="MPL-2.1"
 homepage="https://www.terraform.io/"
 go_import_path="github.com/hashicorp/$pkgname"
 distfiles="https://$go_import_path/archive/v$version.tar.gz"
-checksum=09e549b51b720aef0b3e869edeaf65f32758f159b1d3ffe2fcadd560a7b0c569
+checksum=927b4909a64b8550376e87c737eab0f34a0895f2700fa8bc81de339f4a7ffe20
 
 post_build() {
 	for F in $(find -type f -name main.go); do
@@ -23,8 +23,6 @@ do_install() {
 	do
 		if [ "$(basename $line)" = terraform ]; then
 			vbin $line
-		else
-			vbin $line terraform-$(basename $line)
 		fi
 	done
 }


### PR DESCRIPTION
Since version 0.7 Terraform comes with plugins built in. See
https://www.terraform.io/docs/internals/internal-plugins.html

This change also removes the `terraform-` executables from the path,
and stops Terraform from warning about overridden plugins