### PR TITLE
New package: qucs-0.0.19 

### DIFF
--- a/srcpkgs/ADMS-qucs/template
+++ b/srcpkgs/ADMS-qucs/template
@@ -1,0 +1,20 @@
+# Template file for 'ADMS-qucs'
+pkgname=ADMS-qucs
+version=2.3.6
+revision=1
+wrksrc="ADMS-release-${version}"
+build_style=gnu-configure
+configure_args="--enable-maintainer-mode" # As required by readme.MD
+hostmakedepends="libtool automake flex bison perl perl-XML-LibXML"
+short_desc="Automatic Device Model Synthesizer (Qucs fork)"
+maintainer="Martijn van Buul <martijn.van.buul@gmail.com>"
+license="GPL-3"
+homepage="htps://github.com/Qucs/ADMS"
+distfiles="https://github.com/Qucs/ADMS/archive/release-2.3.6.tar.gz"
+checksum="aaf3f635aae41e1c11913e09b8e1bc5eea64256dcec70f3f60d1b9a794af6053"
+disable_parallel_build="yes" # Suspected race condition involving bison
+
+pre_configure() {
+	./bootstrap.sh
+}
+

--- a/srcpkgs/perl-XML-LibXML/template
+++ b/srcpkgs/perl-XML-LibXML/template
@@ -1,0 +1,16 @@
+# Template file for 'perl-XML-LibXML'
+pkgname=perl-XML-LibXML
+version=2.0129
+revision=1
+wrksrc="${pkgname/perl-/}-${version}"
+build_style=perl-module
+hostmakedepends="perl"
+makedepends="${hostmakedepends} libxml2-devel perl-XML-SAX perl-XML-NamespaceSupport"
+depends="perl>=5.20 perl-XML-SAX perl-XML-NamespaceSupport"
+short_desc="Perl extension interface to libxml2"
+maintainer="Martijn van Buul <martijn.van.buul@gmail.com>"
+license="Artistic, GPL-1"
+homepage="http://search.cpan.org/dist/${pkgname/perl-/}/"
+distfiles="${CPAN_SITE}/XML/${pkgname/perl-/}-${version}.tar.gz"
+checksum="5ca0269ba06800c84061a7f3333c85fab5584d69cd7b4e0641963da7fd36b366"
+nocross="yes" # tries to execute target-compiled binary during configure

--- a/srcpkgs/qucs/template
+++ b/srcpkgs/qucs/template
@@ -1,0 +1,15 @@
+# Template file for 'qucs'
+pkgname=qucs
+version=0.0.19
+revision=1
+build_style=gnu-configure
+configure_args="--disable-doc"
+hostmakedepends="ADMS-qucs gperf qt-devel"
+makedepends="qt-devel"
+short_desc="Quite Universal Circuit Simulator"
+maintainer="Martijn van Buul <martijn.van.buul@gmail.com>"
+license="GPL-2"
+homepage="http://qucs.sourceforge.net"
+distfiles="${SOURCEFORGE_SITE}/${pkgname}/${version}/${pkgname}-${version}.tar.gz"
+checksum="45c6434fde24c533e63550675ac21cdbd3cc6cbba29b82a1dc3f36e7dd4b3b3e"
+nocross="yes" # seems to compile all the way, but seems to link against the wrong libX11 (at least)


### PR DESCRIPTION
From the wikipedia description: 

Quite Universal Circuit Simulator (Qucs) is an open-source electronics circuit simulator software released under GPL. It gives you the ability to set up a circuit with a graphical user interface and simulate the large-signal, small-signal and noise behaviour of the circuit. Pure digital simulations are also supported using VHDL and/or Verilog.

This includes two dependencies:
* ADMS-qucs : A fork of ADMS ("Automatic Device Model Synthesizer"), which is used to create .C source from Verilog files. The original ADMS project has gone stale. 
* perl-XML-LibXML: A perl binding for the libxml2 library. Note that the current version of libxml2 (2.9.4) is marked as "broken" by perl-XML-LibXML, but it passes all regression tests.