### PR TITLE
New package: dotherside-0.5.2

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2770,3 +2770,4 @@ libnma.so.0 libnm-gtk-1.4.0_1
 libgspell-1.so.1 gspell-1.0.0_1
 libotf.so.0 libotf-0.9.13_1
 libimagequant.so.0 libimagequant-2.8.2_1
+libDOtherSide.so.0 dotherside-0.5.2_1

--- a/srcpkgs/dotherside-devel
+++ b/srcpkgs/dotherside-devel
@@ -1,0 +1,1 @@
+dotherside

--- a/srcpkgs/dotherside/patches/fix-solib-versions.patch
+++ b/srcpkgs/dotherside/patches/fix-solib-versions.patch
@@ -1,0 +1,10 @@
+--- lib/CMakeLists.txt	2017-01-07 11:15:04.987490495 +0100
++++ lib/CMakeListslib.txt	2017-01-07 11:32:31.235499364 +0100
+@@ -44,6 +44,7 @@
+ 
+ # Shared version for distributing
+ add_library(${PROJECT_NAME} SHARED ${SRC_LIST} ${HEADERS_LIST})
++set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 0.0.0)
+ set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+ target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Qml Qt5::Quick)
+ 

--- a/srcpkgs/dotherside/template
+++ b/srcpkgs/dotherside/template
@@ -1,0 +1,22 @@
+# Template file for 'dotherside'
+pkgname=dotherside
+version=0.5.2
+revision=1
+build_style=cmake
+hostmakedepends="qt5-host-tools qt5-declarative-devel"
+short_desc="C language library for creating bindings for the Qt QML language"
+maintainer="gangstacat <grumpy@keemail.me>"
+license="LGPL-3.0"
+homepage="https://github.com/filcuc/DOtherSide"
+distfiles="https://github.com/filcuc/${pkgname}/archive/v${version}.tar.gz"
+checksum=1f91c011b776fc6810662155e0408e40ca0cec50331d9501ca514a45fcce145f
+wrksrc="DOtherSide-${version}"
+
+dotherside-devel_package() {
+	depends="dotherside>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include/
+		vmove usr/lib/*.so
+	}
+}


### PR DESCRIPTION
This package is required by some programming languages librairies in order to make Qt QML bindings. This way, for example it is possible to implement some basic GUI with Qt Quick Controls in these languages.

For more informations: https://github.com/filcuc/DOtherSide