### PR TITLE
speech-dispatcher: build/install the Python 3 bits and libao driver.

### DIFF
--- a/srcpkgs/speech-dispatcher/patches/spdconfig.patch
+++ b/srcpkgs/speech-dispatcher/patches/spdconfig.patch
@@ -1,0 +1,23 @@
+Patch pulled from upstream repo, author Samuel Thibault.
+Goes away with 0.8.7 or whatever their next version is.
+diff --git src/api/python/speechd_config/config.py.in src/api/python/speechd_config/config.py.in
+index a59ef79a..e9b2ae53 100644
+--- src/api/python/speechd_config/config.py.in
++++ src/api/python/speechd_config/config.py.in
+@@ -156,6 +156,7 @@ def setup_argparse():
+     parser.add_argument('-D', '--debug', dest='debug',
+             action="store_true", default=False,
+             help=_("Debug a problem and generate a report"))
++    return parser
+ 
+ class Tests:
+     """Tests of functionality of Speech Dispatcher and its dependencies
+@@ -750,7 +751,7 @@ you have to start it manually to continue."""))
+ 
+ def main():
+     options = setup_argparse()
+-    options.parse()
++    options = options.parse_args()
+     test = Tests()
+     configure = Configure(test) # that should possibly be refactored, test should not be passed
+ 

--- a/srcpkgs/speech-dispatcher/template
+++ b/srcpkgs/speech-dispatcher/template
@@ -1,18 +1,20 @@
 # Template build file for 'speech-dispatcher'.
 pkgname=speech-dispatcher
 version=0.8.6
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 short_desc="High-level device independent layer for speech synthesis interface"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL2/FDL"
+license="GPL-2, LGPL-2.1, GFDL-1.2"
 homepage="http://devel.freebsoft.org/speechd"
 distfiles="http://devel.freebsoft.org/pub/projects/speechd/${pkgname}-${version}.tar.gz"
 checksum=c233dc3757c1f0d3676480d1052d42d88d18d29ab0cb0c8b5ce8edc3e7386ff8
+pycompile_module='speechd speechd_config'
 
 hostmakedepends="pkg-config intltool"
-makedepends="libltdl-devel glib-devel dotconf-devel libsndfile-devel libespeak-devel"
+makedepends="libltdl-devel glib-devel dotconf-devel libsndfile-devel libespeak-devel libao-devel python3-devel"
+depends="python3"
 conf_files="
  /etc/speech-dispatcher/clients/*.conf
  /etc/speech-dispatcher/modules/*.conf


### PR DESCRIPTION
The Python 3 component is just a config file generating tool
and a small client library.  Orca (the biggest user of Speech
Dispatcher) breaks if it isn't available.  The libao audio
driver also seems to be their best one, so build it as well.