### PR TITLE
python-github3: Use stable release, clean depends

### DIFF
--- a/srcpkgs/python-github3/template
+++ b/srcpkgs/python-github3/template
@@ -1,19 +1,20 @@
 # Template file for 'python-github3'
 pkgname=python-github3
-version=1.0.0a4
+reverts="1.0.0a4_1"
+version=0.9.6
 revision=1
 noarch=yes
 wrksrc="github3.py-${version}"
 build_style=python-module
 pycompile_module="github3"
 hostmakedepends="python-setuptools python3-setuptools"
-depends="python-requests python-uritemplate python-openssl python-ndg_httpsclient python-pyasn1"
+depends="python-requests python-uritemplate"
 short_desc="Wrapper for GitHub's API (Python2)"
 maintainer="Joseph LaFreniere <joseph@lafreniere.xyz>"
 homepage="https://github3py.readthedocs.org"
 license="3-clause-BSD"
 distfiles="${PYPI_SITE}/g/github3.py/github3.py-${version}.tar.gz"
-checksum=570e776e2ab1318533b1555ee2f2f784142883b49cb4090582c0307c16cc1666
+checksum=b831db85d7ff4a99d6f4e8368918095afeea10f0ec50798f9a937c830ab41dc5
 
 post_install() {
 	vlicense LICENSE
@@ -21,7 +22,7 @@ post_install() {
 
 python3-github3_package() {
 	noarch=yes
-	depends="python3-requests python3-uritemplate python3-openssl python3-ndg_httpsclient python3-pyasn1"
+	depends="python3-requests python3-uritemplate"
 	pycompile_module="github3"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {


### PR DESCRIPTION
The former version packaged was 1.0.0a4.  However, 1.0.0a4 is in fact an
alpha release despite being tagged in the upstream Git repository and
being available on PyPI.  This update reverts the package to 0.9.6, the
latest stable release.

The project's PyPI page lists pyOpenSSL, ndg-httpsclient, and pyasn1 as
dependencies.  grepping github3's repository reveals that none of these
libraries are ever imported.  As such, they have all been removed from
the template's depends.