### PR TITLE
New package: msttcorefonts-1.3.4

### DIFF
--- a/srcpkgs/msttcorefonts/template
+++ b/srcpkgs/msttcorefonts/template
@@ -1,0 +1,67 @@
+# Template file for 'msttcorefonts'
+pkgname=msttcorefonts
+version=1.3.4
+revision=1
+hostmakedepends="cabextract"
+short_desc="Microsoft Typography Project - corefonts"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+# Referenced to the *.spec file, the template and mechanism are GPLv2
+# the fonts are licensed in accordance with the Microsoft Font License
+# Agreement which has since been removed from the MS website.  A very
+# broken version of this original license "Licen.TXT" is included with
+# this package.
+license="GPL-2"
+homepage="http://corefonts.sourceforge.net"
+distfiles="${SOURCEFORGE_SITE}/corefonts/wd97vwr32.exe \
+ ${SOURCEFORGE_SITE}/corefonts/webdin32.exe \
+ ${SOURCEFORGE_SITE}/corefonts/verdan32.exe \
+ ${SOURCEFORGE_SITE}/corefonts/trebuc32.exe \
+ ${SOURCEFORGE_SITE}/corefonts/times32.exe \
+ ${SOURCEFORGE_SITE}/corefonts/impact32.exe \
+ ${SOURCEFORGE_SITE}/corefonts/georgi32.exe \
+ ${SOURCEFORGE_SITE}/corefonts/courie32.exe \
+ ${SOURCEFORGE_SITE}/corefonts/comic32.exe \
+ ${SOURCEFORGE_SITE}/corefonts/arialb32.exe \
+ ${SOURCEFORGE_SITE}/corefonts/arial32.exe \
+ ${SOURCEFORGE_SITE}/corefonts/andale32.exe"
+checksum="f61126a6d17b2d126a7f31b142504dce4934f7989c55f1c13c6477b3fe80b3d2 \
+ 64595b5abc1080fba8610c5c34fab5863408e806aafe84653ca8575bed17d75a \
+ c1cb61255e363166794e47664e2f21af8e3a26cb6346eb8d2ae2fa85dd5aad96 \
+ 5a690d9bb8510be1b8b4fe49f1f2319651fe51bbe54775ddddd8ef0bd07fdac9 \
+ db56595ec6ef5d3de5c24994f001f03b2a13e37cee27bc25c58f6f43e8f807ab \
+ 6061ef3b7401d9642f5dfdb5f2b376aa14663f6275e60a51207ad4facf2fccfb \
+ 2c2c7dcda6606ea5cf08918fb7cd3f3359e9e84338dc690013f20cd42e930301 \
+ bb511d861655dde879ae552eb86b134d6fae67cb58502e6ff73ec5d9151f3384 \
+ 9c6df3feefde26d4e41d4a4fe5db2a89f9123a772594d7f59afd062625cd204e \
+ a425f0ffb6a1a5ede5b979ed6177f4f4f4fdef6ae7c302a7b7720ef332fec0a8 \
+ 85297a4d146e9c87ac6f74822734bdee5f4b2a722d7eaa584b7f2cbf76f478f6 \
+ 0524fe42951adc3a7eb870e32f0920313c71f170c859b5f770d82b4ee111e970"
+
+# While it is fine to distribute the templates that build packages
+# containing the mscorefonts they must not distribute the fonts
+# themselves (this would constitute changinging or otherwise
+# encapsulating the filename which is not permitted).
+restricted=yes
+repository=nonfree
+
+# They're just fonts...
+noarch=yes
+
+# Tell XBPS that these are fonts
+font_dirs="/usr/share/fonts/TTF"
+
+do_extract() {
+	for i in wd97vwr webdin verdan trebuc times impact georgi courie comic arialb arial andale ; do
+		cabextract ${XBPS_SRCDISTDIR}/${pkgname}-${version}/${i}32.exe
+	done
+
+	# Tahoma is nested...
+	cabextract Viewer1.cab
+}
+
+do_install() {
+	vlicense Licen.TXT
+	mkdir -p ${DESTDIR}/usr/share/fonts/TTF
+	vcopy *.TTF usr/share/fonts/TTF
+	vcopy *.ttf usr/share/fonts/TTF
+}


### PR DESCRIPTION
I'm not sure if this needs to rebuild the font-cache after it installs.  I didn't have to on my machine, but I can't find a definitive answer of if you need to rebuild the cache after installing fonts.
