### PR TITLE
liblouis: update to 3.1.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2174,7 +2174,7 @@ libOIS-1.3.0.so ois-1.3_1
 libSILLY.so.1 silly-0.1.0_1
 libkeybinder-3.0.so.0 libkeybinder3-0.3.0_1
 libbrlapi.so.0.6 brltty-5.2_1
-liblouis.so.9 liblouis-2.6.4_1
+liblouis.so.12 liblouis-3.1.0_1
 libCEGUIBase-0.7.9.so cegui07-0.7.9_1
 libCEGUIFalagardWRBase-0.7.9.so cegui07-0.7.9_1
 libCEGUIDevILImageCodec-0.7.9.so cegui07-0.7.9_1

--- a/srcpkgs/liblouis/patches/crosspython.patch
+++ b/srcpkgs/liblouis/patches/crosspython.patch
@@ -1,0 +1,23 @@
+Fixed by https://github.com/liblouis/liblouis/pull/325
+which has been merged upstream.
+The Python bindings use ctypes, and they load the .so as soon as they
+are imported.  setup.py imports them and calls the library's version()
+function, rather than hard-coding a version number.  This breaks crossbuilds.
+diff -Naur python/setup.py liblouis-3.1.0/python/setup.py
+--- python/setup.py	2017-03-06 05:49:10.000000000 -0800
++++ python/setup.py	2017-04-24 16:34:57.293458084 -0700
+@@ -23,7 +23,6 @@
+ """
+ 
+ from distutils.core import setup
+-import louis
+ 
+ classifiers = [
+     'Development Status :: 4 - Beta',
+@@ -38,5 +37,5 @@
+       download_url = "http://code.google.com/p/liblouis/",
+       license="LGPLv2.2",
+       classifiers=classifiers,
+-      version=louis.version().split(',')[0].split('-',1)[-1],
++      version='@VERSION@',
+       packages=["louis"])

--- a/srcpkgs/liblouis/patches/wcharmismatch.patch
+++ b/srcpkgs/liblouis/patches/wcharmismatch.patch
@@ -1,0 +1,14 @@
+Fixed by https://github.com/liblouis/liblouis/pull/324
+which has been merged upstream.
+diff --git tools/brl_checks.c tools/brl_checks.c
+index c125ed5b..0ef2f808 100644
+--- tools/brl_checks.c
++++ tools/brl_checks.c
+@@ -13,6 +13,7 @@ are permitted in any medium without royalty provided the copyright
+ notice and this notice are preserved. This file is offered as-is,
+ without any warranty. */
+ 
++#include <config.h>
+ #include <assert.h>
+ #include <stdio.h>
+ #include <stdlib.h>

--- a/srcpkgs/liblouis/template
+++ b/srcpkgs/liblouis/template
@@ -1,16 +1,31 @@
 # Template file for 'liblouis'
 pkgname=liblouis
-version=2.6.4
+version=3.1.0
 revision=1
 build_style=gnu-configure
-hostmakedepends="pkg-config help2man python-devel"
-makedepends="python-devel"
+hostmakedepends="pkg-config help2man python3-devel"
+makedepends="python3-devel"
+depends="python3"
+disable_parallel_build=yes
+configure_args="--enable-ucs4"
 short_desc="Open-source braille translator and back-translator"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-3"
 homepage="http://liblouis.org/"
 distfiles="https://github.com/$pkgname/$pkgname/releases/download/v$version/$pkgname-$version.tar.gz"
-checksum=5b897a8ffd513153a4999b72374cbdd35417c32317fd6ec3c2e76674ae486ac0
+checksum=2132930503b580ecb75b57105db5dbc2fbdae4341ae749e6a432910a3b33ff1c
+pycompile_module='louis'
+
+# See my commentary in patches/crosspython.patch
+# for justification of pre_build:
+pre_build() {
+	sed -i -e "s/@VERSION@/${version}/" python/setup.py
+}
+
+post_install() {
+	cd python
+	python3 setup.py install --root="${DESTDIR}"
+}
 
 liblouis-devel_package() {
 	short_desc+=" - development files"
@@ -20,5 +35,10 @@ liblouis-devel_package() {
 		vmove usr/lib/*.a
 		vmove usr/lib/*.so
 		vmove usr/lib/pkgconfig
+		# .info files aren't installed because texinfo>=5 isn't
+		# available in the chroot.  Prebuilt .info is supplied
+		# with the source distribution, so install that.
+		vmkdir usr/share/info
+		vcopy "doc/*.info*" usr/share/info
 	}
 }


### PR DESCRIPTION
Also, build Python 3 bindings.  The only thing that depends on
liblouis is Orca, and Orca needs these.
Build with --enable-ucs4.
To see a justification for why I did that,
have a look at https://bugs.archlinux.org/task/44319
Disable parallel builds; they fail for me.
Make sure .info files are installed.