### PR TITLE
openssh: update to 7.5p1.

### DIFF
--- a/srcpkgs/openssh/patches/bug2722.patch
+++ b/srcpkgs/openssh/patches/bug2722.patch
@@ -1,0 +1,36 @@
+--- openbsd-compat/openbsd-compat.h	
++++ openbsd-compat/openbsd-compat.h	
+@@ -179,20 +179,25 @@ int writev(int, struct iovec *, int);
+ int getpeereid(int , uid_t *, gid_t *);
+ #endif
+ 
+-#ifdef HAVE_ARC4RANDOM
+-# ifndef HAVE_ARC4RANDOM_STIR
+-#  define arc4random_stir()
+-# endif
+-#else
++#if !defined(HAVE_ARC4RANDOM) || defined(LIBRESSL_VERSION_NUMBER)
+ unsigned int arc4random(void);
++#endif
++
++#if defined(HAVE_ARC4RANDOM_STIR)
+ void arc4random_stir(void);
+-#endif /* !HAVE_ARC4RANDOM */
++#elif defined(HAVE_ARC4RANDOM) || defined(LIBRESSL_VERSION_NUMBER)
++/* Recent system/libressl implementation; no need for explicit stir */
++# define arc4random_stir()
++#else
++/* openbsd-compat/arc4random.c provides arc4random_stir() */
++void arc4random_stir(void);
++#endif
+ 
+-#ifndef HAVE_ARC4RANDOM_BUF
++#if !defined(HAVE_ARC4RANDOM_BUF) || defined(LIBRESSL_VERSION_NUMBER)
+ void arc4random_buf(void *, size_t);
+ #endif
+ 
+-#ifndef HAVE_ARC4RANDOM_UNIFORM
++#if !defined(HAVE_ARC4RANDOM_UNIFORM) || defined(LIBRESSL_VERSION_NUMBER)
+ u_int32_t arc4random_uniform(u_int32_t);
+ #endif
+ 

--- a/srcpkgs/openssh/patches/config.patch
+++ b/srcpkgs/openssh/patches/config.patch
@@ -1,0 +1,57 @@
+--- configure.ac.orig
++++ configure.ac
+@@ -184,6 +184,7 @@
+ 	OSSH_CHECK_CFLAG_COMPILE([-Wall])
+ 	OSSH_CHECK_CFLAG_COMPILE([-Wpointer-arith])
+ 	OSSH_CHECK_CFLAG_COMPILE([-Wuninitialized])
++	OSSH_CHECK_CFLAG_COMPILE([-Wimplicit-function-declaration])
+ 	OSSH_CHECK_CFLAG_COMPILE([-Wsign-compare])
+ 	OSSH_CHECK_CFLAG_COMPILE([-Wformat-security])
+ 	OSSH_CHECK_CFLAG_COMPILE([-Wsizeof-pointer-memaccess])
+@@ -1692,7 +1693,6 @@
+ 	endgrent \
+ 	err \
+ 	errx \
+-	explicit_bzero \
+ 	fchmod \
+ 	fchown \
+ 	freeaddrinfo \
+@@ -1732,7 +1732,6 @@
+ 	prctl \
+ 	pstat \
+ 	readpassphrase \
+-	reallocarray \
+ 	recvmsg \
+ 	rresvport_af \
+ 	sendmsg \
+@@ -1761,8 +1760,6 @@
+ 	strcasestr \
+ 	strdup \
+ 	strerror \
+-	strlcat \
+-	strlcpy \
+ 	strmode \
+ 	strnlen \
+ 	strnvis \
+@@ -1774,7 +1771,6 @@
+ 	swap32 \
+ 	sysconf \
+ 	tcgetpgrp \
+-	timingsafe_bcmp \
+ 	truncate \
+ 	unsetenv \
+ 	updwtmpx \
+@@ -1785,6 +1781,13 @@
+ 	waitpid \
+ 	warn \
+ ])
++AC_CHECK_DECLS([ \
++	explicit_bzero, \
++	strlcat, \
++	strlcpy, 
++	timingsafe_bcmp \
++], [], [], [[#include <string.h>]])
++AC_CHECK_DECLS([reallocarray], [], [], [[#include <stdlib.h>]])
+ 
+ dnl Wide character support.
+ AC_CHECK_FUNCS([mblen mbtowc nl_langinfo wcwidth])

--- a/srcpkgs/openssh/patches/werror.patch
+++ b/srcpkgs/openssh/patches/werror.patch
@@ -1,0 +1,26 @@
+--- servconf.c.orig
++++ servconf.c
+@@ -935,13 +935,6 @@
+ 	{ "no",				0 },
+ 	{ NULL, -1 }
+ };
+-static const struct multistate multistate_privsep[] = {
+-	{ "yes",			PRIVSEP_NOSANDBOX },
+-	{ "sandbox",			PRIVSEP_ON },
+-	{ "nosandbox",			PRIVSEP_NOSANDBOX },
+-	{ "no",				PRIVSEP_OFF },
+-	{ NULL, -1 }
+-};
+ static const struct multistate multistate_tcpfwd[] = {
+ 	{ "yes",			FORWARD_ALLOW },
+ 	{ "all",			FORWARD_ALLOW },
+--- configure.ac.orig
++++ configure.ac
+@@ -399,7 +399,6 @@
+ 	sys/bitypes.h \
+ 	sys/bsdtty.h \
+ 	sys/capability.h \
+-	sys/cdefs.h \
+ 	sys/dir.h \
+ 	sys/mman.h \
+ 	sys/ndir.h \

--- a/srcpkgs/openssh/template
+++ b/srcpkgs/openssh/template
@@ -1,15 +1,17 @@
 # Template file for 'openssh'
 pkgname=openssh
 version=7.5p1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--datadir=/usr/share/openssh
  --sysconfdir=/etc/ssh --without-selinux --with-privsep-user=nobody
  --with-mantype=doc --without-rpath --with-xauth=/usr/bin/xauth
  --disable-strip --with-privsep-path=/var/chroot/ssh
  --with-pid-dir=/run --with-pam --without-kerberos5 --without-ssh1
- --with-libedit --with-Werror LD=$CC
- $(vopt_with ldns) $(vopt_if ssl --with-ssl-engine --without-openssl)"
+ --with-libedit --with-Werror
+ $(vopt_with ldns ldns=$XBPS_CROSS_BASE/usr)
+ $(vopt_if ssl --with-ssl-engine --without-openssl)
+ LD=$CC"
 hostmakedepends="autoconf perl"
 makedepends="zlib-devel pam-devel libedit-devel
  $(vopt_if ssl libressl-devel) $(vopt_if ldns libldns-devel)"

--- a/srcpkgs/openssh/template
+++ b/srcpkgs/openssh/template
@@ -1,17 +1,16 @@
 # Template file for 'openssh'
 pkgname=openssh
-reverts=7.5p1_1
-version=7.4p1
-revision=4
+version=7.5p1
+revision=2
 build_style=gnu-configure
 configure_args="--datadir=/usr/share/openssh
  --sysconfdir=/etc/ssh --without-selinux --with-privsep-user=nobody
  --with-mantype=doc --without-rpath --with-xauth=/usr/bin/xauth
  --disable-strip --with-privsep-path=/var/chroot/ssh
- --with-pid-dir=/run --with-pam --without-kerberos5
- $(vopt_with ldns) $(vopt_if ssl --with-ssl-engine --without-openssl)
- --without-ssh1 --with-libedit LD=$CC"
-hostmakedepends="perl"
+ --with-pid-dir=/run --with-pam --without-kerberos5 --without-ssh1
+ --with-libedit --with-Werror LD=$CC
+ $(vopt_with ldns) $(vopt_if ssl --with-ssl-engine --without-openssl)"
+hostmakedepends="autoconf perl"
 makedepends="zlib-devel pam-devel libedit-devel
  $(vopt_if ssl libressl-devel) $(vopt_if ldns libldns-devel)"
 short_desc="The OpenSSH implementation of SSH protocol"
@@ -21,7 +20,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.openssh.org"
 license="BSD"
 distfiles="http://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/$pkgname-$version.tar.gz"
-checksum=1b1fc4a14e2024293181924ed24872e6f2e06293f3e8926a376b8aec481f19d1
+checksum=9846e3c5fab9f0547400b4d2c017992f914222b3fd1f8eee6c7dc6bc5e59f9f0
 
 # Package build options
 build_options="ldns ssl"
@@ -32,6 +31,9 @@ case $XBPS_TARGET_MACHINE in
 		configure_args+=" --disable-wtmp --disable-utmp"
 esac
 
+pre_configure() {
+	autoreconf -fi
+}
 post_install() {
 	vinstall contrib/sshd.pam.generic 644 etc/pam.d sshd
 	vbin contrib/ssh-copy-id


### PR DESCRIPTION
Previous build of OpenSSH 7.5p1 broke due to undefined prototypes for
functions provided by LibreSSL, which then were called according to
the wrong calling convention.

We had this situation before in
https://github.com/OpenSMTPD/OpenSMTPD/issues/691

Build with -Werror now to detect new issues arising in the future.
Remove one obsolete constant value to make this pass.

Check OpenBSD libc functions (partially provided by glibc and musl)
using AC_CHECK_DECLS instead to verify they have a prototype.

Explicitly define prototypes for arc4random* when LibreSSL is detected
(from https://bugzilla.mindrot.org/show_bug.cgi?id=2465)