### PR TITLE
libtasn1: add CVE-2017-6891.patch

### DIFF
--- a/srcpkgs/libtasn1/patches/CVE-2017-6891.patch
+++ b/srcpkgs/libtasn1/patches/CVE-2017-6891.patch
@@ -1,0 +1,24 @@
+diff --git a/lib/parser_aux.c b/lib/parser_aux.c
+index b4a7370..976ab38 100644 (file)
+--- lib/parser_aux.c
++++ lib/parser_aux.c
+@@ -120,6 +120,9 @@ asn1_find_node (asn1_node pointer, const char *name)
+       if (n_end)
+        {
+          nsize = n_end - n_start;
++         if (nsize >= sizeof(n))
++               return NULL;
++
+          memcpy (n, n_start, nsize);
+          n[nsize] = 0;
+          n_start = n_end;
+@@ -158,6 +161,9 @@ asn1_find_node (asn1_node pointer, const char *name)
+       if (n_end)
+        {
+          nsize = n_end - n_start;
++         if (nsize >= sizeof(n))
++               return NULL;
++
+          memcpy (n, n_start, nsize);
+          n[nsize] = 0;
+          n_start = n_end;

--- a/srcpkgs/libtasn1/template
+++ b/srcpkgs/libtasn1/template
@@ -1,7 +1,7 @@
 # Template build file for 'libtasn1'.
 pkgname=libtasn1
 version=4.10
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="perl"
 short_desc="ASN.1 structure parser library"


### PR DESCRIPTION
fixes CVE-2017-6891. Patch taken from upstream git commit
5520704d075802df25ce4ffccc010ba1641bd484