### PR TITLE
mate-power-manage: needs upower0 on runtime.

### DIFF
--- a/srcpkgs/mate-power-manager/template
+++ b/srcpkgs/mate-power-manager/template
@@ -1,7 +1,7 @@
 # Template file for 'mate-power-manager'
 pkgname=mate-power-manager
 version=1.18.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--sbindir=/usr/bin --disable-schemas-compile"
 hostmakedepends="pkg-config intltool itstool libtool glib-devel dbus-glib-devel
@@ -9,7 +9,7 @@ hostmakedepends="pkg-config intltool itstool libtool glib-devel dbus-glib-devel
 makedepends="gtk+3-devel dbus-glib-devel libnotify-devel libunique-devel
  upower0-devel libcanberra-devel libgnome-keyring-devel libmate-panel-devel
  mate-desktop-devel"
-depends="dconf"
+depends="dconf upower0"
 short_desc="Power management tool for the MATE desktop"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"


### PR DESCRIPTION
answer to issue #6461 