### PR TITLE
New package: python-axolotl-0.1.39

### DIFF
--- a/srcpkgs/python-axolotl-curve25519/template
+++ b/srcpkgs/python-axolotl-curve25519/template
@@ -1,0 +1,22 @@
+# Template file for 'python-axolotl-curve25519'
+pkgname=python-axolotl-curve25519
+version=0.1
+revision=1
+build_style=python-module
+hostmakedepends="python-setuptools python3-setuptools"
+makedepends="python-devel python3-devel"
+depends="python"
+short_desc="Python2 curve25519 with ed25519 signatures, used by libaxolotl"
+maintainer="Lon Willett <xgit@lonw.net>"
+license="GPL-3"
+homepage="https://pypi.python.org/pypi/python-axolotl-curve25519"
+distfiles="${PYPI_SITE}/p/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum="c559f6a5bf51e869325b36bd83c14cccd7dec1c6e7599e797f9ba27a72d339c0"
+
+python3-axolotl-curve25519_package() {
+	depends="python3"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vmove usr/lib/python3*
+	}
+}

--- a/srcpkgs/python-axolotl/template
+++ b/srcpkgs/python-axolotl/template
@@ -1,0 +1,25 @@
+# Template file for 'python-axolotl'
+pkgname=python-axolotl
+version=0.1.39
+revision=1
+noarch=yes
+build_style=python-module
+hostmakedepends="python-setuptools python3-setuptools"
+depends="python-axolotl-curve25519 python-crypto python-protobuf"
+pycompile_module="axolotl"
+short_desc="Python2 port of libaxolotl-android written by Moxie Marlinspike"
+maintainer="Lon Willett <xgit@lonw.net>"
+license="GPL-3"
+homepage="https://pypi.python.org/pypi/python-axolotl"
+distfiles="${PYPI_SITE}/p/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum="9af9c937d0d05ebea414f1be79ecc7517cc3541a77101941e6a2a71bdd2b6e25"
+
+python3-axolotl_package() {
+	noarch=yes
+	depends="python3-axolotl-curve25519 python3-crypto python3-protobuf"
+	pycompile_module="axolotl"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vmove usr/lib/python3*
+	}
+}

--- a/srcpkgs/python3-axolotl
+++ b/srcpkgs/python3-axolotl
@@ -1,0 +1,1 @@
+python-axolotl

--- a/srcpkgs/python3-axolotl-curve25519
+++ b/srcpkgs/python3-axolotl-curve25519
@@ -1,0 +1,1 @@
+python-axolotl-curve25519


### PR DESCRIPTION
Port of libaxolotl-android written by Moxie Marlinspike.

This provides the underlying cryptographic support for the OMEMO XMPP extension. In particular, installing this package allow gajim users to download and enable the OMEMO plugin.