### PR TITLE
New package: hoogle-5.0.9

### DIFF
--- a/srcpkgs/hoogle/template
+++ b/srcpkgs/hoogle/template
@@ -1,0 +1,19 @@
+# Template file for 'hoogle'
+pkgname=hoogle
+version=5.0.9
+revision=1
+build_style=haskell-stack
+nocross=yes # Can't yet cross compile Haskell
+stackage="lts-8.8"
+makedepends="zlib-devel"
+short_desc="Haskell API search engine"
+maintainer="Inokentiy Babushkin <twk@twki.de>"
+license="BSD-3"
+homepage="http://hoogle.haskell.org/"
+distfiles="https://github.com/ndmitchell/${pkgname}/archive/v${version}.tar.gz"
+checksum="6f181b5d8f061a7679c8d394676201d23be363f4612fd0c93f908e7792591ed3"
+nopie=yes  # network-2.6.3.1 build fails with a relocation
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
Hoogle is a search engine for Haskell libraries. I think it's useful to have as a distribution package as it takes some time to compile and updating it by hand from a local stack or cabal installation is not that good of an idea.