### PR TITLE
spice-vdagent: spice-vdagentd service added

### DIFF
--- a/srcpkgs/spice-vdagent/files/spice-vdagentd/run
+++ b/srcpkgs/spice-vdagent/files/spice-vdagentd/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+mkdir -p /var/run/spice-vdagentd
+exec /usr/bin/spice-vdagentd -x 

--- a/srcpkgs/spice-vdagent/template
+++ b/srcpkgs/spice-vdagent/template
@@ -1,7 +1,7 @@
 # Template file for 'spice-vdagent'
 pkgname=spice-vdagent
 version=0.17.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libglib-devel dbus-devel libXfixes-devel libXrandr-devel
@@ -18,4 +18,8 @@ configure_args="--sbindir=/usr/bin"
 
 do_install() {
 	make DESTDIR=${DESTDIR} udevrulesdir=/usr/lib/udev/rules.d install
+}
+
+post_install() {
+	vsv spice-vdagentd
 }


### PR DESCRIPTION
Spice agent does not work correctly without **spice-vdagentd** daemon running. This PR adds service for the daemon. 