### PR TITLE
New package: kakoune-20170311

### DIFF
--- a/srcpkgs/kakoune/template
+++ b/srcpkgs/kakoune/template
@@ -1,0 +1,18 @@
+# Template file for 'kakoune'
+pkgname=kakoune
+version=0.0.20170311
+revision=1
+_commit="b9317ba38c3e8f2bc4196705d65bbc8a8ef8dbf4"
+wrksrc="${pkgname}-${_commit}"
+build_wrksrc="src"
+build_style=gnu-makefile
+make_build_args="debug=no"
+make_install_args="debug=no"
+hostmakedepends="unzip asciidoc"
+makedepends="boost-devel ncurses-devel"
+short_desc="Selection-based vim-like editor with less keystrokes"
+maintainer="Jakub Skrzypnik <j.skrzypnik@openmailbox.org>"
+license="UNLICENSE"
+homepage="http://kakoune.org"
+distfiles="https://github.com/mawww/kakoune/archive/${_commit}.zip"
+checksum=a867c61b1071268dfd27da5ed278a838a042c1add0416fe9384379543d9d630e


### PR DESCRIPTION
Kakoune is a vim-like text editor, but using a different approach to text editing. It's mostly selection based, uses multiple cursors and has improved (more efficient) key grammar.

Despite being "unreleased" it's pretty usable, I'm using it since late 2015, exclusively since past few months. Did some serious work with it, nothing bad happened.

I've asked the author about versioning scheme, he just said that's only the marketing matter and still not decided about versioning scheme. Kinda weird, but software itself works very well.