### PR TITLE
RFC: gnu-makefile with good makefiles.

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -645,7 +645,10 @@ arguments can be passed in via `configure_args`.
 - `gnu-makefile` For packages that use GNU make, build arguments can be passed in via
 `make_build_args` and install arguments via `make_install_args`. The build
 target can be overridden via `make_build_target` and the install target
-via `make_install_target`.
+via `make_install_target`. This build style tries to compensate for makefiles
+that do not respect environment variables, so well written makefiles, those
+that do such things as append (`+=`) to variables, should have `make_use_env`
+set in the body of the template.
 
 - `go` For programs written in Go that follow the standard package
   structure. The variable `go_import_path` must be set to the package's

--- a/common/build-style/gnu-makefile.sh
+++ b/common/build-style/gnu-makefile.sh
@@ -4,11 +4,15 @@
 do_build() {
 	: ${make_cmd:=make}
 
-	${make_cmd} \
-		CC="$CC" CXX="$CXX" LD="$LD" AR="$AR" RANLIB="$RANLIB" \
-		CPP="$CPP" AS="$AS" OBJDUMP="$OBJDUMP" CFLAGS="$CFLAGS" \
-		LDFLAGS="$LDFLAGS" \
-		${makejobs} ${make_build_args} ${make_build_target}
+	if [ -z "$make_use_env" ]; then
+		${make_cmd} \
+			CC="$CC" CXX="$CXX" LD="$LD" AR="$AR" RANLIB="$RANLIB" \
+			CPP="$CPP" AS="$AS" OBJDUMP="$OBJDUMP" \
+			CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" \
+			${makejobs} ${make_build_args} ${make_build_target}
+	else
+		${make_cmd} ${makejobs} ${make_build_args} ${make_build_target}
+	fi
 }
 
 do_install() {

--- a/common/environment/setup/sourcepkg.sh
+++ b/common/environment/setup/sourcepkg.sh
@@ -6,7 +6,7 @@ unset -v pkgname version revision short_desc homepage license maintainer
 unset -v only_for_archs distfiles checksum build_style nocross broken
 unset -v configure_script configure_args wrksrc build_wrksrc create_wrksrc
 unset -v make_cmd make_build_args make_install_args make_build_target make_install_target python_version stackage
-unset -v patch_args disable_parallel_build keep_libtool_archives
+unset -v patch_args disable_parallel_build keep_libtool_archives make_use_env
 unset -v reverts subpackages makedepends hostmakedepends depends restricted
 unset -v nopie build_options build_options_default bootstrap repository reverts
 unset -v CFLAGS CXXFLAGS FFLAGS CPPFLAGS LDFLAGS LD_LIBRARY_PATH


### PR DESCRIPTION
Cleaner than overwriting `do_build` partially every time we get a good makefile.
Needs a change to unset `good_makefile` as well, so it behaves well.
Tested on the PR of `spt` ( #5883 )