### PR TITLE
mpv: rebuild for libass 0.13.5

### DIFF
--- a/srcpkgs/mpv/template
+++ b/srcpkgs/mpv/template
@@ -1,7 +1,7 @@
 # Template file for 'mpv'
 pkgname=mpv
 version=0.23.0
-revision=1
+revision=2
 build_options="vapoursynth"
 short_desc="Video player based on MPlayer/mplayer2"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"


### PR DESCRIPTION
The last `libass-0.13.5` update causes this error in mpv:

> [osd/libass] [0x7f57a0360560]: Warning: no style named 'Default' found