### PR TITLE
openvpn: update to 2.4.2

### DIFF
--- a/srcpkgs/openvpn/template
+++ b/srcpkgs/openvpn/template
@@ -1,7 +1,7 @@
 # Template file for 'openvpn'
 pkgname=openvpn
-version=2.4.1
-revision=2
+version=2.4.2
+revision=1
 build_style=gnu-configure
 configure_args="--enable-iproute2 --disable-systemd"
 hostmakedepends="iproute2"
@@ -12,7 +12,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="https://www.openvpn.net"
 distfiles="http://build.openvpn.net/downloads/releases/${pkgname}-${version}.tar.xz"
-checksum=fde9e22c6df7a335d2d58c6a4d5967be76df173c766a5c51ece57fd044c76ee5
+checksum=df5c4f384b7df6b08a2f6fa8a84b9fd382baf59c2cef1836f82e2a7f62f1bff9
 
 post_install() {
 	vmkdir usr/share/examples/${pkgname}


### PR DESCRIPTION
Update is because of [the security audit](https://ostif.org/the-openvpn-2-4-0-audit-by-ostif-and-quarkslab-results/) done by ostif and quarkslab