### PR TITLE
cross-*: enable fortran cross compilers and update glibc

### DIFF
--- a/srcpkgs/cross-aarch64-linux-gnu/template
+++ b/srcpkgs/cross-aarch64-linux-gnu/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.27
 _gcc_version=6.3.0
-_glibc_version=2.24
+_glibc_version=2.25
 _linux_version=4.9.8
 
 _triplet=aarch64-linux-gnu
@@ -10,8 +10,8 @@ _archflags="-march=armv8-a"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.22
-revision=3
+version=0.23
+revision=1
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
 homepage="http://www.voidlinux.eu"
@@ -24,7 +24,7 @@ distfiles="
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
  f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
- 99d4a3e8efd144d71488e478f62587578c0f4e1fa0b4eed47ee3d4975ebeb5d3
+ 067bd9bb3390e79aa45911537d13c3721f1d9d3769931a30c2681bfee66f23a0
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45"
 
 lib32disabled=yes
@@ -32,9 +32,9 @@ nocross=yes
 nopie=yes
 create_wrksrc=yes
 hostmakedepends="perl flex"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel"
+makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
 depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
 only_for_archs="x86_64"
 
 _apply_patch() {
@@ -224,7 +224,7 @@ _gcc_build() {
 	_args+=" --libdir=/usr/lib"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,lto"
+	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --with-gnu-as"
 	_args+=" --with-gnu-ld"
 	_args+=" --disable-multilib"

--- a/srcpkgs/cross-aarch64-linux-musl/template
+++ b/srcpkgs/cross-aarch64-linux-musl/template
@@ -10,8 +10,8 @@ _archflags="-march=armv8-a"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.22
-revision=5
+version=0.23
+revision=1
 short_desc="Cross toolchain for ARM64 LE target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -35,8 +35,8 @@ create_wrksrc=yes
 
 only_for_archs="x86_64 x86_64-musl"
 hostmakedepends="perl flex"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel"
-nostrip_files="libgcc.a libgcov.a libgcc_eh.a"
+makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
 _apply_patch() {
@@ -161,7 +161,7 @@ _gcc_build() {
 	_args+=" --libexecdir=/usr/lib"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,lto"
+	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"

--- a/srcpkgs/cross-arm-linux-gnueabi/template
+++ b/srcpkgs/cross-arm-linux-gnueabi/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.27
 _gcc_version=6.3.0
-_glibc_version=2.24
+_glibc_version=2.25
 _linux_version=4.9.8
 
 _triplet=arm-linux-gnueabi
@@ -11,8 +11,8 @@ _archflags="-march=armv5te -msoft-float -mfloat-abi=soft"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.22
-revision=3
+version=0.23
+revision=1
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -25,7 +25,7 @@ distfiles="
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
  f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
- 99d4a3e8efd144d71488e478f62587578c0f4e1fa0b4eed47ee3d4975ebeb5d3
+ 067bd9bb3390e79aa45911537d13c3721f1d9d3769931a30c2681bfee66f23a0
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45"
 
 lib32disabled=yes
@@ -35,9 +35,9 @@ nodebug=yes
 create_wrksrc=yes
 
 hostmakedepends="perl flex"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel"
+makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
 depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
 only_for_archs="i686 x86_64"
 
 _apply_patch() {
@@ -228,7 +228,7 @@ _gcc_build() {
 	_args+=" --libexecdir=/usr/lib"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,lto"
+	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --with-gnu-as"
 	_args+=" --with-gnu-ld"
 	_args+=" --disable-multilib"

--- a/srcpkgs/cross-arm-linux-gnueabihf/template
+++ b/srcpkgs/cross-arm-linux-gnueabihf/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.27
 _gcc_version=6.3.0
-_glibc_version=2.24
+_glibc_version=2.25
 _linux_version=4.9.8
 
 _triplet=arm-linux-gnueabihf
@@ -11,8 +11,8 @@ _archflags="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.22
-revision=3
+version=0.23
+revision=1
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -25,7 +25,7 @@ distfiles="
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
  f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
- 99d4a3e8efd144d71488e478f62587578c0f4e1fa0b4eed47ee3d4975ebeb5d3
+ 067bd9bb3390e79aa45911537d13c3721f1d9d3769931a30c2681bfee66f23a0
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45"
 
 lib32disabled=yes
@@ -35,9 +35,9 @@ nodebug=yes
 create_wrksrc=yes
 
 hostmakedepends="perl flex"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel"
+makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
 depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
 only_for_archs="i686 x86_64"
 
 _apply_patch() {
@@ -228,7 +228,7 @@ _gcc_build() {
 	_args+=" --libexecdir=/usr/lib"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,lto"
+	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --with-gnu-as"
 	_args+=" --with-gnu-ld"
 	_args+=" --disable-multilib"

--- a/srcpkgs/cross-arm-linux-musleabi/template
+++ b/srcpkgs/cross-arm-linux-musleabi/template
@@ -11,8 +11,8 @@ _archflags="-march=armv5te -msoft-float -mfloat-abi=soft"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.22
-revision=5
+version=0.23
+revision=1
 short_desc="Cross toolchain for ARMv5 TE target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -35,8 +35,8 @@ nodebug=yes
 create_wrksrc=yes
 
 hostmakedepends="perl flex"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel"
-nostrip_files="libgcc.a libgcov.a libgcc_eh.a"
+makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
 _apply_patch() {
@@ -166,7 +166,7 @@ _gcc_build() {
 	_args="--prefix=/usr"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,lto"
+	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"

--- a/srcpkgs/cross-arm-linux-musleabihf/template
+++ b/srcpkgs/cross-arm-linux-musleabihf/template
@@ -11,8 +11,8 @@ _archflags="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.22
-revision=5
+version=0.23
+revision=1
 short_desc="Cross toolchain for ARMv6 LE Hard Float target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -35,8 +35,8 @@ nodebug=yes
 create_wrksrc=yes
 
 hostmakedepends="perl flex"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel"
-nostrip_files="libgcc.a libgcov.a libgcc_eh.a"
+makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
 _apply_patch() {
@@ -165,7 +165,7 @@ _gcc_build() {
 	_args="--prefix=/usr"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,lto"
+	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"

--- a/srcpkgs/cross-armv7l-linux-gnueabihf/template
+++ b/srcpkgs/cross-armv7l-linux-gnueabihf/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.27
 _gcc_version=6.3.0
-_glibc_version=2.24
+_glibc_version=2.25
 _linux_version=4.9.8
 
 _triplet=armv7l-linux-gnueabihf
@@ -11,8 +11,8 @@ _archflags="-march=armv7-a -mfpu=vfpv3 -mfloat-abi=hard"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.22
-revision=3
+version=0.23
+revision=1
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -25,7 +25,7 @@ distfiles="
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
  f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
- 99d4a3e8efd144d71488e478f62587578c0f4e1fa0b4eed47ee3d4975ebeb5d3
+ 067bd9bb3390e79aa45911537d13c3721f1d9d3769931a30c2681bfee66f23a0
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45"
 
 lib32disabled=yes
@@ -35,9 +35,9 @@ nodebug=yes
 create_wrksrc=yes
 
 hostmakedepends="perl flex"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel"
+makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
 depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
 only_for_archs="i686 x86_64"
 
 _apply_patch() {
@@ -229,7 +229,7 @@ _gcc_build() {
 	_args+=" --libexecdir=/usr/lib"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,lto"
+	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --with-gnu-as"
 	_args+=" --with-gnu-ld"
 	_args+=" --disable-multilib"

--- a/srcpkgs/cross-armv7l-linux-musleabihf/template
+++ b/srcpkgs/cross-armv7l-linux-musleabihf/template
@@ -11,8 +11,8 @@ _archflags="-march=armv7-a -mfpu=vfpv3 -mfloat-abi=hard"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.22
-revision=5
+version=0.23
+revision=1
 short_desc="Cross toolchain for ARMv7 LE Hard Float target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -35,8 +35,8 @@ nodebug=yes
 create_wrksrc=yes
 
 hostmakedepends="perl flex"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel"
-nostrip_files="libgcc.a libgcov.a libgcc_eh.a"
+makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
 _apply_patch() {
@@ -167,7 +167,7 @@ _gcc_build() {
 	_args="--prefix=/usr"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,lto"
+	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"

--- a/srcpkgs/cross-i686-linux-musl/template
+++ b/srcpkgs/cross-i686-linux-musl/template
@@ -10,8 +10,8 @@ _sysroot="/usr/${_triplet}"
 _archflags="-march=i686"
 
 pkgname=cross-${_triplet}
-version=0.22
-revision=5
+version=0.23
+revision=1
 short_desc="Cross toolchain for i686 target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -33,8 +33,8 @@ nopie=yes
 nodebug=yes
 create_wrksrc=yes
 hostmakedepends="perl flex"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel"
-nostrip_files="libgcc.a libgcov.a libgcc_eh.a"
+makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
 depends="${pkgname}-libc-${version}_${revision}"
 only_for_archs="i686 x86_64 x86_64-musl"
 
@@ -163,12 +163,13 @@ _gcc_build() {
 	_args="--target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
 	_args+=" --prefix=/usr"
-	_args+=" --enable-languages=c,c++,lto"
+	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"
 	_args+=" --disable-libmpx"
 	_args+=" --disable-libmudflap"
+	_args+=" --enable-libquadmath"
 	_args+=" --enable-shared"
 	_args+=" --disable-symvers"
 	_args+=" libat_cv_have_ifunc=no"

--- a/srcpkgs/cross-i686-pc-linux-gnu/template
+++ b/srcpkgs/cross-i686-pc-linux-gnu/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.27
 _gcc_version=6.3.0
-_glibc_version=2.24
+_glibc_version=2.25
 _linux_version=4.9.8
 
 _triplet=i686-pc-linux-gnu
@@ -10,8 +10,8 @@ _archflags="-march=i686 -mtune=generic"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.22
-revision=3
+version=0.23
+revision=1
 short_desc="GNU Cross toolchain for the ${_triplet} target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -24,7 +24,7 @@ distfiles="
 checksum="
  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
  f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
- 99d4a3e8efd144d71488e478f62587578c0f4e1fa0b4eed47ee3d4975ebeb5d3
+ 067bd9bb3390e79aa45911537d13c3721f1d9d3769931a30c2681bfee66f23a0
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45"
 
 only_for_archs="armv6l armv7l x86_64"
@@ -36,7 +36,7 @@ create_wrksrc=yes
 hostmakedepends="perl flex"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
 depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
 
 _apply_patch() {
 	local args="$1" pname="$(basename $2)"
@@ -217,7 +217,7 @@ _gcc_build() {
 	_args+=" --prefix=/usr"
 	_args+=" --libdir=/usr/lib"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,lto"
+	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --with-gnu-as"
 	_args+=" --with-gnu-ld"
 	_args+=" --disable-multilib"
@@ -230,7 +230,7 @@ _gcc_build() {
 	_args+=" --enable-gnu-unique-object"
 	_args+=" --enable-lto"
 	_args+=" --enable-gnu-indirect-function"
-	_args+=" --disable-libquadmath"
+	_args+=" --enable-libquadmath"
 	_args+=" --disable-libatomic"
 	_args+=" --disable-libssp"
 	_args+=" --disable-libmpx"

--- a/srcpkgs/cross-mips-linux-musl/template
+++ b/srcpkgs/cross-mips-linux-musl/template
@@ -11,8 +11,8 @@ _archflags="-march=mips32r2 -msoft-float"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.22
-revision=5
+version=0.23
+revision=1
 short_desc="Cross toolchain for MIPS32r2 BE softfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -35,8 +35,8 @@ nodebug=yes
 create_wrksrc=yes
 
 hostmakedepends="perl flex"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel"
-nostrip_files="libgcc.a libgcov.a libgcc_eh.a"
+makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
 _apply_patch() {
@@ -162,7 +162,7 @@ _gcc_build() {
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
 	_args+=" --libexecdir=/usr/lib"
-	_args+=" --enable-languages=c,c++,lto"
+	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"

--- a/srcpkgs/cross-mipsel-linux-musl/template
+++ b/srcpkgs/cross-mipsel-linux-musl/template
@@ -11,8 +11,8 @@ _archflags="-march=mips32r2 -msoft-float"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.22
-revision=5
+version=0.23
+revision=1
 short_desc="Cross toolchain for MIPS32r2 LE softfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -35,8 +35,8 @@ nodebug=yes
 create_wrksrc=yes
 
 hostmakedepends="perl flex"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel"
-nostrip_files="libgcc.a libgcov.a libgcc_eh.a"
+makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
 _apply_patch() {
@@ -162,7 +162,7 @@ _gcc_build() {
 	_args+=" --libexecdir=/usr/lib"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,lto"
+	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"

--- a/srcpkgs/cross-mipsel-linux-muslhf/template
+++ b/srcpkgs/cross-mipsel-linux-muslhf/template
@@ -11,8 +11,8 @@ _archflags="-march=mips32r2 -mhard-float"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.22
-revision=5
+version=0.23
+revision=1
 short_desc="Cross toolchain for MIPS32r2 LE hardfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -35,8 +35,8 @@ nodebug=yes
 create_wrksrc=yes
 
 hostmakedepends="perl flex"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel"
-nostrip_files="libgcc.a libgcov.a libgcc_eh.a"
+makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
 _apply_patch() {
@@ -162,7 +162,7 @@ _gcc_build() {
 	_args+=" --libexecdir=/usr/lib"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,lto"
+	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"

--- a/srcpkgs/cross-vpkg-dummy/template
+++ b/srcpkgs/cross-vpkg-dummy/template
@@ -23,6 +23,7 @@ provides="
 	libgomp-9999_1
 	libgomp-devel-9999_1
 	gcc-9999_1
+	gcc-fortran-9999_1
 	glibc-9999_1
 	glibc-devel-9999_1
 	musl-9999_1"
@@ -35,6 +36,7 @@ conflicts="
 	libgomp>=0
 	libgomp-devel>=0
 	gcc>=0
+	gcc-fortran>=0
 	glibc>=0
 	glibc-devel>=0
 	musl>=0"

--- a/srcpkgs/cross-x86_64-linux-musl/template
+++ b/srcpkgs/cross-x86_64-linux-musl/template
@@ -9,8 +9,8 @@ _triplet=x86_64-linux-musl
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.22
-revision=5
+version=0.23
+revision=1
 short_desc="Cross toolchain for x86_64 with musl"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -32,8 +32,8 @@ nopie=yes
 nodebug=yes
 create_wrksrc=yes
 hostmakedepends="perl flex"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel"
-nostrip_files="libgcc.a libgcov.a libgcc_eh.a"
+makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
 depends="${pkgname}-libc-${version}_${revision}"
 only_for_archs="i686 i686-musl x86_64"
 
@@ -110,8 +110,8 @@ _gcc_bootstrap() {
 	_args+=" libat_cv_have_ifunc=no"
 	_args+=" ${_fpuflags}"
 
-	CFLAGS="-O0 -g0" CXXFLAGS="-O0 -g0" \
-		../gcc-${_gcc_version}/configure ${_args}
+	../gcc-${_gcc_version}/configure ${_args}
+	find -name Makefile -exec sed -i "{}" -e "s;^CFLAGS.*;& -fPIC -D__WCHAR_TYPE__=int;" \;
 
 	make ${makejobs}
 	make install
@@ -165,8 +165,9 @@ _gcc_build() {
 	_args="--prefix=/usr"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,lto"
+	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
+	_args+=" --enable-libquadmath"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"
 	_args+=" --disable-libmpx"
@@ -177,6 +178,7 @@ _gcc_build() {
 	_args+=" ${_fpuflags}"
 
 	../gcc-${_gcc_version}/configure ${_args}
+	find -name Makefile -exec sed -i "{}" -e "s;^CFLAGS.*;& -fPIC -D__WCHAR_TYPE__=int;" \;
 
 	make ${makejobs}
 
@@ -187,7 +189,7 @@ do_build() {
 	# Ensure we use sane environment
 	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
 	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os -pipe" CXXFLAGS="-Os -pipe"
+	export CFLAGS="-Os -pipe -fPIC" CXXFLAGS="-Os -pipe -fPIC"
 
 	for f in include lib libexec bin sbin; do
 		if [ ! -d ${_sysroot}/usr/${f} ]; then


### PR DESCRIPTION
+ Enable the fortran language for all cross compilers.
+ Update glibc to 2.25 for the cross-*-gnu cross compilers.
+ Enable lapack cross compiling with `<triplet>-gfortran`. (separate PR)

