### PR TITLE
openjdk-jre: add libjawt.so in shlib_provides

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1789,7 +1789,7 @@ libslab.so.0 libmate-control-center-1.8.2_1
 liblz4.so.1 lz4-1.7.3_1
 libatrilview.so.3 libatril-1.8.0_1
 libatrildocument.so.3 libatril-1.8.0_1
-libjawt.so openjdk-jre-8u20_1
+libjawt.so openjdk-jre-8u20_2
 libawt.so openjdk-jre-8u20_1
 libawt_xawt.so openjdk-jre-8u20_1
 libjava.so openjdk-jre-8u20_1

--- a/srcpkgs/openjdk/template
+++ b/srcpkgs/openjdk/template
@@ -12,7 +12,7 @@ _openjdk_version="openjdk-1.8.0_${_jdk_update}"
 
 pkgname=openjdk
 version=${_java_ver}u${_jdk_update}
-revision=1
+revision=2
 nocross=yes
 nopie=yes
 wrksrc=jdk8u-jdk8u${_jdk_update}-b${_jdk_build}/
@@ -181,7 +181,7 @@ post_install() {
 }
 
 openjdk-jre_package() {
-	shlib_provides="libawt.so libawt_xawt.so libjava.so libjli.so libjvm.so"
+	shlib_provides="libawt.so libawt_xawt.so libjava.so libjli.so libjvm.so libjawt.so"
 	short_desc="OpenJDK Java Runtime Environment"
 	provides="java-runtime-${version}_1"
 	alternatives="


### PR DESCRIPTION
required for compiling libreoffice with java support (tested here: https://github.com/juliendehos/void-packages/commit/512dd8cfce43a58a8afad30ed25f9be0647cf995)
