### PR TITLE
zlib: update to 1.2.10

### DIFF
--- a/srcpkgs/zlib/template
+++ b/srcpkgs/zlib/template
@@ -1,6 +1,6 @@
 # Template build file for 'zlib'
 pkgname=zlib
-version=1.2.9
+version=1.2.10
 revision=1
 bootstrap=yes
 build_style=configure
@@ -9,7 +9,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="zlib"
 homepage="http://www.zlib.net"
 distfiles="$homepage/$pkgname-$version.tar.gz"
-checksum=73ab302ef31ed1e74895d2af56f52f5853f26b0370f3ef21954347acec5eaa21
+checksum=8d7e9f698ce48787b6e1c67e6bff79e487303e66077e25cb9784ac8835978017
 
 do_configure() {
 	LDFLAGS= LDSHAREDLIBC= ./configure --prefix=/usr --shared


### PR DESCRIPTION
The release announcement for zlib 1.2.10 says:
"zlib 1.2.9 had two serious bugs that are fixed in 1.2.10. If you installed 1.2.9, it would behoove you to replace it as soon as possible with 1.2.10. Thank you, and sorry for any mess this might have created."

/cc @xtraeme 