### PR TITLE
xpra: remove pulseaudio dependency

### DIFF
--- a/srcpkgs/xpra/template
+++ b/srcpkgs/xpra/template
@@ -1,7 +1,7 @@
 # Template file for 'xpra'
 pkgname=xpra
 version=2.0
-revision=1
+revision=2
 build_style=python2-module
 conf_files="
  /etc/xpra/xpra.conf
@@ -13,7 +13,7 @@ makedepends="ffmpeg-devel libXcomposite-devel libXdamage-devel libXrandr-devel
  libXtst-devel libwebp-devel libxkbfile-devel pygtk-devel x264-devel
  $(vopt_if vpx libvpx-devel)"
 depends="pygtk python-Pillow xorg-server-xvfb python-rencode python-lz4
- python-cups xf86-video-dummy python-PyOpenGL-accelerate pulseaudio cups
+ python-cups xf86-video-dummy python-PyOpenGL-accelerate cups
  python-dbus xauth python-numpy"
 short_desc="Like screen(1) for X"
 maintainer="Leah Neukirchen <leah@vuxu.org>"


### PR DESCRIPTION
Up to and including xpra 1.0.1, connection would always fail with a
Python exception unless pulseaudio was installed. xpra 1.0.2 seems to
have fixed this issue.