### PR TITLE
glibc: revert upstream changes to memchr-sse2

### DIFF
--- a/srcpkgs/glibc/patches/revert-memchr-i686.patch
+++ b/srcpkgs/glibc/patches/revert-memchr-i686.patch
@@ -1,0 +1,42 @@
+diff --git a/sysdeps/i386/i686/multiarch/memchr-sse2-bsf.S b/sysdeps/i386/i686/multiarch/memchr-sse2-bsf.S
+index dd316486e6..c035329ece 100644
+--- a/sysdeps/i386/i686/multiarch/memchr-sse2-bsf.S
++++ b/sysdeps/i386/i686/multiarch/memchr-sse2-bsf.S
+@@ -149,15 +149,9 @@ L(crosscache):
+ 	.p2align 4
+ L(unaligned_no_match):
+ # ifndef USE_AS_RAWMEMCHR
+-        /* Calculate the last acceptable address and check for possible
+-           addition overflow by using satured math:
+-           edx = ecx + edx
+-           edx |= -(edx < ecx)  */
+-	add	%ecx, %edx
+-	sbb	%eax, %eax
+-	or	%eax, %edx
+ 	sub	$16, %edx
+-	jbe	L(return_null)
++	add	%ecx, %edx
++	jle	L(return_null)
+ 	add	$16, %edi
+ # else
+ 	add	$16, %edx
+diff --git a/sysdeps/i386/i686/multiarch/memchr-sse2.S b/sysdeps/i386/i686/multiarch/memchr-sse2.S
+index 910679cfc0..f1a11b5c67 100644
+--- a/sysdeps/i386/i686/multiarch/memchr-sse2.S
++++ b/sysdeps/i386/i686/multiarch/memchr-sse2.S
+@@ -118,14 +118,8 @@ L(crosscache):
+ # ifndef USE_AS_RAWMEMCHR
+ 	jnz	L(match_case2_prolog1)
+ 	lea	-16(%edx), %edx
+-        /* Calculate the last acceptable address and check for possible
+-           addition overflow by using satured math:
+-           edx = ecx + edx
+-           edx |= -(edx < ecx)  */
+ 	add	%ecx, %edx
+-	sbb	%eax, %eax
+-	or	%eax, %edx
+-	jbe	L(return_null)
++	jle	L(return_null)
+ 	lea	16(%edi), %edi
+ # else
+ 	jnz	L(match_case1_prolog1)

--- a/srcpkgs/glibc/template
+++ b/srcpkgs/glibc/template
@@ -1,7 +1,7 @@
 # Template file for 'glibc'
 pkgname=glibc
 version=2.25
-revision=2
+revision=3
 bootstrap=yes
 short_desc="The GNU C library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"


### PR DESCRIPTION
the changes made in glibc upstream commit 23d27709a423aec32821e9a5198a10267107bae2
cause segmentation faults on at least some i686 processors. This commit
reverts these changes to resolve the issue on affected systems until
there's an upstream fix.

This PR is intended as an alternative to #5752. Since at least some important packages (gnutls, sshd) now link against glib-2.25 symbols, it is now longer feasible to stay on glibc-2.24 on a Void installation. Reverting the repository back to 2.24 would require a rebuild of these packages.