### PR TITLE
kernel-libc-headers: musl libc support for compat with linux/*.h

### DIFF
--- a/srcpkgs/blueman/patches/musl.patch
+++ b/srcpkgs/blueman/patches/musl.patch
@@ -1,6 +1,6 @@
 --- module/libblueman.c.orig	2016-03-27 09:13:07.203123088 +0200
 +++ module/libblueman.c	2016-03-27 09:13:19.497969382 +0200
-@@ -28,8 +28,13 @@
+@@ -28,6 +28,7 @@
  #include <string.h>
  #include <sys/ioctl.h>
  #include <sys/socket.h>
@@ -8,11 +8,6 @@
  #include <unistd.h>
  #include <linux/sockios.h>
  #include <linux/if.h>
-+#if defined(__GLIBC__)
- #include <linux/if_bridge.h>
-+#else
-+#define BRCTL_SET_BRIDGE_FORWARD_DELAY 8
-+#endif
 
 --- module/modem-prober.c.orig	2016-03-27 09:19:20.635454542 +0200
 +++ module/modem-prober.c	2016-03-27 09:19:28.550355592 +0200

--- a/srcpkgs/blueman/template
+++ b/srcpkgs/blueman/template
@@ -1,7 +1,7 @@
 # Template file for 'blueman'
 pkgname=blueman
 version=2.0.4
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="intltool pkg-config python-Cython"

--- a/srcpkgs/cross-aarch64-linux-musl/template
+++ b/srcpkgs/cross-aarch64-linux-musl/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.27
 _gcc_version=6.3.0
-_musl_version=1.1.15
+_musl_version=1.1.16
 _linux_version=4.9.8
 
 _triplet=aarch64-linux-musl
@@ -11,7 +11,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=4
+revision=5
 short_desc="Cross toolchain for ARM64 LE target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -25,7 +25,7 @@ checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
  f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
+ 937185a5e5d721050306cf106507a006c3f1f86d86cd550024ea7be909071011"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-arm-linux-musleabi/template
+++ b/srcpkgs/cross-arm-linux-musleabi/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.27
 _gcc_version=6.3.0
-_musl_version=1.1.15
+_musl_version=1.1.16
 _linux_version=4.9.8
 
 _triplet=arm-linux-musleabi
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=4
+revision=5
 short_desc="Cross toolchain for ARMv5 TE target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -26,7 +26,7 @@ checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
  f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
+ 937185a5e5d721050306cf106507a006c3f1f86d86cd550024ea7be909071011"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-arm-linux-musleabihf/template
+++ b/srcpkgs/cross-arm-linux-musleabihf/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.27
 _gcc_version=6.3.0
-_musl_version=1.1.15
+_musl_version=1.1.16
 _linux_version=4.9.8
 
 _triplet=arm-linux-musleabihf
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=4
+revision=5
 short_desc="Cross toolchain for ARMv6 LE Hard Float target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -26,7 +26,7 @@ checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
  f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
+ 937185a5e5d721050306cf106507a006c3f1f86d86cd550024ea7be909071011"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-armv7l-linux-musleabihf/template
+++ b/srcpkgs/cross-armv7l-linux-musleabihf/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.27
 _gcc_version=6.3.0
-_musl_version=1.1.15
+_musl_version=1.1.16
 _linux_version=4.9.8
 
 _triplet=armv7l-linux-musleabihf
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=4
+revision=5
 short_desc="Cross toolchain for ARMv7 LE Hard Float target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -26,7 +26,7 @@ checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
  f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
+ 937185a5e5d721050306cf106507a006c3f1f86d86cd550024ea7be909071011"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-i686-linux-musl/template
+++ b/srcpkgs/cross-i686-linux-musl/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.27
 _gcc_version=6.3.0
-_musl_version=1.1.15
+_musl_version=1.1.16
 _linux_version=4.9.8
 
 _triplet=i686-linux-musl
@@ -11,7 +11,7 @@ _archflags="-march=i686"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=4
+revision=5
 short_desc="Cross toolchain for i686 target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -25,7 +25,7 @@ checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
  f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
+ 937185a5e5d721050306cf106507a006c3f1f86d86cd550024ea7be909071011"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-mips-linux-musl/template
+++ b/srcpkgs/cross-mips-linux-musl/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=4
+revision=5
 short_desc="Cross toolchain for MIPS32r2 BE softfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -26,7 +26,7 @@ checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
  f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
+ 937185a5e5d721050306cf106507a006c3f1f86d86cd550024ea7be909071011"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-mipsel-linux-musl/template
+++ b/srcpkgs/cross-mipsel-linux-musl/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.27
 _gcc_version=6.3.0
-_musl_version=1.1.15
+_musl_version=1.1.16
 _linux_version=4.9.8
 
 _triplet=mipsel-linux-musl
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=4
+revision=5
 short_desc="Cross toolchain for MIPS32r2 LE softfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -26,7 +26,7 @@ checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
  f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
+ 937185a5e5d721050306cf106507a006c3f1f86d86cd550024ea7be909071011"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-mipsel-linux-muslhf/template
+++ b/srcpkgs/cross-mipsel-linux-muslhf/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=4
+revision=5
 short_desc="Cross toolchain for MIPS32r2 LE hardfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -26,7 +26,7 @@ checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
  f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
+ 937185a5e5d721050306cf106507a006c3f1f86d86cd550024ea7be909071011"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-x86_64-linux-musl/template
+++ b/srcpkgs/cross-x86_64-linux-musl/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.27
 _gcc_version=6.3.0
-_musl_version=1.1.15
+_musl_version=1.1.16
 _linux_version=4.9.8
 
 _triplet=x86_64-linux-musl
@@ -10,7 +10,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.22
-revision=4
+revision=5
 short_desc="Cross toolchain for x86_64 with musl"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -24,7 +24,7 @@ checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
  f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa"
+ 937185a5e5d721050306cf106507a006c3f1f86d86cd550024ea7be909071011"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/kernel-libc-headers/patches/1-5-kernel-libc-compat-musl-support.patch
+++ b/srcpkgs/kernel-libc-headers/patches/1-5-kernel-libc-compat-musl-support.patch
@@ -1,0 +1,114 @@
+--- include/uapi/linux/libc-compat.h.orig
++++ include/uapi/linux/libc-compat.h
+@@ -165,10 +165,102 @@
+ #define __UAPI_DEF_XATTR		1
+ #endif
+ 
++
++/*
++ * Support of guessed LIBC musl, since neither glibc nor kernel space.
++ * Written for musl libc 1.1.16. Mimics the glibc support above.
++ */
++#elif !defined(__KERNEL__) /* and not __GLIBC__ */
++
++/* Coordinate with musl libc net/if.h header. */
++#if defined(_NET_IF_H)
++
++/* LIBC headers included first so don't define anything
++ * that would already be defined. */
++
++#define __UAPI_DEF_IF_IFCONF		0
++#define __UAPI_DEF_IF_IFMAP		0
++#define __UAPI_DEF_IF_IFNAMSIZ		0
++#define __UAPI_DEF_IF_IFREQ		0
++
++/* Everything up to IFF_DYNAMIC, matches net/if.h */
++#define __UAPI_DEF_IF_NET_DEVICE_FLAGS	0
++
++/* musl libc defines IFF_LOWER_UP, IFF_DORMANT and IFF_ECHO */
++#define __UAPI_DEF_IF_NET_DEVICE_FLAGS_LOWER_UP_DORMANT_ECHO 0
++
++#else /* _NET_IF_H */
++
++/* Linux headers included first, and we must define everything
++ * we need. Will define the corresponding structures twice
++ * if net/if.h is included later ?  */
++
++#define __UAPI_DEF_IF_IFCONF		1
++#define __UAPI_DEF_IF_IFMAP		1
++#define __UAPI_DEF_IF_IFNAMSIZ		1
++#define __UAPI_DEF_IF_IFREQ		1
++#define __UAPI_DEF_IF_NET_DEVICE_FLAGS	1
++#define __UAPI_DEF_IF_NET_DEVICE_FLAGS_LOWER_UP_DORMANT_ECHO 1
++
++#endif /* _NET_IF_H */
++
++/* Coordinate with musl libc netinet/in.h header. */
++#if defined(_NETINET_IN_H)
++
++/* musl 1.1.16 LIBC netinet/in.h defines the following (to 0),
++ * so it's useless to set them again:
++ *   __UAPI_DEF_IN_ADDR        __UAPI_DEF_IN_IPPROTO
++ *   __UAPI_DEF_IN_PKTINFO     __UAPI_DEF_IP_MREQ
++ *   __UAPI_DEF_SOCKADDR_IN    __UAPI_DEF_IN_CLASS
++ *   __UAPI_DEF_IN6_ADDR       __UAPI_DEF_IN6_ADDR_ALT
++ *   __UAPI_DEF_SOCKADDR_IN6   __UAPI_DEF_IPV6_MREQ
++ *   __UAPI_DEF_IPPROTO_V6     __UAPI_DEF_IPV6_OPTIONS
++ *   __UAPI_DEF_IN6_PKTINFO    __UAPI_DEF_IP6_MTUINFO
++ */
++
++#else /* _NETINET_IN_H */
++
++/* Linux headers included first, and we must define everything
++ * we need. Will define the corresponding structures twice
++ * if netinet/in.h is included later ? */
++
++#define __UAPI_DEF_IN_ADDR		1
++#define __UAPI_DEF_IN_IPPROTO		1
++#define __UAPI_DEF_IN_PKTINFO		1
++#define __UAPI_DEF_IP_MREQ		1
++#define __UAPI_DEF_SOCKADDR_IN		1
++#define __UAPI_DEF_IN_CLASS		1
++
++#define __UAPI_DEF_IN6_ADDR		1
++#define __UAPI_DEF_IN6_ADDR_ALT		1
++#define __UAPI_DEF_SOCKADDR_IN6		1
++#define __UAPI_DEF_IPV6_MREQ		1
++#define __UAPI_DEF_IPPROTO_V6		1
++#define __UAPI_DEF_IPV6_OPTIONS		1
++#define __UAPI_DEF_IN6_PKTINFO		1
++#define __UAPI_DEF_IP6_MTUINFO		1
++
++#endif /* _NETINET_IN_H */
++
++/* musl libc does not provide IPX support */
++#define __UAPI_DEF_SOCKADDR_IPX			1
++#define __UAPI_DEF_IPX_ROUTE_DEFINITION		1
++#define __UAPI_DEF_IPX_INTERFACE_DEFINITION	1
++#define __UAPI_DEF_IPX_CONFIG_DATA		1
++#define __UAPI_DEF_IPX_ROUTE_DEF		1
++
++/* Definitions for sys/xattr.h */
++#if defined(_SYS_XATTR_H)
++#define __UAPI_DEF_XATTR		0
++#else
++#define __UAPI_DEF_XATTR		1
++#endif
++
++
+ /* If we did not see any headers from any supported C libraries,
+  * or we are being included in the kernel, then define everything
+  * that we need. */
+-#else /* !defined(__GLIBC__) */
++#else /* defined(__KERNEL__) */
+ 
+ /* Definitions for if.h */
+ #define __UAPI_DEF_IF_IFCONF 1
+@@ -208,6 +300,6 @@
+ /* Definitions for xattr.h */
+ #define __UAPI_DEF_XATTR		1
+ 
+-#endif /* __GLIBC__ */
++#endif /* __KERNEL__ or __GLIBC__ or libc */
+ 
+ #endif /* _LIBC_COMPAT_H */

--- a/srcpkgs/kernel-libc-headers/template
+++ b/srcpkgs/kernel-libc-headers/template
@@ -1,7 +1,7 @@
 # Template file for 'kernel-libc-headers'
 pkgname=kernel-libc-headers
 version=4.9.8
-revision=1
+revision=2
 bootstrap=yes
 nostrip=yes
 noverifyrdeps=yes


### PR DESCRIPTION
following issue #5786 
still WIP, but NetworkManager 1.0.2 builds (native muslc)

