### PR TITLE
vidcutter: distfile checksum changed

### DIFF
--- a/srcpkgs/vidcutter/template
+++ b/srcpkgs/vidcutter/template
@@ -1,7 +1,7 @@
 # Template file for 'vidcutter'
 pkgname=vidcutter
 version=3.2.0
-revision=1
+revision=2
 noarch=yes
 build_style=python3-module
 pycompile_module="${pkgname}"
@@ -12,9 +12,7 @@ maintainer="bra1nwave <brainwave@openmailbox.org>"
 license="GPL-3"
 homepage="http://vidcutter.ozmartians.com/"
 distfiles="https://github.com/ozmartian/${pkgname}/archive/${version}.tar.gz"
-checksum=2f74f40c274b91600f241825872b8f50453000f2d60cb4b3194f521146c29642
-
-broken="checksum changed?"
+checksum=a1b1042c90e9e0cc7dd2e3c436c273bbf417248788154d4b35d030e67b4720ab
 
 pre_configure() {
 	sed -i "s/pypi/arch/" vidcutter/__init__.py


### PR DESCRIPTION
The Author updated the distfile without version bump (See [AUR](https://aur.archlinux.org/cgit/aur.git/commit/?h=vidcutter&id=22f8f034cb7eff0c03cf3c6e45d471c4e2abacf7))
Something like this has happened in the [past](https://github.com/voidlinux/void-packages/pull/5651).