### PR TITLE
New package: fuse-emulator

### DIFF
--- a/srcpkgs/fuse-emulator/template
+++ b/srcpkgs/fuse-emulator/template
@@ -1,0 +1,15 @@
+# Template file for 'fuse-emulator'
+pkgname=fuse-emulator
+version=1.3.4
+revision=1
+wrksrc="fuse-${version}"
+build_style=gnu-configure
+configure_args="--verbose --with-gtk --with-libspectrum-prefix=/usr --enable-desktop-integration"
+hostmakedepends="pkg-config perl"
+makedepends="gtk+-devel alsa-lib-devel glib-devel libao-devel libgcrypt-devel libspectrum-devel zlib-devel libpng-devel"
+short_desc="Free Unix Spectrum Emulator"
+maintainer="Jakub Skrzypnik <j.skrzypnik@openmailbox.org>"
+license="GPL-2"
+homepage="http://fuse-emulator.sourceforge.net"
+distfiles="${SOURCEFORGE_SITE}/${pkgname}/fuse-${version}.tar.gz"
+checksum=3089d2c3e08c72055ccbcbd5bcc69fd6cc492b8ac649ee15fc93703f0d3d9486

--- a/srcpkgs/libspectrum-devel
+++ b/srcpkgs/libspectrum-devel
@@ -1,0 +1,1 @@
+libspectrum

--- a/srcpkgs/libspectrum/template
+++ b/srcpkgs/libspectrum/template
@@ -1,0 +1,22 @@
+# Template file for 'libspectrum'
+pkgname=libspectrum
+version=1.2.2
+revision=1
+build_style=gnu-configure
+hostmakedepends="perl pkg-config"
+makedepends="glib-devel libgcrypt-devel zlib-devel bzip2-devel audiofile-devel"
+short_desc="Spectrum emulation support library"
+maintainer="Jakub Skrzypnik <j.skrzypnik@openmailbox.org>"
+license="GPL-2"
+homepage="http://fuse-emulator.sourceforge.net/"
+distfiles="${SOURCEFORGE_SITE}/fuse-emulator/${pkgname}-${version}.tar.gz"
+checksum=1f8a365df30d7cb2bb5c289163cf122241660cae6dc2cb70687064c847ad12d1
+
+libspectrum-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/*.a
+	}
+}


### PR DESCRIPTION
Back to pushing packages after some months of inactivity.

**FUSE** is a **F**ree **U**nix **S**pectrum **E**mulator.

I had packaged it locally for some days, works well, I'm using it together with Z80 assembler.

About ROM files inside: Amstrad (current holder of ZX Spectrum copyrights) allowed to use them freely with any emulator, redistribute, disassemble or patch, with copyright strings retained.

**NOTE**: `fuse(1)` is different than `fuse(8)`, I don't see a problem here.