### PR TITLE
python-smmap: Add missing dependency on python

### DIFF
--- a/srcpkgs/python-smmap/template
+++ b/srcpkgs/python-smmap/template
@@ -1,12 +1,13 @@
 # Template file for 'python-smmap'
 pkgname=python-smmap
 version=2.0.1
-revision=2
+revision=3
 noarch=yes
 wrksrc="smmap-${version}"
 build_style=python-module
 pycompile_module="smmap"
 hostmakedepends="python-setuptools python3-setuptools"
+depends="python"
 short_desc="Sliding memory map manager (Python2)"
 maintainer="Joseph LaFreniere <joseph@lafreniere.xyz>"
 homepage="https://github.com/gitpython-developers/smmap"
@@ -14,14 +15,17 @@ license="BSD"
 distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=ff3df98fe1874228c5cae8c2cca18bf0122bbd1f8957eb2339f5faa61ffc4081
 
+post_install() {
+	vlicense LICENSE
+}
+
 python3-smmap_package() {
 	noarch=yes
 	pycompile_module="smmap"
+	depends="python3"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {
 		vmove usr/lib/python3*
+		vlicense LICENSE
 	}
-}
-post_install() {
-	vlicense LICENSE
 }


### PR DESCRIPTION
python-smmap has a dependency on the base Python install.  Explicitly
adding the python package as a dependency slipped through the cracks
initially because, as a Python library, there are very few use cases
where one would attempt to install smmap without already having the base
language.

The calling of `post_install()` is moved above the python3 subpackage in
the source to be more consistent with other Python packages.