### PR TITLE
gajim-otr: fixed broken xbps-src fetch

### DIFF
--- a/srcpkgs/gajim-otr/template
+++ b/srcpkgs/gajim-otr/template
@@ -11,8 +11,35 @@ short_desc="OTR Plugin for Gajim"
 homepage="https://dev.gajim.org/gajim/gajim-plugins/wikis/OffTheRecordPlugin"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="GPL-3"
-distfiles="https://ftp.gajim.org/plugins_0.16_zip/gotr.zip"
-checksum="00ba5bf027b82d5f6a9867af5295b6518835b138c5ac22a891102bfb26b32a1d"
+#distfiles="https://ftp.gajim.org/plugins_0.16_zip/gotr.zip"
+checksum="c80f7dca53cc9e1c7ba0cfa955721217a7dd27220f0f07b99a79f6ad478dfc05"
+
+do_fetch() {
+	# Source archives seem to be regenerated frequently, with
+	# indeterminate file order or some other such innocuous
+	# changes.  Work around this by repacking the files in
+	# a deterministic way, and then checksumming.
+	# xxx I'm not clear if everything I'm using here is guaranteed
+	# to be available, or if I should add some more to hostdepends.
+	plug="gotr"
+	$XBPS_FETCH_CMD "https://ftp.gajim.org/plugins_0.16_zip/$plug.zip"
+	mkdir "$plug.tmp"
+	unzip -o -q "$plug.zip" -d "$plug.tmp"
+	x="$( (cd "$plug.tmp"; export LC_ALL="C"; find "$plug" ! -type d -print | sort |
+	tar -cf - --owner=root:0 --group=root:0 --verbatim-files-from -T -) | sha256sum | sed -n -e '1 s/[     ].*$//p' )"
+	if [ -e "$wrksrc" ]; then rm -rf "$wrksrc"; fi
+	mv "$plug.tmp/$plug" "$wrksrc"
+	rm -f "$plug.zip"
+	rmdir "$plug.tmp"
+	if [ -e "$plug.zip" -o -d "$plug.tmp" ]; then
+		echo "Unexpected garbage left around"
+		return 1
+	fi
+	if [ "$checksum" != "$x" ]; then
+		echo "$x"
+		return 1
+	fi
+}
 
 do_install() {
 	vmkdir usr/share/gajim/plugins/gotr


### PR DESCRIPTION
The gajim web server seems to regenerate its plugin's zip files
frequently (hourly?), and the file order and/or other properties seem
to be indeterminate.

The bottom line is that the contents constantly change, so the
xbps-src digest check fails, even though the actual contents of the
archive haven't changed.

This adds a custom fetch function, which checksums the files in a
reproducible fashion. It's rather a kludge, but seems to work.