### PR TITLE
i3blocks: fix musl

### DIFF
--- a/srcpkgs/i3blocks/patches/fix_musl.patch
+++ b/srcpkgs/i3blocks/patches/fix_musl.patch
@@ -1,0 +1,54 @@
+--- src/sched.c.orig	2017-05-20 13:31:34.109614479 +0300
++++ src/sched.c	2017-05-20 13:34:25.934611402 +0300
+@@ -31,7 +31,7 @@
+ #include "json.h"
+ #include "log.h"
+ 
+-static sigset_t sigset;
++static sigset_t sigset_ng;
+ 
+ static int
+ gcd(int a, int b)
+@@ -88,13 +88,13 @@
+ static int
+ setup_signals(void)
+ {
+-	if (sigemptyset(&sigset) == -1) {
++	if (sigemptyset(&sigset_ng) == -1) {
+ 		errorx("sigemptyset");
+ 		return 1;
+ 	}
+ 
+ #define ADD_SIG(_sig) \
+-	if (sigaddset(&sigset, _sig) == -1) { errorx("sigaddset(%d)", _sig); return 1; }
++	if (sigaddset(&sigset_ng, _sig) == -1) { errorx("sigaddset(%d)", _sig); return 1; }
+ 
+ 	/* Control signals */
+ 	ADD_SIG(SIGTERM);
+@@ -125,7 +125,7 @@
+ #undef ADD_SIG
+ 
+ 	/* Block signals for which we are interested in waiting */
+-	if (sigprocmask(SIG_SETMASK, &sigset, NULL) == -1) {
++	if (sigprocmask(SIG_SETMASK, &sigset_ng, NULL) == -1) {
+ 		errorx("sigprocmask");
+ 		return 1;
+ 	}
+@@ -164,7 +164,7 @@
+ 	bar_poll_timed(bar);
+ 
+ 	while (1) {
+-		sig = sigwaitinfo(&sigset, &siginfo);
++		sig = sigwaitinfo(&sigset_ng, &siginfo);
+ 		if (sig == -1) {
+ 			/* Hiding the bar may interrupt this system call */
+ 			if (errno == EINTR)
+@@ -212,7 +212,7 @@
+ 	 * Unblock signals (so subsequent syscall can be interrupted)
+ 	 * and wait for child processes termination.
+ 	 */
+-	if (sigprocmask(SIG_UNBLOCK, &sigset, NULL) == -1)
++	if (sigprocmask(SIG_UNBLOCK, &sigset_ng, NULL) == -1)
+ 		errorx("sigprocmask");
+ 	while (waitpid(-1, NULL, 0) > 0)
+ 		continue;

--- a/srcpkgs/i3blocks/template
+++ b/srcpkgs/i3blocks/template
@@ -1,7 +1,7 @@
 # Template file for 'i3blocks'
 pkgname=i3blocks
 version=1.4
-revision=2
+revision=3
 build_style=gnu-makefile
 short_desc="Flexible scheduler for i3bar"
 maintainer="Eivind Uggedal <eivind@uggedal.com>"


### PR DESCRIPTION
i3blocks errors during build on musl with:

    src/sched.c:34:17: error: 'sigset' redeclared as different kind of symbol
     static sigset_t sigset;
                     ^~~~~~
    In file included from src/sched.c:21:0:
    /usr/include/signal.h:231:8: note: previous declaration of 'sigset' was here
     void (*sigset(int, void (*)(int)))(int);
            ^~~~~~
    make: *** [<builtin>: src/sched.o] Error 1
    make: *** Waiting for unfinished jobs....

I did the first thing that came to my mind, which was `:%s/sigset\([^_]\)/sigset_ng\1/g`.
This seem to fix the issue.