### PR TITLE
New package: fsharp-4.1.0.2

### DIFF
--- a/srcpkgs/fsharp/template
+++ b/srcpkgs/fsharp/template
@@ -1,0 +1,24 @@
+# Template file for 'fsharp'
+pkgname=fsharp
+version=4.1.0.2
+revision=1
+lib32disabled=yes
+build_style=gnu-configure
+configure_args="--with-gacdir=/usr/lib/mono/gac"
+hostmakedepends="automake pkg-config mono-devel"
+makedepends="mono-devel"
+depends="mono"
+short_desc="F# compiler, core library and tools"
+maintainer="Wojciech Nawrocki <wjnawrocki@protonmail.com>"
+license="Apache-2.0"
+homepage="http://fsharp.org"
+distfiles="https://github.com/fsharp/fsharp/archive/$version.tar.gz"
+checksum=7633bb37846197638c563f65d184fc2fbb6b4b447afbd2251fac401fe7a7c636
+
+case "$XBPS_TARGET_MACHINE" in
+	*-musl) broken="https://s3.amazonaws.com/archive.travis-ci.org/jobs/211856891/log.txt"
+esac
+
+pre_configure() {
+	autoreconf -fi
+}


### PR DESCRIPTION
The F# compiler is required for MonoDevelop. Building is currently broken on musl libc