### PR TITLE
libcap: fix gperf build error

### DIFF
--- a/srcpkgs/libcap/patches/gperf-3.1-fix.patch
+++ b/srcpkgs/libcap/patches/gperf-3.1-fix.patch
@@ -1,0 +1,13 @@
+# Source: https://604802.bugs.gentoo.org/attachment.cgi?id=460354
+
+--- libcap/Makefile
++++ libcap/Makefile
+@@ -41,7 +41,7 @@ cap_names.h: _makenames
+ 	./_makenames > cap_names.h
+ 
+ $(GPERF_OUTPUT): cap_names.list.h
+-	perl -e 'print "struct __cap_token_s { const char *name; int index; };\n%{\nconst struct __cap_token_s *__cap_lookup_name(const char *, unsigned int);\n%}\n%%\n"; while ($$l = <>) { $$l =~ s/[\{\"]//g; $$l =~ s/\}.*// ; print $$l; }' < $< | gperf --ignore-case --language=ANSI-C --readonly --null-strings --global-table --hash-function-name=__cap_hash_name --lookup-function-name="__cap_lookup_name" -c -t -m20 $(INDENT) > $@
++	perl -e 'print "struct __cap_token_s { const char *name; int index; };\n%%\n"; while ($$l = <>) { $$l =~ s/[\{\"]//g; $$l =~ s/\}.*// ; print $$l; }' < $< | gperf --ignore-case --language=ANSI-C --includes --readonly --null-strings --global-table --hash-function-name=__cap_hash_name --lookup-function-name="__cap_lookup_name" -c -t -m20 $(INDENT) > $@
+ 
+ cap_names.list.h: Makefile $(KERNEL_HEADERS)/linux/capability.h
+ 	@echo "=> making $@ from $(KERNEL_HEADERS)/linux/capability.h"

--- a/srcpkgs/libcap/template
+++ b/srcpkgs/libcap/template
@@ -1,7 +1,7 @@
 # Template file for 'libcap'
 pkgname=libcap
 version=2.25
-revision=1
+revision=2
 bootstrap=yes
 makedepends="attr-devel"
 short_desc="POSIX.1e capabilities suite"


### PR DESCRIPTION
Added a patch from gentoo to allow building with gperf 3.1