### PR TITLE
LXQt: some rebuild in order to fix Qt apps crashes

### DIFF
--- a/srcpkgs/liblxqt/template
+++ b/srcpkgs/liblxqt/template
@@ -1,7 +1,7 @@
 # Template file for 'liblxqt'
 pkgname=liblxqt
 version=0.11.0
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DPULL_TRANSLATIONS=0"
 hostmakedepends="pkg-config qt5-host-tools kwindowsystem-devel"

--- a/srcpkgs/libqtxdg/template
+++ b/srcpkgs/libqtxdg/template
@@ -1,7 +1,7 @@
 # Template file for 'libqtxdg'
 pkgname=libqtxdg
 version=2.0.0
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="pkg-config qt5-qmake qt5-host-tools qt5-tools-devel"
 makedepends="qt5-tools-devel qt5-svg-devel"

--- a/srcpkgs/lxqt-panel/template
+++ b/srcpkgs/lxqt-panel/template
@@ -1,7 +1,7 @@
 # Template file for 'lxqt-panel'
 pkgname=lxqt-panel
 version=0.11.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DPULL_TRANSLATIONS=0"
 hostmakedepends="pkg-config"

--- a/srcpkgs/lxqt-qtplugin/template
+++ b/srcpkgs/lxqt-qtplugin/template
@@ -1,7 +1,7 @@
 # Template file for 'lxqt-qtplugin'
 pkgname=lxqt-qtplugin
 version=0.11.1
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="lxqt-build-tools liblxqt-devel libdbusmenu-qt5-devel"


### PR DESCRIPTION
Applications like lxqt-powermanagement, qtox, qbittorrent or vlc crash at launch since last Qt5 update due to their tray icon.

Killing lxqt-panel and launching these apps don't crash them anymore.

Rebuilding the following packages fix the issue. Maybe a global rebuilding of LXQt could be wise.