### PR TITLE
python-bitbucket-api: More encompassing dependency

### DIFF
--- a/srcpkgs/python-bitbucket-api/template
+++ b/srcpkgs/python-bitbucket-api/template
@@ -1,13 +1,13 @@
 # Template file for 'python-bitbucket-api'
 pkgname=python-bitbucket-api
 version=0.5.0
-revision=1
+revision=2
 noarch=yes
 wrksrc="bitbucket-api-${version}"
 build_style=python-module
 pycompile_module="bitbucket"
 hostmakedepends="python-setuptools python3-setuptools"
-depends="python-requests python-sh python-oauthlib"
+depends="python-requests-oauthlib python-sh"
 short_desc="Wrapper for BitBucket's REST API (Python2)"
 maintainer="Joseph LaFreniere <joseph@lafreniere.xyz>"
 homepage="https://github.com/Sheeprider/BitBucket-api"
@@ -21,7 +21,7 @@ post_install() {
 
 python3-bitbucket-api_package() {
 	noarch=yes
-	depends="python3-requests python3-sh python3-oauthlib"
+	depends="python3-requests-oauthlib python3-sh"
 	pycompile_module="bitbucket"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {


### PR DESCRIPTION
Features from python-requests-oauthlib are used in the library, so that
package needs to be a dependency.  python-requests-oauthlib depends on
python-oauthlib, so the latter can safely be removed from the dependency
list without fear of any lost functionality.