### PR TITLE
jbig2dec: add patches for multiple CVEs

### DIFF
--- a/srcpkgs/jbig2dec/patches/CVE-2017-7885.patch
+++ b/srcpkgs/jbig2dec/patches/CVE-2017-7885.patch
@@ -1,0 +1,13 @@
+diff --git a/jbig2dec/jbig2_symbol_dict.c b/jbig2dec/jbig2_symbol_dict.c
+index 4acaba9..36225cb 100644 (file)
+--- jbig2_symbol_dict.c
++++ jbig2_symbol_dict.c
+@@ -629,7 +629,7 @@ jbig2_decode_symbol_dict(Jbig2Ctx *ctx,
+                 byte *dst = image->data;
+ 
+                 /* SumatraPDF: prevent read access violation */
+-                if (size - jbig2_huffman_offset(hs) < image->height * stride) {
++                if ((size - jbig2_huffman_offset(hs) < image->height * stride) || (size < jbig2_huffman_offset(hs))) {
+                     jbig2_error(ctx, JBIG2_SEVERITY_FATAL, segment->number, "not enough data for decoding (%d/%d)", image->height * stride,
+                                 size - jbig2_huffman_offset(hs));
+                     jbig2_image_release(ctx, image);

--- a/srcpkgs/jbig2dec/patches/CVE-2017-7975.patch
+++ b/srcpkgs/jbig2dec/patches/CVE-2017-7975.patch
@@ -1,0 +1,15 @@
+diff --git a/jbig2dec/jbig2_huffman.c b/jbig2dec/jbig2_huffman.c
+index 511e461..b4189a1 100644 (file)
+--- jbig2_huffman.c
++++ jbig2_huffman.c
+@@ -421,8 +421,8 @@ jbig2_build_huffman_table(Jbig2Ctx *ctx, const Jbig2HuffmanParams *params)
+ 
+             if (PREFLEN == CURLEN) {
+                 int RANGELEN = lines[CURTEMP].RANGELEN;
+-                int start_j = CURCODE << shift;
+-                int end_j = (CURCODE + 1) << shift;
++                uint32_t start_j = CURCODE << shift;
++                uint32_t end_j = (CURCODE + 1) << shift;
+                 byte eflags = 0;
+ 
+                 if (end_j > max_j) {

--- a/srcpkgs/jbig2dec/patches/CVE-2017-7976.patch
+++ b/srcpkgs/jbig2dec/patches/CVE-2017-7976.patch
@@ -1,0 +1,29 @@
+diff --git a/jbig2dec/jbig2_image.c b/jbig2dec/jbig2_image.c
+index 94e5a4c..00f966b 100644 (file)
+--- jbig2_image.c
++++ jbig2_image.c
+@@ -256,7 +256,7 @@ jbig2_image_compose(Jbig2Ctx *ctx, Jbig2Image *dst, Jbig2Image *src, int x, int
+     /* general OR case */
+     s = ss;
+     d = dd = dst->data + y * dst->stride + leftbyte;
+-    if (d < dst->data || leftbyte > dst->stride || h * dst->stride < 0 || d - leftbyte + h * dst->stride > dst->data + dst->height * dst->stride) {
++    if (d < dst->data || leftbyte > dst->stride || d - leftbyte + h * dst->stride > dst->data + dst->height * dst->stride) {
+         return jbig2_error(ctx, JBIG2_SEVERITY_FATAL, -1, "preventing heap overflow in jbig2_image_compose");
+     }
+     if (leftbyte == rightbyte) {
+
+
+diff --git a/jbig2dec/jbig2_image.c b/jbig2dec/jbig2_image.c
+index 661d0a5..ae161b9 100644 (file)
+--- jbig2_image.c
++++ jbig2_image.c
+@@ -263,7 +263,8 @@ jbig2_image_compose(Jbig2Ctx *ctx, Jbig2Image *dst, Jbig2Image *src, int x, int
+     /* general OR case */
+     s = ss;
+     d = dd = dst->data + y * dst->stride + leftbyte;
+-    if (d < dst->data || leftbyte > dst->stride || d - leftbyte + h * dst->stride > dst->data + dst->height * dst->stride) {
++    if (d < dst->data || leftbyte > dst->stride || d - leftbyte + h * dst->stride > dst->data + dst->height * dst->stride ||
++        s - leftbyte + (h - 1) * src->stride + rightbyte > src->data + src->height * src->stride) {
+         return jbig2_error(ctx, JBIG2_SEVERITY_FATAL, -1, "preventing heap overflow in jbig2_image_compose");
+     }
+     if (leftbyte == rightbyte) {

--- a/srcpkgs/jbig2dec/template
+++ b/srcpkgs/jbig2dec/template
@@ -1,7 +1,7 @@
 # Template file for 'jbig2dec'
 pkgname=jbig2dec
 version=0.13
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="libpng-devel"
 short_desc="Decoder implementation of the JBIG2 image compression format"


### PR DESCRIPTION
fixes CVE-2017-7885, CVE-2017-7975 and CVE-2017-7976.
Patches taken from the upstream ghostpdl git repository,
http://git.ghostscript.com/?p=ghostpdl.git
git revisions
e24e6194ca59d7b556116451490f71d2d85f4642
1a624d1bfa1e63ceab87f5e4e22c3daffa2d0f01 and
04b37bbce174eed24edec7ad5b920eb93db4d47d