### PR TITLE
gdb: configure with --with-build-sysroot, not --with-sysroot.

### DIFF
--- a/srcpkgs/gdb/template
+++ b/srcpkgs/gdb/template
@@ -1,7 +1,7 @@
 # Template file for 'gdb'
 pkgname=gdb
 version=7.12.1
-revision=1
+revision=2
 patch_args="-Np1"
 build_style=gnu-configure
 pycompile_dirs="/usr/share/gdb"
@@ -35,6 +35,9 @@ vopt_conflict gdbserver static
 
 post_extract() {
 	sed -i 's,sgidefs.h,asm/sgidefs.h,' gdb/mips-linux-nat.c
+}
+pre_configure() {
+	configure_args="${configure_args/with-sysroot/with-build-sysroot}"
 }
 pre_build() {
 	export gl_cv_func_gettimeofday_clobber=no


### PR DESCRIPTION
When a cross-compiled gdb is built with --with-sysroot, it
looks for shared libraries in the wrong place when installed
to the target system.  So use --with-build-sysroot instead.