### PR TITLE
jhead: add CVE-2016-3822.patch

### DIFF
--- a/srcpkgs/jhead/patches/CVE-2016-3822.patch
+++ b/srcpkgs/jhead/patches/CVE-2016-3822.patch
@@ -1,0 +1,19 @@
+--- exif.c
++++ exif.c
+@@ -9,6 +9,7 @@
+ #include "jhead.h"
+ 
+ #include <math.h>
++#include <stdint.h>
+ 
+ static unsigned char * DirWithThumbnailPtrs;
+ static double FocalplaneXRes;
+@@ -527,7 +528,7 @@
+             unsigned OffsetVal;
+             OffsetVal = Get32u(DirEntry+8);
+             // If its bigger than 4 bytes, the dir entry contains an offset.
+-            if (OffsetVal+ByteCount > ExifLength){
++            if (OffsetVal > UINT32_MAX - ByteCount || OffsetVal+ByteCount > ExifLength){
+                 // Bogus pointer offset and / or bytecount value
+                 ErrNonfatal("Illegal value pointer for tag %04x in Exif", Tag,0);
+                 continue;

--- a/srcpkgs/jhead/template
+++ b/srcpkgs/jhead/template
@@ -1,7 +1,7 @@
 # Template file for 'jhead'
 pkgname=jhead
 version=3.00
-revision=2
+revision=3
 build_style=gnu-makefile
 short_desc="Display and manipulate EXIF header of JPEG images"
 maintainer="Oliver Kiddle <okiddle@yahoo.co.uk>"


### PR DESCRIPTION
fixes CVE-2016-3822, patch origin:
https://android.googlesource.com/platform/external/jhead/+/bae671597d47b9e5955c4cb742e468cebfd7ca6b