### PR TITLE
base-files: fix vkpurge rm installed check

### DIFF
--- a/srcpkgs/base-files/files/vkpurge
+++ b/srcpkgs/base-files/files/vkpurge
@@ -59,8 +59,8 @@ remove_kernel()
 		exit 0
 	fi
 
-	installed=$(xbps-uhelper -r / version $rmkver)
-	if [ -n "$installed" ]; then
+	installed=$(xbps-uhelper version "linux${rmkver%*.*}" 2>/dev/null)
+	if [ -n "$installed" -a "$installed" = "$rmkver" ]; then
 		echo "Kernel $rmkver is currently installed."
 		exit 0
 	fi

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,7 +1,7 @@
 # Template file for 'base-files'
 pkgname=base-files
 version=0.139
-revision=5
+revision=6
 bootstrap=yes
 depends="xbps-triggers"
 short_desc="Void Linux base system files"


### PR DESCRIPTION
`vkpurge rm 4.10.1_1` does not correctly check if the version is installed and would delete the files anyways, `vkpurge list` and `vkpurge all` use the the correct check.