### PR TITLE
kdoctools: enable cross for dependents

### DIFF
--- a/srcpkgs/kdoctools/patches/cmake_macro_cross.patch
+++ b/srcpkgs/kdoctools/patches/cmake_macro_cross.patch
@@ -1,0 +1,5 @@
+--- KF5DocToolsMacros.cmake.orig
++++ KF5DocToolsMacros.cmake
+@@ -86 +86 @@ set(KDOCTOOLS_SERIALIZE_TOOL "" CACHE ST
+-set(KDOCTOOLS_MEINPROC_EXECUTABLE "KF5::meinproc5")
++set(KDOCTOOLS_MEINPROC_EXECUTABLE "meinproc5")

--- a/srcpkgs/kdoctools/template
+++ b/srcpkgs/kdoctools/template
@@ -1,7 +1,7 @@
 # Template file for 'kdoctools'
 pkgname=kdoctools
 version=5.29.0
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules perl perl-URI"


### PR DESCRIPTION
some packages use `kdoctools` to generate documentation.
When cross building, the cmake macro selects `meinproc5` executable from the target architecture.
Setting `KDOCTOOLS_MEINPROC_EXECUTABLE` to `meinproc5` prevents this and uses the executable for the host.
