### PR TITLE
feh: Fix icon permissions

### DIFF
--- a/srcpkgs/feh/template
+++ b/srcpkgs/feh/template
@@ -1,7 +1,7 @@
 # Template file for 'feh'
 pkgname=feh
 version=2.18.3
-revision=1
+revision=2
 hostmakedepends="pkg-config"
 makedepends="giblib-devel libcurl-devel libexif-devel
  libpng-devel libjpeg-turbo-devel libXinerama-devel libXt-devel"
@@ -19,4 +19,7 @@ do_build() {
 do_install() {
 	make PREFIX=/usr DESTDIR=${DESTDIR} install
 	vlicense COPYING
+
+	# Fix the permissions on the icons
+	chmod 644 ${DESTDIR}/usr/share/icons/hicolor/*/*/*
 }


### PR DESCRIPTION
Currently the icon for feh does not have world read permissions.