### PR TITLE
buku: add missing dependency python3-requests

### DIFF
--- a/srcpkgs/buku/template
+++ b/srcpkgs/buku/template
@@ -1,11 +1,11 @@
 # Template file for 'buku'
 pkgname=buku
 version=2.9
-revision=1
+revision=2
 wrksrc=Buku-${version}
 noarch=yes
 python_version="3"
-depends="python3"
+depends="python3 python3-requests"
 short_desc="A cmdline bookmark management utility"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="GPL-3"


### PR DESCRIPTION
This fixes [#6054](https://github.com/voidlinux/void-packages/issues/6054).