### PR TITLE
New package: gns3

### DIFF
--- a/srcpkgs/dynamips/template
+++ b/srcpkgs/dynamips/template
@@ -1,0 +1,18 @@
+# Template file for 'dynamips'
+pkgname=dynamips
+version=0.2.16
+revision=1
+build_style=cmake
+makedepends="elfutils-devel"
+depends="iouyap"
+short_desc="Hardware emulation for Cisco IOS capable devices"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="GPL-2"
+homepage="https://github.com/GNS3/dynamips"
+distfiles="https://github.com/GNS3/${pkgname}/archive/v${version}.tar.gz"
+checksum=0fcf18d701898a77cb589bd9bad16dde436ac1ccb87516fefe07d09de1a196c0
+
+# Dynamips does processor instruction translation.  This is already
+# painfully slow on powerful x86 hardware and is unlikely to work
+# reliably on arm processors.
+only_for_archs="i686 i686-musl x86_64 x86_64-musl"

--- a/srcpkgs/gns3-gui/template
+++ b/srcpkgs/gns3-gui/template
@@ -1,0 +1,13 @@
+# Template file for 'gns3-gui'
+pkgname=gns3-gui
+version=1.5.3
+revision=1
+build_style=python3-module
+hostmakedepends="python3 python3-setuptools"
+depends="python3 python3-setuptools python3-psutil python3-jsonschema python3-configobj python3-sip python3-PyQt5 python3-PyQt5-svg xterm inetutils-telnet gns3-net-converter"
+short_desc="Graphical Network Simulator 3 - GUI"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="GPL-3"
+homepage="https://gns3.com"
+distfiles="https://github.com/GNS3/${pkgname}/archive/v${version}.tar.gz"
+checksum=446fdc87d884fb24f879b8bba862dc43b92b6f859edefcd22f8682bdac61bec4

--- a/srcpkgs/gns3-net-converter/template
+++ b/srcpkgs/gns3-net-converter/template
@@ -1,0 +1,13 @@
+# Template file for 'gns3-net-converter'
+pkgname=gns3-net-converter
+version=1.3.0
+revision=1
+build_style=python3-module
+hostmakedepends="python3 python3-setuptools"
+depends="python3"
+short_desc="Convert old ini-style GNS3 topologies to the newer version"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="GPL-3"
+homepage="http://gns3-converter.readthedocs.io/en/latest/"
+distfiles="${PYPI_SITE}/g/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=0d189874a299af3853e97e88e41f089cad2949251ef0a68c9b217485ccc76ac6

--- a/srcpkgs/gns3-server/template
+++ b/srcpkgs/gns3-server/template
@@ -1,0 +1,21 @@
+# Template file for 'gns3-server'
+pkgname=gns3-server
+version=1.5.3
+revision=1
+build_style=python3-module
+hostmakedepends="python3 python3-setuptools"
+depends="python3 python3-zipstream python3-Jinja2 python3-yarl python3-aiohttp-cors raven-python dynamips"
+short_desc="Graphical Network Simulator 3 - Server"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="GPL-3"
+homepage="https://gns3.com"
+distfiles="https://github.com/GNS3/${pkgname}/archive/v${version}.tar.gz"
+checksum=2f42dd1bc1304bed04a83ce3e7fe158cc126a1aad4e044d541af0726ed8693fb
+
+# The source archive contains statically linked artifacts for x86_64
+# glibc, since this is the only architecture supported by upstream, we
+# mirror that requirement here.  The artifacts in questions are the C
+# modules that are used to drive additional virtualization backends
+# for gns3.  For more information, see this ticket:
+# https://github.com/GNS3/gns3-server/issues/970
+only_for_archs="x86_64"

--- a/srcpkgs/iouyap/template
+++ b/srcpkgs/iouyap/template
@@ -1,0 +1,22 @@
+# Template file for 'iouyap'
+pkgname=iouyap
+version=0.97
+revision=1
+build_style=gnu-makefile
+hostmakedepends="bison flex"
+short_desc="Bridge IOU to UDP, TAP and Ethernet"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="GPL-3"
+homepage="https://github.com/GNS3/iouyap"
+distfiles="https://github.com/GNS3/${pkgname}/archive/v${version}.tar.gz"
+checksum=181850a4ce73a4d4035f9eb39b2656ae31d360f18b577ee65f5149132da3eccf
+
+case $XBPS_TARGET_MACHINE in
+	*-musl) broken=yes # Uses GNU Short types
+	;;
+esac
+
+
+do_install() {
+	vbin iouyap
+}

--- a/srcpkgs/python3-aiohttp-cors/template
+++ b/srcpkgs/python3-aiohttp-cors/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-aiohttp-cors'
+pkgname=python3-aiohttp-cors
+version=0.5.0
+revision=1
+wrksrc=aiohttp-cors-${version}
+build_style=python3-module
+hostmakedepends="python3 python3-setuptools"
+depends="python3-aiohttp"
+short_desc="CORS support for aiohttp"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="Apache-2"
+homepage="https://github.com/aio-libs/aiohttp-cors"
+distfiles="https://github.com/aio-libs/aiohttp-cors/archive/v${version}.tar.gz"
+checksum=7d0c682657db4f3265337875be75e5f222aef644e780e125267e98a690ff9d85
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-aiohttp/template
+++ b/srcpkgs/python3-aiohttp/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-aiohttp'
+pkgname=python3-aiohttp
+version=1.2.0
+revision=1
+wrksrc=aiohttp-${version}
+build_style=python3-module
+hostmakedepends="python3 python3-setuptools"
+depends="python3-async-timeout python3-chardet"
+short_desc="HTTP client/server for asyncio (PEP-3156)"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="Apache-2"
+homepage="http://aiohttp.readthedocs.io/"
+distfiles="https://github.com/KeepSafe/aiohttp/archive/v${version}.tar.gz"
+checksum=b2fa11df067207ff15813be84b78910f6f9d897f02e9c345993b9962802a6bea
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/python3-async-timeout/template
+++ b/srcpkgs/python3-async-timeout/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-async-timeout'
+pkgname=python3-async-timeout
+version=1.1.0
+revision=1
+wrksrc=async-timeout-${version}
+build_style=python3-module
+hostmakedepends="python3 python3-setuptools"
+short_desc="Timeout class compatible with asyncio"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="Apache-2"
+homepage="https://github.com/aio-libs/async-timeout"
+distfiles="https://github.com/aio-libs/async-timeout/archive/v${version}.tar.gz"
+checksum=44a72eaedb82e53786d2b2590499b5e86a97805557361f51d467c283dc79b328
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-multidict/template
+++ b/srcpkgs/python3-multidict/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-multidict'
+pkgname=python3-multidict
+version=2.1.4
+revision=1
+wrksrc=multidict-${version}
+build_style=python3-module
+hostmakedepends="python3 python3-setuptools"
+short_desc="Multidict implementation from aiohttp"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="Apache-2"
+homepage="https://github.com/aio-libs/multidict"
+distfiles="https://github.com/aio-libs/multidict/archive/v${version}.tar.gz"
+checksum=4116a99f024269210bc5629661e55f5f613e1b11016b3bbf4e0ba453b02a65c1
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-yarl/template
+++ b/srcpkgs/python3-yarl/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-yarl'
+pkgname=python3-yarl
+version=0.8.1
+revision=1
+wrksrc=yarl-${version}
+#create_wrksrc=yes
+#only_for_archs="i686 x86_64"
+build_style=python3-module
+hostmakedepends="python3 python3-setuptools"
+depends="python3-multidict"
+short_desc="Yet another URL library"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="Apache-2.0"
+homepage="http://yarl.readthedocs.io/"
+distfiles="https://github.com/aio-libs/yarl/archive/v${version}.tar.gz"
+checksum=cb2790f35af5d04986b14c5b79678954cd4052ad9846f3d7327baed62581c48e
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-zipstream/template
+++ b/srcpkgs/python3-zipstream/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-zipstream'
+pkgname=python3-zipstream
+version=1.1.4
+revision=1
+wrksrc=python-zipstream-${version}
+build_style=python3-module
+hostmakedepends="python python3 python-setuptools python3-setuptools"
+short_desc="Python's ZipFile module, except it works as a generator"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="GPL-3"
+homepage="https://github.com/allanlei/python-zipstream"
+distfiles="https://github.com/allanlei/python-zipstream/archive/v${version}.tar.gz"
+checksum=32a7a4bdb786914445589595273beffbbf9b6a0a3a3dc2cf19ea96114bd2abd7

--- a/srcpkgs/raven-python/template
+++ b/srcpkgs/raven-python/template
@@ -1,0 +1,13 @@
+# Template file for 'raven-python'
+pkgname=raven-python
+version=5.32.0
+revision=1
+build_style=python3-module
+hostmakedepends="python3 python3-setuptools"
+depends="python3"
+short_desc="Raven is a Python client for Sentry (getsentry.com)"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="GPL-3"
+homepage="https://github.com/getsentry/raven-python"
+distfiles="https://github.com/getsentry/${pkgname}/archive/${version}.tar.gz"
+checksum=beb421c7741c94225d1648dcd8165e709e885b45505b4a99acb1f2867bf279cb

--- a/srcpkgs/vpcs/patches/ldflags.patch
+++ b/srcpkgs/vpcs/patches/ldflags.patch
@@ -1,0 +1,13 @@
+--- src/Makefile.linux.orig	2017-01-20 15:51:20.339835620 -0600
++++ src/Makefile.linux	2017-01-20 15:52:18.975831788 -0600
+@@ -4,8 +4,8 @@
+ CPUTYPE=i386
+ HVOPT=-DHV
+ 
+-CFLAGS=-D$(OSTYPE) -D$(CPUTYPE) $(HVOPT) -Wall -I. -DTAP
+-LDFLAGS=-lpthread -lutil -s -static
++override CFLAGS+=-D$(OSTYPE) -D$(CPUTYPE) $(HVOPT) -Wall -I. -DTAP
++override LDFLAGS+=-lpthread -lutil -s -static
+ OBJS=vpcs.o \
+ 	daemon.o \
+ 	readline.o \

--- a/srcpkgs/vpcs/patches/readline.patch
+++ b/srcpkgs/vpcs/patches/readline.patch
@@ -1,0 +1,11 @@
+--- src/readline.c.orig	2017-04-21 00:27:54.248062134 -0500
++++ src/readline.c	2017-04-21 00:28:07.690155810 -0500
+@@ -431,7 +431,7 @@
+ 		i = kb[0];
+ 		if (!isprint(i))
+ 			continue;
+-		if (rls->pos < strlen(rls->kbuffer) - 1) {
++		if (rls->pos < strlen(rls->kbuffer) + 1) {
+ 			j = strlen(rls->kbuffer);
+ 			/* avoid overflow */
+ 			if (j < rls->maxbuflen - 1) {

--- a/srcpkgs/vpcs/patches/remote_musl.patch
+++ b/srcpkgs/vpcs/patches/remote_musl.patch
@@ -1,0 +1,18 @@
+--- src/remote.c.orig	2017-01-20 16:46:45.037618348 -0600
++++ src/remote.c	2017-01-20 16:47:18.504616161 -0600
+@@ -43,13 +43,13 @@
+ #include "readline.h"
+ #include "utils.h"
+ 
+-int open_remote(int fdio, const char *destip, const u_short destport)
++int open_remote(int fdio, const char *destip, const unsigned short destport)
+ {
+ 	int s;
+ 	struct sockaddr_in addr_in;
+ 	struct termios termios;
+ 	char kb[512];
+-	u_char outbuf[512];
++	unsigned char outbuf[512];
+ 	int rc;
+ 	int i;
+ 	struct timeval tv;

--- a/srcpkgs/vpcs/template
+++ b/srcpkgs/vpcs/template
@@ -1,0 +1,27 @@
+# Template file for 'vpcs'
+pkgname=vpcs
+version=0.8
+revision=1
+build_wrksrc="src"
+build_style=gnu-makefile
+makedepends="glibc-devel"
+short_desc="Virtual PC Simulator"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="BSD 2-Clause"
+homepage="https://sourceforge.net/projects/vpcs"
+distfiles="${SOURCEFORGE_SITE}/project/vpcs/${version}/${pkgname}-${version}-src.tbz"
+checksum=dca602d0571ba852c916632c4c0060aa9557dd744059c0f7368860cfa8b3c993
+
+case "$XBPS_TARGET_MACHINE" in
+	*-musl) broken=yes # depends on GNU getopt
+	;;
+esac
+
+pre_build() {
+	ln -s Makefile.linux Makefile
+}
+
+do_install() {
+	vbin vpcs
+	vlicense $wrksrc/COPYING
+}


### PR DESCRIPTION
This PR includes GNS3 and all of the required dependencies.  This has been tested to the ability that I could pull off without undue effort.  This includes setting up VirtualBox VMs and Dynamips switches and confirming traffic can be routed between them.  VPCs also work, but some gymnastics are required to get the unique implementation of readline to work on Void.