### PR TITLE
inspircd: Fix permissions on /var/run/inspircd

### DIFF
--- a/srcpkgs/inspircd/files/inspircd/run
+++ b/srcpkgs/inspircd/files/inspircd/run
@@ -2,6 +2,9 @@
 if [ ! -d /var/run/inspircd ]; then
 	mkdir -m0755 -p /var/run/inspircd
 fi
+
+chown inspircd:inspircd /var/run/inspircd
+
 exec chpst -u inspircd inspircd \
     --nofork --config /etc/inspircd/inspircd.conf \
     --logfile /var/log/inspircd/ircd.log

--- a/srcpkgs/inspircd/template
+++ b/srcpkgs/inspircd/template
@@ -1,7 +1,7 @@
 # Template file for 'inspircd'
 pkgname=inspircd
 version=2.0.23
-revision=2
+revision=3
 build_style=gnu-makefile
 hostmakedepends="perl pkg-config"
 makedepends="geoip-devel libressl-devel sqlite-devel"


### PR DESCRIPTION
Without the chown, inspircd just sits there trying to write the PID to a directory that it can't write to.