### PR TITLE
xbps: bump to depend on glibc>=2.25_1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -17,36 +17,36 @@
 # one (order top->bottom) is preferred over the next ones.
 #
 libc.so musl-0.9.9_1
-libc.so.6 glibc-2.8_1
-libm.so.6 glibc-2.8_1
-libpthread.so.0 glibc-2.8_1
-librt.so.1 glibc-2.8_1
-libdl.so.2 glibc-2.8_1
-ld-linux-x86-64.so.2 glibc-2.8_1 x86_64
-ld-linux.so.2 glibc-2.8_1 i686
-ld-linux.so.3 glibc-2.17_1 armv5tel
-ld-linux-aarch64.so.1 glibc-2.19_1 aarch64
-ld.so.1 glibc-2.17_1 mips
-ld-linux-armhf.so.3 glibc-2.17_1
-libresolv.so.2 glibc-2.8_1
-libanl.so.1 glibc-2.8_1
-libthread_db.so.1 glibc-2.8_1
-libutil.so.1 glibc-2.8_1
-libnsl.so.1 glibc-2.8_1
-libnss_db.so.2 glibc-2.22_1
-libnss_files.so.2 glibc-2.8_1
-libnss_compat.so.2 glibc-2.8_1
-libnss_dns.so.2 glibc-2.8_1
-libnss_hesiod.so.2 glibc-2.8_1
-libnss_nisplus.so.2 glibc-2.8_1
-libnss_nis.so.2 glibc-2.8_1
-libcrypt.so.1 glibc-2.8_1
-libBrokenLocale.so.1 glibc-2.8_1
-libmemusage.so glibc-2.8_1
-libSegFault.so glibc-2.8_1
-libpcprofile.so glibc-2.8_1
-libcidn.so.1 glibc-2.8_1
-libmvec.so.1 glibc-2.22_1
+libc.so.6 glibc-2.25_1
+libm.so.6 glibc-2.25_1
+libpthread.so.0 glibc-2.25_1
+librt.so.1 glibc-2.25_1
+libdl.so.2 glibc-2.25_1
+ld-linux-x86-64.so.2 glibc-2.25_1 x86_64
+ld-linux.so.2 glibc-2.25_1 i686
+ld-linux.so.3 glibc-2.25_1 armv5tel
+ld-linux-aarch64.so.1 glibc-2.25_1 aarch64
+ld.so.1 glibc-2.25_1 mips
+ld-linux-armhf.so.3 glibc-2.25_1
+libresolv.so.2 glibc-2.25_1
+libanl.so.1 glibc-2.25_1
+libthread_db.so.1 glibc-2.25_1
+libutil.so.1 glibc-2.25_1
+libnsl.so.1 glibc-2.25_1
+libnss_db.so.2 glibc-2.25_1
+libnss_files.so.2 glibc-2.25_1
+libnss_compat.so.2 glibc-2.25_1
+libnss_dns.so.2 glibc-2.25_1
+libnss_hesiod.so.2 glibc-2.25_1
+libnss_nisplus.so.2 glibc-2.25_1
+libnss_nis.so.2 glibc-2.25_1
+libcrypt.so.1 glibc-2.25_1
+libBrokenLocale.so.1 glibc-2.25_1
+libmemusage.so glibc-2.25_1
+libSegFault.so glibc-2.25_1
+libpcprofile.so glibc-2.25_1
+libcidn.so.1 glibc-2.25_1
+libmvec.so.1 glibc-2.25_1
 libz.so.1 zlib-1.2.3_1
 libbz2.so.1 bzip2-1.0.5_1
 libarchive.so.13 libarchive-3.1.2_1

--- a/srcpkgs/xbps/template
+++ b/srcpkgs/xbps/template
@@ -1,7 +1,7 @@
 # Template file for 'xbps'
 pkgname=xbps
 version=0.51
-revision=16
+revision=17
 bootstrap=yes
 build_style=configure
 short_desc="The XBPS package system utilities"


### PR DESCRIPTION
We have versioned symbols for glibc, if you update an old system with
the previous glibc release installed, only xbps is updated and breaks
because of those versioned symbols.
Increasing the required glibc version in common/shlibs and bumping xbps
fixes this and would update glibc too if it upates itself.

https://forum.voidlinux.eu/t/update-of-fresh-install-breaking-xbps/2143