### PR TITLE
gcc: update to 6.3.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -56,7 +56,7 @@ libitm.so.1 libitm-4.7.3_1
 libgcj_bc.so.1 libgcj-4.7.3_1
 liblto_plugin.so.0 gcc-4.7.3_1
 libgcc_s.so.1 libgcc-4.4.0_1
-libgcj.so.17 libgcj-6.2.0_1
+libgcj.so.17 libgcj-6.3.0_1
 libgcj-tools.so.17 libgcj-6.2.1_1
 libgij.so.17 libgcj-6.2.1_1
 libgo.so.9 libgo-6.2.1_1
@@ -1657,12 +1657,12 @@ libmitlm.so.0 mitlm-0.4.1_1
 libextractor.so.3 libextractor-1.1_1
 libextractor_common.so.1 libextractor-1.1_1
 libpano13.so.3 libpano13-2.9.19_1
-libubsan.so.0 libsanitizer-4.9.0_1
-libtsan.so.0 libsanitizer-4.9.0_1
-libasan.so.3 libsanitizer-6.2.0_1
-liblsan.so.0 libsanitizer-4.9.0_1
-libcilkrts.so.5 libcilkrts-4.9.0_1
-libvtv.so.0 libvtv-4.9.0_1
+libubsan.so.0 libsanitizer-6.3.0_1
+libtsan.so.0 libsanitizer-6.3.0_1
+libasan.so.3 libsanitizer-6.3.0_1
+liblsan.so.0 libsanitizer-6.3.0_1
+libcilkrts.so.5 libcilkrts-6.3.0_1
+libvtv.so.0 libvtv-6.3.0_1
 libatomic.so.1 libatomic-4.9.0_1
 libpcsclite.so.1 libpcsclite-1.8.11_1
 libpcscspy.so.0 libpcsclite-1.8.11_1

--- a/srcpkgs/avr-gcc/template
+++ b/srcpkgs/avr-gcc/template
@@ -1,13 +1,13 @@
 # Template build file for 'avr-gcc'
 pkgname=avr-gcc
-version=6.2.1
+version=6.3.0
 revision=1
 short_desc="The GNU C Compiler for AVR"
 maintainer="allan <mail@may.mooo.com>"
 homepage="http://gcc.gnu.org"
 license="GFDL-1.2, GPL-3, LGPL-2.1"
-distfiles="https://repo.voidlinux.eu/distfiles/gcc-$version.tar.xz"
-checksum=a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+distfiles="${GNU_SITE}/gcc/gcc-${version}/gcc-${version}.tar.bz2"
+checksum=f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
 wrksrc="gcc-$version"
 
 hostmakedepends="flex avr-binutils"

--- a/srcpkgs/ccache/template
+++ b/srcpkgs/ccache/template
@@ -1,7 +1,7 @@
 # Template file for 'ccache'
 pkgname=ccache
 version=3.3.3
-revision=2
+revision=3
 bootstrap=yes
 build_style=gnu-configure
 makedepends="zlib-devel"
@@ -18,7 +18,8 @@ post_install() {
 		ln -sfr ${DESTDIR}/usr/bin/ccache ${DESTDIR}/usr/lib/ccache/bin/${f}
 		for x in arm-linux-gnueabi arm-linux-gnueabihf armv7l-linux-gnueabihf \
 			arm-linux-musleabihf armv7l-linux-musleabihf aarch64-linux-gnu \
-			aarch64-linux-musl; do
+			aarch64-linux-musl i686-linux-musl
+			mips-linux-musl mipsel-linux-musl mipsel-linux-muslhf; do
 			ln -sfr ${DESTDIR}/usr/bin/ccache ${DESTDIR}/usr/lib/ccache/bin/${x}-${f}
 		done
 	done

--- a/srcpkgs/cross-aarch64-linux-gnu/template
+++ b/srcpkgs/cross-aarch64-linux-gnu/template
@@ -1,7 +1,7 @@
 # Template build file for 'cross-aarch64-linux-gnu'
 #
 _binutils_version=2.27
-_gcc_version=6.2.1
+_gcc_version=6.3.0
 _glibc_version=2.24
 _linux_version=4.1.34
 
@@ -11,19 +11,19 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=1
+revision=2
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
 homepage="http://www.voidlinux.eu"
 license="GPL-3, GPL-2, LGPL-2.1"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
- https://repo.voidlinux.eu/distfiles/gcc-$_gcc_version.tar.xz
+ ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.bz2
  ${GNU_SITE}/glibc/glibc-${_glibc_version}.tar.xz
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
- a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+ f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  99d4a3e8efd144d71488e478f62587578c0f4e1fa0b4eed47ee3d4975ebeb5d3
  412316b32b5c7a513ba3ab8e68fc443db4d9423f07b577473089def0ee7406af"
 

--- a/srcpkgs/cross-aarch64-linux-musl/files/gcc-6.3.0-musl.diff
+++ b/srcpkgs/cross-aarch64-linux-musl/files/gcc-6.3.0-musl.diff
@@ -1,0 +1,1 @@
+../../gcc/files/gcc-6.3.0-musl.diff

--- a/srcpkgs/cross-aarch64-linux-musl/template
+++ b/srcpkgs/cross-aarch64-linux-musl/template
@@ -1,7 +1,7 @@
 # Template build file for 'cross-aarch64-linux-musl'
 #
 _binutils_version=2.27
-_gcc_version=6.2.1
+_gcc_version=6.3.0
 _musl_version=1.1.15
 _linux_version=4.1.34
 
@@ -11,19 +11,19 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=1
+revision=2
 short_desc="Cross toolchain for ARM64 LE target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
 license="GPL-3, GPL-2, MIT"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
- https://repo.voidlinux.eu/distfiles/gcc-$_gcc_version.tar.xz
+ ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.bz2
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
  http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
- a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+ f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  412316b32b5c7a513ba3ab8e68fc443db4d9423f07b577473089def0ee7406af
  97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
 
@@ -79,7 +79,7 @@ _gcc_bootstrap() {
 	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
 
 	cd ${wrksrc}/gcc-${_gcc_version}
-	_apply_patch -p1 ${FILESDIR}/gcc-6.2.1-musl.diff
+	_apply_patch -p1 ${FILESDIR}/gcc-6.3.0-musl.diff
 	_apply_patch -p0 ${FILESDIR}/libcpp-source_date_epoch.patch
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
 

--- a/srcpkgs/cross-arm-linux-gnueabi/template
+++ b/srcpkgs/cross-arm-linux-gnueabi/template
@@ -1,7 +1,7 @@
 # Template build file for 'cross-arm-linux-gnueabi'
 #
 _binutils_version=2.27
-_gcc_version=6.2.1
+_gcc_version=6.3.0
 _glibc_version=2.24
 _linux_version=4.1.34
 
@@ -12,19 +12,19 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=1
+revision=2
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
 license="GPL-3, GPL-2, LGPL-2.1"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
- https://repo.voidlinux.eu/distfiles/gcc-$_gcc_version.tar.xz
+ ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.bz2
  ${GNU_SITE}/glibc/glibc-${_glibc_version}.tar.xz
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
- a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+ f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  99d4a3e8efd144d71488e478f62587578c0f4e1fa0b4eed47ee3d4975ebeb5d3
  412316b32b5c7a513ba3ab8e68fc443db4d9423f07b577473089def0ee7406af"
 

--- a/srcpkgs/cross-arm-linux-gnueabihf/template
+++ b/srcpkgs/cross-arm-linux-gnueabihf/template
@@ -1,7 +1,7 @@
 # Template build file for 'cross-arm-linux-gnueabihf'
 #
 _binutils_version=2.27
-_gcc_version=6.2.1
+_gcc_version=6.3.0
 _glibc_version=2.24
 _linux_version=4.1.34
 
@@ -12,19 +12,19 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=1
+revision=2
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
 license="Public Domain"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
- https://repo.voidlinux.eu/distfiles/gcc-$_gcc_version.tar.xz
+ ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.bz2
  ${GNU_SITE}/glibc/glibc-${_glibc_version}.tar.xz
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
- a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+ f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  99d4a3e8efd144d71488e478f62587578c0f4e1fa0b4eed47ee3d4975ebeb5d3
  412316b32b5c7a513ba3ab8e68fc443db4d9423f07b577473089def0ee7406af"
 

--- a/srcpkgs/cross-arm-linux-musleabi/files/gcc-6.3.0-musl.diff
+++ b/srcpkgs/cross-arm-linux-musleabi/files/gcc-6.3.0-musl.diff
@@ -1,0 +1,1 @@
+../../gcc/files/gcc-6.3.0-musl.diff

--- a/srcpkgs/cross-arm-linux-musleabi/template
+++ b/srcpkgs/cross-arm-linux-musleabi/template
@@ -1,7 +1,7 @@
 # Template build file for 'cross-arm-linux-musleabi'
 #
 _binutils_version=2.27
-_gcc_version=6.2.1
+_gcc_version=6.3.0
 _musl_version=1.1.15
 _linux_version=4.1.34
 
@@ -12,19 +12,19 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=1
+revision=2
 short_desc="Cross toolchain for ARMv5 TE target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
 license="GPL-3, GPL-2, MIT"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
- https://repo.voidlinux.eu/distfiles/gcc-$_gcc_version.tar.xz
+ ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.bz2
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
  http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
- a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+ f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  412316b32b5c7a513ba3ab8e68fc443db4d9423f07b577473089def0ee7406af
  97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
 
@@ -82,7 +82,7 @@ _gcc_bootstrap() {
 	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
 
 	cd ${wrksrc}/gcc-${_gcc_version}
-	_apply_patch -p1 ${FILESDIR}/gcc-6.2.1-musl.diff
+	_apply_patch -p1 ${FILESDIR}/gcc-6.3.0-musl.diff
 	_apply_patch -p0 ${FILESDIR}/libcpp-source_date_epoch.patch
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
 

--- a/srcpkgs/cross-arm-linux-musleabihf/files/gcc-6.3.0-musl.diff
+++ b/srcpkgs/cross-arm-linux-musleabihf/files/gcc-6.3.0-musl.diff
@@ -1,0 +1,1 @@
+../../gcc/files/gcc-6.3.0-musl.diff

--- a/srcpkgs/cross-arm-linux-musleabihf/template
+++ b/srcpkgs/cross-arm-linux-musleabihf/template
@@ -1,7 +1,7 @@
 # Template build file for 'cross-arm-linux-musleabihf'
 #
 _binutils_version=2.27
-_gcc_version=6.2.1
+_gcc_version=6.3.0
 _musl_version=1.1.15
 _linux_version=4.1.34
 
@@ -12,19 +12,19 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=1
+revision=2
 short_desc="Cross toolchain for ARMv6 LE Hard Float target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
 license="GPL-3, GPL-2, MIT"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
- https://repo.voidlinux.eu/distfiles/gcc-$_gcc_version.tar.xz
+ ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.bz2
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
  http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
- a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+ f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  412316b32b5c7a513ba3ab8e68fc443db4d9423f07b577473089def0ee7406af
  97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
 
@@ -82,7 +82,7 @@ _gcc_bootstrap() {
 	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
 
 	cd ${wrksrc}/gcc-${_gcc_version}
-	_apply_patch -p1 ${FILESDIR}/gcc-6.2.1-musl.diff
+	_apply_patch -p1 ${FILESDIR}/gcc-6.3.0-musl.diff
 	_apply_patch -p0 ${FILESDIR}/libcpp-source_date_epoch.patch
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
 

--- a/srcpkgs/cross-armv7l-linux-gnueabihf/template
+++ b/srcpkgs/cross-armv7l-linux-gnueabihf/template
@@ -1,7 +1,7 @@
 # Template build file for 'cross-armv7l-linux-gnueabihf'
 #
 _binutils_version=2.27
-_gcc_version=6.2.1
+_gcc_version=6.3.0
 _glibc_version=2.24
 _linux_version=4.1.34
 
@@ -12,19 +12,19 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=1
+revision=2
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
 license="GPL-3,GPL-2,LGPL-2.1"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
- https://repo.voidlinux.eu/distfiles/gcc-$_gcc_version.tar.xz
+ ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.bz2
  http://ftp.gnu.org/gnu/glibc/glibc-${_glibc_version}.tar.xz
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
- a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+ f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  99d4a3e8efd144d71488e478f62587578c0f4e1fa0b4eed47ee3d4975ebeb5d3
  412316b32b5c7a513ba3ab8e68fc443db4d9423f07b577473089def0ee7406af"
 

--- a/srcpkgs/cross-armv7l-linux-musleabihf/files/gcc-6.3.0-musl.diff
+++ b/srcpkgs/cross-armv7l-linux-musleabihf/files/gcc-6.3.0-musl.diff
@@ -1,0 +1,1 @@
+../../gcc/files/gcc-6.3.0-musl.diff

--- a/srcpkgs/cross-armv7l-linux-musleabihf/template
+++ b/srcpkgs/cross-armv7l-linux-musleabihf/template
@@ -1,7 +1,7 @@
 # Template build file for 'cross-armv7l-linux-musleabihf'
 #
 _binutils_version=2.27
-_gcc_version=6.2.1
+_gcc_version=6.3.0
 _musl_version=1.1.15
 _linux_version=4.1.34
 
@@ -12,19 +12,19 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=1
+revision=2
 short_desc="Cross toolchain for ARMv7 LE Hard Float target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
 license="GPL-3, GPL-2, MIT"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
- https://repo.voidlinux.eu/distfiles/gcc-$_gcc_version.tar.xz
+ ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.bz2
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
  http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
- a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+ f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  412316b32b5c7a513ba3ab8e68fc443db4d9423f07b577473089def0ee7406af
  97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
 
@@ -82,7 +82,7 @@ _gcc_bootstrap() {
 	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
 
 	cd ${wrksrc}/gcc-${_gcc_version}
-	_apply_patch -p1 ${FILESDIR}/gcc-6.2.1-musl.diff
+	_apply_patch -p1 ${FILESDIR}/gcc-6.3.0-musl.diff
 	_apply_patch -p0 ${FILESDIR}/libcpp-source_date_epoch.patch
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
 

--- a/srcpkgs/cross-i686-linux-musl/files/gcc-6.3.0-musl.diff
+++ b/srcpkgs/cross-i686-linux-musl/files/gcc-6.3.0-musl.diff
@@ -1,0 +1,1 @@
+../../gcc/files/gcc-6.3.0-musl.diff

--- a/srcpkgs/cross-i686-linux-musl/template
+++ b/srcpkgs/cross-i686-linux-musl/template
@@ -1,7 +1,7 @@
 # Template build file for 'cross-i686-linux-musl'
 #
 _binutils_version=2.27
-_gcc_version=6.2.1
+_gcc_version=6.3.0
 _musl_version=1.1.15
 _linux_version=4.1.34
 
@@ -11,19 +11,19 @@ _archflags="-march=i686"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=1
+revision=2
 short_desc="Cross toolchain for i686 target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
 license="GPL-3, GPL-2, MIT"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
- https://repo.voidlinux.eu/distfiles/gcc-$_gcc_version.tar.xz
+ ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.bz2
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
  http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
- a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+ f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  412316b32b5c7a513ba3ab8e68fc443db4d9423f07b577473089def0ee7406af
  97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
 
@@ -81,7 +81,7 @@ _gcc_bootstrap() {
 	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
 
 	cd ${wrksrc}/gcc-${_gcc_version}
-	_apply_patch -p1 ${FILESDIR}/gcc-6.2.1-musl.diff
+	_apply_patch -p1 ${FILESDIR}/gcc-6.3.0-musl.diff
 	_apply_patch -p0 ${FILESDIR}/libcpp-source_date_epoch.patch
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
 

--- a/srcpkgs/cross-i686-pc-linux-gnu/template
+++ b/srcpkgs/cross-i686-pc-linux-gnu/template
@@ -1,7 +1,7 @@
 # Template build file for 'cross-i686-pc-linux-gnu'
 #
 _binutils_version=2.27
-_gcc_version=6.2.1
+_gcc_version=6.3.0
 _glibc_version=2.24
 _linux_version=4.1.34
 
@@ -11,19 +11,19 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=1
+revision=2
 short_desc="GNU Cross toolchain for the ${_triplet} target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
 license="GPL-3, GPL-2, LGPL-2.1"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
- https://repo.voidlinux.eu/distfiles/gcc-$_gcc_version.tar.xz
+ ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.bz2
  ${GNU_SITE}/glibc/glibc-${_glibc_version}.tar.xz
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
- a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+ f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  99d4a3e8efd144d71488e478f62587578c0f4e1fa0b4eed47ee3d4975ebeb5d3
  412316b32b5c7a513ba3ab8e68fc443db4d9423f07b577473089def0ee7406af"
 

--- a/srcpkgs/cross-mips-linux-musl/files/gcc-6.3.0-musl.diff
+++ b/srcpkgs/cross-mips-linux-musl/files/gcc-6.3.0-musl.diff
@@ -1,0 +1,1 @@
+../../gcc/files/gcc-6.3.0-musl.diff

--- a/srcpkgs/cross-mips-linux-musl/template
+++ b/srcpkgs/cross-mips-linux-musl/template
@@ -1,7 +1,7 @@
 # Template build file for 'cross-mips-linux-musl'
 #
 _binutils_version=2.27
-_gcc_version=6.2.1
+_gcc_version=6.3.0
 _musl_version=1.1.15
 _linux_version=4.1.34
 
@@ -12,19 +12,19 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=1
+revision=2
 short_desc="Cross toolchain for MIPS32r2 BE softfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
 license="GPL-3, GPL-2, MIT"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
- https://repo.voidlinux.eu/distfiles/gcc-$_gcc_version.tar.xz
+ ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.bz2
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
  http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
- a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+ f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  412316b32b5c7a513ba3ab8e68fc443db4d9423f07b577473089def0ee7406af
  97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
 
@@ -82,7 +82,7 @@ _gcc_bootstrap() {
 	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
 
 	cd ${wrksrc}/gcc-${_gcc_version}
-	_apply_patch -p1 ${FILESDIR}/gcc-6.2.1-musl.diff
+	_apply_patch -p1 ${FILESDIR}/gcc-6.3.0-musl.diff
 	_apply_patch -p0 ${FILESDIR}/libcpp-source_date_epoch.patch
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
 

--- a/srcpkgs/cross-mipsel-linux-musl/files/gcc-6.3.0-musl.diff
+++ b/srcpkgs/cross-mipsel-linux-musl/files/gcc-6.3.0-musl.diff
@@ -1,0 +1,1 @@
+../../gcc/files/gcc-6.3.0-musl.diff

--- a/srcpkgs/cross-mipsel-linux-musl/template
+++ b/srcpkgs/cross-mipsel-linux-musl/template
@@ -1,7 +1,7 @@
 # Template build file for 'cross-mipsel-linux-musl'
 #
 _binutils_version=2.27
-_gcc_version=6.2.1
+_gcc_version=6.3.0
 _musl_version=1.1.15
 _linux_version=4.1.34
 
@@ -12,19 +12,19 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=1
+revision=2
 short_desc="Cross toolchain for MIPS32r2 LE softfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
 license="GPL-3, GPL-2, MIT"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
- https://repo.voidlinux.eu/distfiles/gcc-$_gcc_version.tar.xz
+ ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.bz2
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
  http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
- a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+ f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  412316b32b5c7a513ba3ab8e68fc443db4d9423f07b577473089def0ee7406af
  97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
 
@@ -82,7 +82,7 @@ _gcc_bootstrap() {
 	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
 
 	cd ${wrksrc}/gcc-${_gcc_version}
-	_apply_patch -p1 ${FILESDIR}/gcc-6.2.1-musl.diff
+	_apply_patch -p1 ${FILESDIR}/gcc-6.3.0-musl.diff
 	_apply_patch -p0 ${FILESDIR}/libcpp-source_date_epoch.patch
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
 

--- a/srcpkgs/cross-mipsel-linux-muslhf/files/gcc-6.3.0-musl.diff
+++ b/srcpkgs/cross-mipsel-linux-muslhf/files/gcc-6.3.0-musl.diff
@@ -1,0 +1,1 @@
+../../gcc/files/gcc-6.3.0-musl.diff

--- a/srcpkgs/cross-mipsel-linux-muslhf/template
+++ b/srcpkgs/cross-mipsel-linux-muslhf/template
@@ -1,7 +1,7 @@
 # Template build file for 'cross-mipsel-linux-muslhf'
 #
 _binutils_version=2.27
-_gcc_version=6.2.1
+_gcc_version=6.3.0
 _musl_version=1.1.15
 _linux_version=4.1.34
 
@@ -12,19 +12,19 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=1
+revision=2
 short_desc="Cross toolchain for MIPS32r2 LE hardfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
 license="GPL-3, GPL-2, MIT"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
- https://repo.voidlinux.eu/distfiles/gcc-$_gcc_version.tar.xz
+ ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.bz2
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
  http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
- a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+ f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  412316b32b5c7a513ba3ab8e68fc443db4d9423f07b577473089def0ee7406af
  97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
 
@@ -82,7 +82,7 @@ _gcc_bootstrap() {
 	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
 
 	cd ${wrksrc}/gcc-${_gcc_version}
-	_apply_patch -p1 ${FILESDIR}/gcc-6.2.1-musl.diff
+	_apply_patch -p1 ${FILESDIR}/gcc-6.3.0-musl.diff
 	_apply_patch -p0 ${FILESDIR}/libcpp-source_date_epoch.patch
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
 

--- a/srcpkgs/cross-x86_64-linux-musl/files/gcc-6.3.0-musl.diff
+++ b/srcpkgs/cross-x86_64-linux-musl/files/gcc-6.3.0-musl.diff
@@ -1,0 +1,1 @@
+../../gcc/files/gcc-6.3.0-musl.diff

--- a/srcpkgs/cross-x86_64-linux-musl/template
+++ b/srcpkgs/cross-x86_64-linux-musl/template
@@ -1,7 +1,7 @@
 # Template build file for 'cross-x86_64-linux-musl'
 #
 _binutils_version=2.27
-_gcc_version=6.2.1
+_gcc_version=6.3.0
 _musl_version=1.1.15
 _linux_version=4.1.34
 
@@ -10,19 +10,19 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=1
+revision=2
 short_desc="Cross toolchain for x86_64 with musl"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
 license="GPL-3, GPL-2, MIT"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
- https://repo.voidlinux.eu/distfiles/gcc-$_gcc_version.tar.xz
+ ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.bz2
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
  http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
- a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+ f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  412316b32b5c7a513ba3ab8e68fc443db4d9423f07b577473089def0ee7406af
  97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
 
@@ -81,7 +81,7 @@ _gcc_bootstrap() {
 	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
 
 	cd ${wrksrc}/gcc-${_gcc_version}
-	_apply_patch -p1 ${FILESDIR}/gcc-6.2.1-musl.diff
+	_apply_patch -p1 ${FILESDIR}/gcc-6.3.0-musl.diff
 	_apply_patch -p0 ${FILESDIR}/libcpp-source_date_epoch.patch
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
 

--- a/srcpkgs/gcc-multilib/template
+++ b/srcpkgs/gcc-multilib/template
@@ -1,18 +1,18 @@
 # Template build file for 'gcc-multilib'
 only_for_archs="x86_64"
 _triplet="x86_64-unknown-linux-gnu"
-_majorver=6.2
+_majorver=6.3
 
 pkgname=gcc-multilib
-version=${_majorver}.1
-revision=2
+version=${_majorver}.0
+revision=1
 wrksrc="gcc-${version}"
 short_desc="The GNU C Compiler (multilib files)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://gcc.gnu.org"
 license="GFDL-1.2, GPL-3, LGPL-2.1"
-distfiles="https://repo.voidlinux.eu/distfiles/gcc-$version.tar.xz"
-checksum=a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+distfiles="${GNU_SITE}/gcc/gcc-${version}/gcc-${version}.tar.bz2"
+checksum=f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
 
 hostmakedepends="perl flex zip unzip"
 makedepends="zlib-devel libmpc-devel ppl-devel cloog-devel
@@ -36,10 +36,6 @@ do_configure() {
 
 	# _FORTIFY_SOURCE needs an optimization level.
 	sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" {gcc,libiberty}/configure
-	# As specified in the LFS book, disable installing libiberty.
-	sed -i 's/install_to_$(INSTALL_DEST) //' libiberty/Makefile.in
-	# Do not run fixincludes
-	sed -i 's@\./fixinc\.sh@-c true@' gcc/Makefile.in
 	# hack! some configure tests for header files using "$CPP $CPPFLAGS"
 	sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" {libiberty,gcc}/configure
 
@@ -50,8 +46,8 @@ do_configure() {
 		--disable-rpath --with-system-zlib --enable-shared --enable-lto \
 		--enable-linker-build-id --enable-gnu-unique-object \
 		--enable-checking=release --disable-libstdcxx-pch \
-		--with-ppl --enable-cloog-backend=isl --enable-libstdcxx-time \
-		--enable-tls --enable-languages="c,c++,lto" \
+		--disable-target-libiberty --with-ppl --enable-cloog-backend=isl \
+		--enable-libstdcxx-time --enable-tls --enable-languages="c,c++,lto" \
 		--with-linker-hash-style=gnu
 }
 

--- a/srcpkgs/gcc/files/gcc-6.3.0-musl.diff
+++ b/srcpkgs/gcc/files/gcc-6.3.0-musl.diff
@@ -19,7 +19,7 @@ diff -r 90a7a3809a7c libstdc++-v3/configure.host
      if [ "$uclibc" = "yes" ]; then
        os_include_dir="os/uclibc"
      elif [ "$bionic" = "yes" ]; then
-@@ -281,6 +281,9 @@
+@@ -274,6 +274,9 @@
        os_include_dir="os/gnu-linux"
      fi
      ;;
@@ -126,7 +126,7 @@ Support for powerpc-linux-musl.
 diff -r 971d41041173 gcc/config.gcc
 --- a/gcc/config.gcc	Fri Dec 25 08:44:09 2015 -0500
 +++ b/gcc/config.gcc	Fri Dec 25 09:42:16 2015 -0500
-@@ -2464,6 +2464,10 @@
+@@ -2475,6 +2475,10 @@
  	    powerpc*-*-linux*paired*)
  		tm_file="${tm_file} rs6000/750cl.h" ;;
  	esac
@@ -243,7 +243,7 @@ diff --git a/gcc/config/i386/i386.c b/gcc/config/i386/i386.c
 index 861a029..1c97d72 100644
 --- a/gcc/config/i386/i386.c
 +++ b/gcc/config/i386/i386.c
-@@ -40323,10 +40323,10 @@ ix86_expand_builtin (tree exp, rtx target, rtx subtarget,
+@@ -40497,10 +40497,10 @@ ix86_expand_builtin (tree exp, rtx target, rtx subtarget,
      {
      case IX86_BUILTIN_CPU_INIT:
        {
@@ -310,7 +310,7 @@ index 11bb46e..4f47f7b 100644
  /* It may still not be available in the library on the target system.   */
 --- a/boehm-gc/include/private/gcconfig.h
 +++ b/boehm-gc/include/private/gcconfig.h
-@@ -684,7 +684,7 @@
+@@ -696,7 +696,7 @@
  #       ifdef __ELF__
  #            define DYNAMIC_LOADING
  #	     include <features.h>
@@ -319,7 +319,7 @@ index 11bb46e..4f47f7b 100644
  #              define SEARCH_FOR_DATA_START
  #	     else /* !GLIBC2 */
                 extern char **__environ;
-@@ -1147,7 +1147,7 @@
+@@ -1167,7 +1167,7 @@
  #              define DATASTART ((ptr_t)((((word) (_etext)) + 0xfff) & ~0xfff))
  #	     endif
  #	     include <features.h>
@@ -328,7 +328,7 @@ index 11bb46e..4f47f7b 100644
  #		 define SEARCH_FOR_DATA_START
  #	     else
       	         extern char **__environ;
-@@ -1367,7 +1367,7 @@
+@@ -1387,7 +1387,7 @@
  #       define HBLKSIZE 4096
  #     endif
  #     define USE_GENERIC_PUSH_REGS
@@ -337,7 +337,7 @@ index 11bb46e..4f47f7b 100644
  #        define LINUX_STACKBOTTOM
  #     else
  #        define STACKBOTTOM 0x80000000
-@@ -1858,7 +1858,7 @@
+@@ -1909,7 +1909,7 @@
  #       ifdef __ELF__
  #            define DYNAMIC_LOADING
  #	     include <features.h>

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -1,16 +1,16 @@
 # Template build file for 'gcc'
-_majorver=6.2
+_majorver=6.3
 _gcjrel=17
 
 pkgname=gcc
-version=${_majorver}.1
-revision=3
+version=${_majorver}.0
+revision=1
 short_desc="The GNU C Compiler"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://gcc.gnu.org"
 license="GFDL-1.2, GPL-3, LGPL-2.1"
-distfiles="https://repo.voidlinux.eu/distfiles/gcc-$version.tar.xz"
-checksum=a7addd2d4e42e66c3b56ced8baee5a11ef7fb577e23615a4f43877273eaf9409
+distfiles="${GNU_SITE}/gcc/gcc-${version}/gcc-${version}.tar.bz2"
+checksum=f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
 
 nopie=yes
 lib32disabled=yes

--- a/srcpkgs/kernel-libc-headers/template
+++ b/srcpkgs/kernel-libc-headers/template
@@ -21,6 +21,7 @@ case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*) _arch="x86";;
 	arm*) _arch="arm";;
 	aarch64*) _arch="arm64";;
+	mips*) _arch="mips";;
 	*) msg_error "$pkgname: unknown architecture.\n";;
 esac
 

--- a/srcpkgs/libffi/patches/mips.softfloat.patch
+++ b/srcpkgs/libffi/patches/mips.softfloat.patch
@@ -1,0 +1,83 @@
+Taken from the Optware fork Optware-ng:
+alllexx88 libffi: mips: fix build for soft-float
+https://raw.githubusercontent.com/Optware/Optware-ng/master/sources/libffi/mips.softfloat.patch
+
+--- src/mips/o32.S.orig	2014-11-08 14:47:24.000000000 +0200
++++ src/mips/o32.S	2015-04-16 12:03:11.302116104 +0300
+@@ -82,13 +82,16 @@
+ 		
+ 	ADDU	$sp, 4 * FFI_SIZEOF_ARG		# adjust $sp to new args
+ 
++#ifndef __mips_soft_float
+ 	bnez	t0, pass_d			# make it quick for int
++#endif
+ 	REG_L	a0, 0*FFI_SIZEOF_ARG($sp)	# just go ahead and load the
+ 	REG_L	a1, 1*FFI_SIZEOF_ARG($sp)	# four regs.
+ 	REG_L	a2, 2*FFI_SIZEOF_ARG($sp)
+ 	REG_L	a3, 3*FFI_SIZEOF_ARG($sp)
+ 	b	call_it
+ 
++#ifndef __mips_soft_float
+ pass_d:
+ 	bne	t0, FFI_ARGS_D, pass_f
+ 	l.d	$f12, 0*FFI_SIZEOF_ARG($sp)	# load $fp regs from args
+@@ -130,6 +133,7 @@
+  #	bne	t0, FFI_ARGS_F_D, call_it
+ 	l.s	$f12, 0*FFI_SIZEOF_ARG($sp)	# load $fp regs from args
+ 	l.d	$f14, 2*FFI_SIZEOF_ARG($sp)	# passing double and float
++#endif
+ 
+ call_it:	
+ 	# Load the function pointer
+@@ -158,14 +162,23 @@
+ 	bne     t2, FFI_TYPE_FLOAT, retdouble
+ 	jalr	t9
+ 	REG_L	t0, SIZEOF_FRAME + 4*FFI_SIZEOF_ARG($fp)
++#ifndef __mips_soft_float
+ 	s.s	$f0, 0(t0)
++#else
++	REG_S	v0, 0(t0)
++#endif
+ 	b	epilogue
+ 
+ retdouble:	
+ 	bne	t2, FFI_TYPE_DOUBLE, noretval
+ 	jalr	t9
+ 	REG_L	t0, SIZEOF_FRAME + 4*FFI_SIZEOF_ARG($fp)
++#ifndef __mips_soft_float
+ 	s.d	$f0, 0(t0)
++#else
++	REG_S	v1, 4(t0)
++	REG_S	v0, 0(t0)
++#endif
+ 	b	epilogue
+ 	
+ noretval:	
+@@ -261,9 +274,11 @@
+ 	li	$13, 1		# FFI_O32
+ 	bne	$16, $13, 1f	# Skip fp save if FFI_O32_SOFT_FLOAT
+ 	
++#ifndef __mips_soft_float
+ 	# Store all possible float/double registers.
+ 	s.d	$f12, FA_0_0_OFF2($fp)
+ 	s.d	$f14, FA_1_0_OFF2($fp)
++#endif
+ 1:	
+ 	# Call ffi_closure_mips_inner_O32 to do the work.
+ 	la	t9, ffi_closure_mips_inner_O32
+@@ -281,6 +296,7 @@
+ 	li	$13, 1		# FFI_O32
+ 	bne	$16, $13, 1f	# Skip fp restore if FFI_O32_SOFT_FLOAT
+ 
++#ifndef __mips_soft_float
+ 	li	$9, FFI_TYPE_FLOAT
+ 	l.s	$f0, V0_OFF2($fp)
+ 	beq	$8, $9, closure_done
+@@ -288,6 +304,7 @@
+ 	li	$9, FFI_TYPE_DOUBLE
+ 	l.d	$f0, V0_OFF2($fp)
+ 	beq	$8, $9, closure_done
++#endif
+ 1:	
+ 	REG_L	$3, V1_OFF2($fp)
+ 	REG_L	$2, V0_OFF2($fp)


### PR DESCRIPTION
See #5400

+ gcc-6.3.0-musl.diff line number changes have been adjusted
+ Successfully built all GCCs
+ fixed mips{,el} soft float issues with libffi
+ Successfully built base-chroot{,-musl} for all architectures
