### PR TITLE
libressl: add patch for CVE-2016-7056

### DIFF
--- a/srcpkgs/libressl/patches/CVE-2016-7056.patch
+++ b/srcpkgs/libressl/patches/CVE-2016-7056.patch
@@ -1,0 +1,12 @@
+Avoid possible side-channel leak of ECDSA private keys when signing.
+--- crypto/ecdsa/ecs_ossl.c
++++ crypto/ecdsa/ecs_ossl.c
+@@ -141,6 +141,8 @@ ecdsa_sign_setup(EC_KEY *eckey, BN_CTX *
+ 		if (BN_num_bits(k) <= BN_num_bits(order))
+ 			if (!BN_add(k, k, order))
+ 				goto err;
++
++		BN_set_flags(k, BN_FLG_CONSTTIME);
+ 
+ 		/* compute r the x-coordinate of generator * k */
+ 		if (!EC_POINT_mul(group, tmp_point, k, NULL, NULL, ctx)) {

--- a/srcpkgs/libressl/template
+++ b/srcpkgs/libressl/template
@@ -1,7 +1,7 @@
 # Template file for 'libressl'
 pkgname=libressl
 version=2.4.4
-revision=1
+revision=2
 bootstrap=yes
 build_style=gnu-configure
 short_desc="Version of the TLS/crypto stack forked from OpenSSL"


### PR DESCRIPTION
CVE-2016-7056 ECDSA P-256 timing attack key recovery
http://seclists.org/oss-sec/2017/q1/52