### PR TITLE
speech-dispatcher: fix cross.

### DIFF
--- a/srcpkgs/speech-dispatcher/template
+++ b/srcpkgs/speech-dispatcher/template
@@ -1,7 +1,7 @@
 # Template build file for 'speech-dispatcher'.
 pkgname=speech-dispatcher
 version=0.8.6
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-static"
 short_desc="High-level device independent layer for speech synthesis interface"
@@ -12,7 +12,7 @@ distfiles="http://devel.freebsoft.org/pub/projects/speechd/${pkgname}-${version}
 checksum=c233dc3757c1f0d3676480d1052d42d88d18d29ab0cb0c8b5ce8edc3e7386ff8
 pycompile_module='speechd speechd_config'
 
-hostmakedepends="pkg-config intltool"
+hostmakedepends="pkg-config intltool python3-devel"
 makedepends="libltdl-devel glib-devel dotconf-devel libsndfile-devel libespeak-devel libao-devel python3-devel"
 depends="python3"
 conf_files="


### PR DESCRIPTION
I forgot to add python3-devel to hostmakedepends in revision
2, so cross builds were still missing the Python bits.