### PR TITLE
perl-Test-Script: update to 1.16

### DIFF
--- a/srcpkgs/perl-Test-Script/template
+++ b/srcpkgs/perl-Test-Script/template
@@ -1,6 +1,6 @@
 # Template build file for 'perl-Test-Script'.
 pkgname=perl-Test-Script
-version=1.14
+version=1.16
 revision=1
 wrksrc="${pkgname#*-}-${version}"
 build_style=perl-module
@@ -12,5 +12,5 @@ maintainer="Enguerrand de Rochefort <voidlinux@rochefort.de>"
 homepage="https://metacpan.org/pod/Test::Script"
 license="GPL-1, Artistic"
 distfiles="$CPAN_SITE/Test/Test-Script-${version}.tar.gz"
-checksum=3f29824e101e4402f4417427b157ee7069ba5e1268315386f72452938693cd99
-nocross="https://build.voidlinux.eu/builders/armv6l_builder/builds/27930/steps/shell_3/logs/stdio"
+checksum=9a38d46d8c19d92330d5a6be2547ed709ba6f2fc2758556d9e191754f264df06
+nocross="https://api.travis-ci.org/jobs/209362491/log.txt"


### PR DESCRIPTION
First build will fail, and for some reason the mirror only has 1.07, 1.15 & 1.16