### PR TITLE
mailple: Added python-setuptools to depends

### DIFF
--- a/srcpkgs/mailpile/template
+++ b/srcpkgs/mailpile/template
@@ -1,13 +1,13 @@
 # Template file for 'mailpile'
 pkgname=mailpile
 version=0.5.2
-revision=1
+revision=2
 wrksrc=Mailpile-${version}
 noarch=yes
 build_style=python2-module
 hostmakedepends="python-setuptools"
 depends="python python-Jinja2 python-lxml python-MarkupSafe python-Pillow
- python-spambayes python-pydns python-pgpdump gnupg"
+ python-spambayes python-pydns python-pgpdump gnupg python-setuptools"
 pycompile_module="static $pkgname"
 short_desc="Modern email client with user-friendly encryption and privacy features"
 maintainer="Duncaen <duncaen@voidlinux.eu>"


### PR DESCRIPTION
Mailpile won't launch without python-setuptools. It has been a while since I've messed with templates, not sure if I need to remove it from hostmakedepends.