### PR TITLE
k3b: add cdrtools, cdrdao and dvd+rw-tools into depends

### DIFF
--- a/srcpkgs/k3b/template
+++ b/srcpkgs/k3b/template
@@ -2,13 +2,14 @@
 pkgname=k3b
 _realversion=2.0.3
 version=${_realversion}a
-revision=5
+revision=6
 build_style=cmake
 hostmakedepends="qt-qmake automoc4 pkg-config"
 makedepends="kde-runtime-devel libcddb-devel libsamplerate-devel libmad-devel
  ffmpeg-devel taglib-devel libmpcdec-devel libdvdread-devel libXft-devel qt-webkit-devel
  kdelibs-devel phonon-devel libmusicbrainz5-devel lame-devel libkcddb-devel"
 short_desc="CD/DVD Kreator for Linux"
+depends="cdrtools cdrdao dvd+rw-tools"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="GPL-2"
 homepage="http://www.k3b.org/"


### PR DESCRIPTION
Dependencies needed to use the application in a meaningful way. Cannot be automatically detected since these are separate binaries and not shared libraries, also see #5438.