### PR TITLE
ccsm: fix icon directory path issue.

### DIFF
--- a/srcpkgs/ccsm/patches/prefix.patch
+++ b/srcpkgs/ccsm/patches/prefix.patch
@@ -1,0 +1,11 @@
+--- setup.py	2017-03-02 11:35:41.688884000 -0800
++++ setup.py	2017-03-02 11:36:07.745885086 -0800
+@@ -103,7 +103,7 @@
+ if not prefix and "PREFIX" in os.environ:
+     prefix = os.environ["PREFIX"]
+ if not prefix or not len (prefix):
+-    prefix = "/usr/local"
++    prefix = "/usr"
+ 
+ if sys.argv[1] in ("install", "uninstall") and len (prefix):
+     sys.argv += ["--prefix", prefix]

--- a/srcpkgs/ccsm/template
+++ b/srcpkgs/ccsm/template
@@ -1,11 +1,11 @@
 # Template file for 'ccsm' of Compiz Reloaded
 pkgname=ccsm
 version=0.8.12.4
-revision=1
+revision=2
 build_style=python2-module
 
 hostmakedepends="automake intltool libtool pkg-config python"
-makedepends="compiz-core-devel compizconfig-python python-cairo-devel"
+makedepends="compiz-core-devel compizconfig-python python-cairo-devel pygtk-devel"
 depends="compizconfig-python python-cairo"
 
 short_desc="Compiz Configuration Seetings Manager for Compiz Reloaded"


### PR DESCRIPTION
The main application prefix was not being set in all places correctly. This is a patch the changes the default prefix from `/usr/local` to `/usr.` It also includes `pygtk` to allow for proper updating of icon themes.