### PR TITLE
orca: fix build-time detection of liblouis.

### DIFF
--- a/srcpkgs/orca/template
+++ b/srcpkgs/orca/template
@@ -1,11 +1,11 @@
 # Template file for 'orca'
 pkgname=orca
 version=3.24.0
-revision=1
+revision=2
 noarch=yes
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool itstool"
-makedepends="python-gobject-devel at-spi2-atk-devel"
+makedepends="python-gobject-devel at-spi2-atk-devel liblouis-devel"
 depends="brltty liblouis gtk+3 at-spi2-atk speech-dispatcher
  python3-atspi python3-dbus python3-xdg python3-gobject
  hicolor-icon-theme desktop-file-utils gsettings-desktop-schemas"


### PR DESCRIPTION
Contracted braille breaks if we can't find the .pc file for
liblouis at build time, so liblouis-devel belongs in makedepends.