### PR TITLE
Mosh rebuild

### DIFF
--- a/srcpkgs/mosh/template
+++ b/srcpkgs/mosh/template
@@ -1,7 +1,7 @@
 # Template file for 'mosh'
 pkgname=mosh
 version=1.3.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config protobuf-devel"
 makedepends="ncurses-devel protobuf-devel libutempter-devel libressl-devel"

--- a/srcpkgs/protobuf/template
+++ b/srcpkgs/protobuf/template
@@ -1,7 +1,7 @@
 # Template file for 'protobuf'
 pkgname=protobuf
 version=2.6.1
-revision=5
+revision=6
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
 makedepends="zlib-devel"


### PR DESCRIPTION
I just updated an arm system and got this while connecting via mosh:

`mosh-server: symbol lookup error: mosh-server: undefined symbol: _ZNK6google8protobuf11MessageLite25InitializationErrorStringB5cxx11Ev`

Rebuilding both, protobuf and mosh, solved the problem.