### PR TITLE
samba: add CVE-2017-6891.patch

### DIFF
--- a/srcpkgs/samba/patches/CVE-2017-7494.patch
+++ b/srcpkgs/samba/patches/CVE-2017-7494.patch
@@ -1,0 +1,32 @@
+From c12670f75b6403aa0b7d7c02bd7af0d4f1160b9e Mon Sep 17 00:00:00 2001
+From: Volker Lendecke <vl@samba.org>
+Date: Mon, 8 May 2017 21:40:40 +0200
+Subject: [PATCH 1/1] CVE-2017-7494: Refuse to open pipe names with / inside
+
+BUG: https://bugzilla.samba.org/show_bug.cgi?id=12780
+
+Signed-off-by: Volker Lendecke <vl@samba.org>
+Reviewed-by: Andreas Schneider <asn@samba.org>
+---
+ source3/rpc_server/srv_pipe.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/source3/rpc_server/srv_pipe.c b/source3/rpc_server/srv_pipe.c
+index 251f899..7126865 100644
+--- source3/rpc_server/srv_pipe.c
++++ source3/rpc_server/srv_pipe.c
+@@ -473,6 +473,11 @@ bool is_known_pipename(const char *cli_filename, struct ndr_syntax_id *syntax)
+ 		pipename += 1;
+ 	}
+ 
++	if (strchr(pipename, '/')) {
++		DEBUG(1,("Refusing open on pipe %s\n", pipename));
++		return false;
++	}
++
+ 	if (lp_disable_spoolss() && strequal(pipename, "spoolss")) {
+ 		DEBUG(10, ("refusing spoolss access\n"));
+ 		return false;
+2.9.3
+
+

--- a/srcpkgs/samba/template
+++ b/srcpkgs/samba/template
@@ -1,7 +1,7 @@
 # Template file for 'samba' 
 pkgname=samba
 version=3.6.25
-revision=12
+revision=13
 build_wrksrc=source3
 build_style=gnu-configure
 configure_args="--with-fhs --with-pam --with-pam_smbpass --with-ldap


### PR DESCRIPTION
fixes CVE-2017-6891, patch from upstream via Debian.