### PR TITLE
New package: hlint-2.0.5

### DIFF
--- a/srcpkgs/hlint/template
+++ b/srcpkgs/hlint/template
@@ -1,0 +1,19 @@
+# Template file for 'hoogle'
+pkgname=hlint
+version=2.0.5
+revision=1
+build_style=haskell-stack
+nocross=yes # Can't yet cross compile Haskell
+# make_build_args="--ghc-options -fPIC"
+stackage="lts-8.12"
+short_desc="Haskell source code suggestions"
+maintainer="Inokentiy Babushkin <twk@twki.de>"
+license="BSD-3"
+homepage="https://github.com/ndmitchell/hlint"
+distfiles="https://github.com/ndmitchell/${pkgname}/archive/v${version}.tar.gz"
+checksum="7547bc716e69367bb808f878c528bd9f014fa84de202b89c0f70fe96fb3c9421"
+nopie=yes
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
`hlint` is a (or even *the*?) linter for haskell code.

Note that I wasn't able to get stack/ghc to generate a PIE. adding `make_build_args="--ghc-options -fPIC"` didn't yield the expected result, so that might be worth taking a look at.