### PR TITLE
New package: fbxkb-0.6

### DIFF
--- a/srcpkgs/fbxkb/patches/fbxkb.patch
+++ b/srcpkgs/fbxkb/patches/fbxkb.patch
@@ -1,0 +1,41 @@
+Found on Arch User Repository, adapted for -p0
+
+
+--- fbxkb.c	2006-12-18 23:47:52.000000000 +0200
++++ fbxkb.c	2012-01-15 22:27:30.571427088 +0200
+@@ -378,10 +378,11 @@ read_kbd_description()
+             g_assert((no >= 0) && (no < ngroups));
+             if (group2info[no].sym != NULL) {
+                 ERR("xkb group #%d is already defined\n", no);
++            } else {
++                group2info[no].sym = g_strdup(tok);
++                group2info[no].flag = sym2flag(tok);
++                group2info[no].name = XGetAtomName(dpy, kbd_desc_ptr->names->groups[no]);           
+             }
+-            group2info[no].sym = g_strdup(tok);
+-            group2info[no].flag = sym2flag(tok);
+-            group2info[no].name = XGetAtomName(dpy, kbd_desc_ptr->names->groups[no]);           
+         }
+         XFree(sym_name);
+     }
+--- Makefile.common	2004-10-16 01:18:59.000000000 +0300
++++ Makefile.common	2012-01-15 23:20:02.081020564 +0200
+
+@@ -16,7 +16,7 @@ endif
+ endif
+ 
+ CC = gcc
+-LIBS = $(shell pkg-config --libs gtk+-2.0 gdk-pixbuf-2.0 gdk-pixbuf-xlib-2.0) -L/usr/X11R6/lib  -lXmu
++LIBS = $(shell pkg-config --libs gtk+-2.0 gdk-pixbuf-2.0 gdk-pixbuf-xlib-2.0) -lX11 -L/usr/X11R6/lib  -lXmu
+ INCS = $(shell pkg-config --cflags gtk+-2.0 gdk-pixbuf-2.0 gdk-pixbuf-xlib-2.0)
+ CFLAGS = -O2    # overwriten by command line or env. variable
+ CFLAGS += -Wall # always nice to have 
+@@ -24,9 +24,6 @@ ifneq (,$(DEVEL))
+ CFLAGS := -g -Wall 
+ endif
+ 
+-# -DGTK_DISABLE_DEPRECATED does not work yet
+-CFLAGS += -g -DG_DISABLE_DEPRECATED -DGDK_DISABLE_DEPRECATED -DGTK_DISABLE_DEPRECATED
+-
+ %.o: %.c
+ 	$(CC) $(CFLAGS) $(INCS) -c $<

--- a/srcpkgs/fbxkb/template
+++ b/srcpkgs/fbxkb/template
@@ -1,0 +1,29 @@
+# Template for fbxkb
+
+pkgname="fbxkb"
+version="0.6"
+revision=1
+build_style=configure
+short_desc="Lightweight X keyboard layout indicator, uses GTK+2"
+maintainer="Pavel Kiselev <kispash@yandex.ru>"
+hostmakedepends="pkg-config"
+makedepends="xorg-server-devel gtk+-devel"
+license="MIT"
+homepage="http://fbxkb.sourceforge.net/"
+distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tgz"
+checksum="fcbaf4ed9a70f58ea1316b19da74e2ca8b3fb0e2de5a73c849317589ce840ef2"
+
+pre_build() {
+# Substitute compiler,
+# Substitute CFLAGS (original options are subset of void's options),
+# Put LDFLAGS at the end of command (enables PIE)
+	sed -i Makefile* \
+		-e "s;^CC.*=.*$;CC = ${CC};" \
+		-e "s;^CFLAGS.*=.*$;CFLAGS = ${CFLAGS};" \
+		-e "s;^\(.*\).(LDFLAGS)\(.*\)$;\1\2 ${LDFLAGS};"
+}
+
+do_install() {
+	make PREFIX="${DESTDIR}/usr" install
+	vlicense COPYING
+}


### PR DESCRIPTION
fbxkb is a very lightweight and minimalist, although pretty old (last official update in 2006) X keyboard layout indicator. It's a good choice for lightweight WMs like i3.

I understand that pre-1.0 package with such a long period without maintenance is concerning, but due to its minimal functionality and rather small codebase I don't think it would do any harm. I've been using fbxkb for three month on two distributions and did not have any problems with it.

EDIT: added "only_for_arches" to the template, package didn't build on some architectures.