### PR TITLE
sigil: add necessary python3 dependency; fix cross

### DIFF
--- a/srcpkgs/sigil/template
+++ b/srcpkgs/sigil/template
@@ -1,19 +1,27 @@
 # Template file for 'sigil'
 pkgname=sigil
 version=0.9.7
-revision=1
+revision=2
 create_wrksrc=yes
 build_style=cmake
-hostmakedepends="pkg-config unzip"
+hostmakedepends="pkg-config unzip qt5-qmake"
 makedepends="zlib-devel minizip-devel pcre-devel qt5-tools-devel qt5-svg-devel
  qt5-webkit-devel qt5-xmlpatterns-devel qt5-multimedia-devel qt5-sensors-devel
  qt5-declarative-devel qt5-location-devel qt5-webchannel-devel
  qt5-plugin-odbc qt5-plugin-mysql qt5-plugin-pgsql qt5-plugin-sqlite qt5-plugin-tds
  boost-devel hunspell-devel python3-devel"
-depends="desktop-file-utils"
+depends="desktop-file-utils python3-lxml"
 short_desc="A multi-platform EPUB ebook editor"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-3"
 homepage="https://github.com/Sigil-Ebook/Sigil"
 distfiles="${homepage}/releases/download/${version}/Sigil-${version}-Code.zip"
 checksum=fbd7afdef862794512cde6eb42c0abc05daff428a483bd03710226c5bdf09c69
+
+if [ -n "$CROSS_BUILD" ]; then
+	hostmakedepends+=" qt5-host-tools qt5-tools-devel qt5-svg-devel"
+	hostmakedepends+=" qt5-webkit-devel qt5-xmlpatterns-devel qt5-multimedia-devel"
+	hostmakedepends+=" qt5-sensors-devel qt5-declarative-devel qt5-location-devel"
+	hostmakedepends+=" qt5-webchannel-devel python3-devel"
+fi
+


### PR DESCRIPTION
The application throws a ton of errors before startup and then crashes without this python3 package being installed.