### PR TITLE
salt: fix runit support as grain 'init'

### DIFF
--- a/srcpkgs/salt/patches/fix-grain-init-runit-2016.11.0.patch
+++ b/srcpkgs/salt/patches/fix-grain-init-runit-2016.11.0.patch
@@ -1,0 +1,22 @@
+fix runit support as init grain.
+See https://github.com/saltstack/salt/pull/38326
+--- salt/grains/core.py
++++ salt/grains/core.py
+@@ -1256,7 +1256,7 @@ def os_data():
+                     init_cmdline = fhr.read().replace('\x00', ' ').split()
+                     init_bin = salt.utils.which(init_cmdline[0])
+                     if init_bin is not None and init_bin.endswith('bin/init'):
+-                        supported_inits = (six.b('upstart'), six.b('sysvinit'), six.b('systemd'), six.b('runit'))
++                        supported_inits = (six.b('upstart'), six.b('sysvinit'), six.b('systemd'))
+                         edge_len = max(len(x) for x in supported_inits) - 1
+                         try:
+                             buf_size = __opts__['file_buffer_size']
+@@ -1286,6 +1286,8 @@ def os_data():
+                             )
+                     elif salt.utils.which('supervisord') in init_cmdline:
+                         grains['init'] = 'supervisord'
++                    elif init_cmdline == ['runit']:
++                        grains['init'] = 'runit'
+                     else:
+                         log.info(
+                             'Could not determine init system from command line: ({0})'

--- a/srcpkgs/salt/template
+++ b/srcpkgs/salt/template
@@ -1,7 +1,7 @@
 # Template file for 'salt'
 pkgname=salt
 version=2016.11.0
-revision=1
+revision=2
 build_style=python2-module
 noarch=yes
 pycompile_module="salt"


### PR DESCRIPTION
.. while waiting fix in next salt 2016.11.x release.  
See PR  https://github.com/saltstack/salt/pull/38326 for more details
