### PR TITLE
octoxbps: don't use --force

### DIFF
--- a/srcpkgs/octoxbps/patches/no-force.patch
+++ b/srcpkgs/octoxbps/patches/no-force.patch
@@ -1,0 +1,75 @@
+This patch is also offered to upstream: https://github.com/aarnt/octoxbps/pull/3
+
+--- src/xbpsexec.cpp
++++ src/xbpsexec.cpp
+@@ -594,10 +594,10 @@
+  */
+ void XBPSExec::doInstall(const QString &listOfPackages)
+ {
+-  QString command = "xbps-install -f -y " + listOfPackages;
++  QString command = "xbps-install -y " + listOfPackages;
+ 
+   m_lastCommandList.clear();
+-  m_lastCommandList.append("xbps-install -f " + listOfPackages + ";");
++  m_lastCommandList.append("xbps-install " + listOfPackages + ";");
+   m_lastCommandList.append("echo -e;");
+   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+ 
+@@ -611,7 +611,7 @@
+ void XBPSExec::doInstallInTerminal(const QString &listOfPackages)
+ {
+   m_lastCommandList.clear();
+-  m_lastCommandList.append("xbps-install -f " + listOfPackages + ";");
++  m_lastCommandList.append("xbps-install " + listOfPackages + ";");
+   m_lastCommandList.append("echo -e;");
+   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+ 
+@@ -654,10 +654,10 @@
+  */
+ void XBPSExec::doRemove(const QString &listOfPackages)
+ {
+-  QString command = "xbps-remove -R -f -y " + listOfPackages;
++  QString command = "xbps-remove -R -y " + listOfPackages;
+ 
+   m_lastCommandList.clear();
+-  m_lastCommandList.append("xbps-remove -R -f " + listOfPackages + ";");
++  m_lastCommandList.append("xbps-remove -R " + listOfPackages + ";");
+   m_lastCommandList.append("echo -e;");
+   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+ 
+@@ -671,7 +671,7 @@
+ void XBPSExec::doRemoveInTerminal(const QString &listOfPackages)
+ {
+   m_lastCommandList.clear();
+-  m_lastCommandList.append("xbps-remove -R -f " + listOfPackages + ";");
++  m_lastCommandList.append("xbps-remove -R " + listOfPackages + ";");
+   m_lastCommandList.append("echo -e;");
+   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+ 
+@@ -684,12 +684,12 @@
+  */
+ void XBPSExec::doRemoveAndInstall(const QString &listOfPackagestoRemove, const QString &listOfPackagestoInstall)
+ {
+-  QString command = "xbps-remove -R -f -y " + listOfPackagestoRemove +
+-      "; xbps-install -f " + listOfPackagestoInstall;
++  QString command = "xbps-remove -R -y " + listOfPackagestoRemove +
++      "; xbps-install " + listOfPackagestoInstall;
+ 
+   m_lastCommandList.clear();
+-  m_lastCommandList.append("xbps-remove -R -f " + listOfPackagestoRemove + ";");
+-  m_lastCommandList.append("xbps-install -f " + listOfPackagestoInstall + ";");
++  m_lastCommandList.append("xbps-remove -R " + listOfPackagestoRemove + ";");
++  m_lastCommandList.append("xbps-install " + listOfPackagestoInstall + ";");
+   m_lastCommandList.append("echo -e;");
+   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+ 
+@@ -703,8 +703,8 @@
+ void XBPSExec::doRemoveAndInstallInTerminal(const QString &listOfPackagestoRemove, const QString &listOfPackagestoInstall)
+ {
+   m_lastCommandList.clear();
+-  m_lastCommandList.append("xbps-remove -R -f " + listOfPackagestoRemove + ";");
+-  m_lastCommandList.append("xbps-install -f " + listOfPackagestoInstall + ";");
++  m_lastCommandList.append("xbps-remove -R " + listOfPackagestoRemove + ";");
++  m_lastCommandList.append("xbps-install " + listOfPackagestoInstall + ";");
+   m_lastCommandList.append("echo -e;");
+   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");

--- a/srcpkgs/octoxbps/template
+++ b/srcpkgs/octoxbps/template
@@ -1,7 +1,7 @@
 # Template file for 'octoxbps'
 pkgname=octoxbps
 version=0.2.2
-revision=1
+revision=2
 build_style=qmake
 hostmakedepends="qt5-qmake"
 makedepends="qt5-declarative-devel"


### PR DESCRIPTION
As it has already been discussed a few times, this is a dangerous flag to have in a package managing too, especially if user's may not be aware of it.
Whover wants to --force on his xbps-system, should do that on the terminal.