### PR TITLE
dovecot-plugin-pigeonhole: fix managesieve-login

### DIFF
--- a/srcpkgs/dovecot-plugin-pigeonhole/template
+++ b/srcpkgs/dovecot-plugin-pigeonhole/template
@@ -1,7 +1,7 @@
 # Template file for 'dovecot-plugin-pigeonhole'
 pkgname=dovecot-plugin-pigeonhole
 version=0.4.16
-revision=2
+revision=3
 wrksrc="dovecot-2.2-pigeonhole-${version}"
 build_style=gnu-configure
 configure_args="--prefix=/usr

--- a/srcpkgs/dovecot/template
+++ b/srcpkgs/dovecot/template
@@ -2,7 +2,7 @@
 # revbump dovecot-plugin-pigeonhole when updating dovecot!
 pkgname=dovecot
 version=2.2.27
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-moduledir=/usr/lib/dovecot/modules --with-sql=plugin
  --disable-static --with-pam --with-mysql --with-pgsql --with-lucene
@@ -15,6 +15,7 @@ license="LGPL-2.1"
 homepage="http://dovecot.org"
 distfiles="${homepage}/releases/2.2/${pkgname}-${version}.tar.gz"
 checksum=897f92a87cda4b27b243f8149ce0ba7b7e71a2be8fb7994eb0a025e54cde18e9
+keep_libtool_archives=yes
 
 makedepends="
  lz4-devel zlib-devel bzip2-devel liblzma-devel libressl-devel mit-krb5-devel


### PR DESCRIPTION
Removing libtool archives breaks the RPATH on the managesieve-login binary, which breaks the remote sieve-editing capabilities.

I wasn't able to cross-compile on my system, but was able to compile using the native musl environment, I can't remember if this is normal or not for this package. I don't think changing `keep_libtool_archives` affects the package's ability to cross-compile.