### PR TITLE
lutris: update to 0.4.4.1.

### DIFF
--- a/srcpkgs/lutris/template
+++ b/srcpkgs/lutris/template
@@ -1,16 +1,15 @@
 # Template file for 'Lutris'
 pkgname=lutris
-version=0.4.3
+version=0.4.4.1
 revision=1
 build_style=python3-module
 wrksrc="${pkgname}"
 pycompile_module="${pkgname}"
 hostmakedepends="python3-setuptools python3-gobject"
-depends="python3-dbus python3-gobject python3-xdg python3-yaml
- python3-inotify xrandr"
+depends="python3-dbus python3-gobject python3-yaml python3-inotify xrandr"
 short_desc="Open gaming platform for managing games in a unified way"
 maintainer="Jan Wey. <janwey.git@gmail.com>"
 license="GPL-3"
 homepage="https://lutris.net"
 distfiles="${homepage}/releases/${pkgname}_${version}.tar.xz"
-checksum=e200235965d484027ff297acdb0b4534087ab71035a8da913d9ef01a95c1476b
+checksum=203d24fdbb2f40e02e95e8f7b9c27701b8bfd9d25909ea149d702a18477b8485


### PR DESCRIPTION
Removed `python3-xdg` from runtime dependencies.
See [here](https://github.com/lutris/lutris/blob/master/debian/changelog):
>  * Remove dependencies to python3-xdg and xdg-user-dirs