### PR TITLE
mongodb: rebuild against wiredtiger 2.9.2

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2374,6 +2374,7 @@ libwiredtiger_lz4.so wiredtiger-2.9.0_1
 libwiredtiger_snappy.so wiredtiger-2.9.0_1
 libwiredtiger_zlib.so wiredtiger-2.9.0_1
 libwiredtiger-2.9.1.so wiredtiger-2.9.1_1
+libwiredtiger-2.9.2.so wiredtiger-2.9.2_1
 libvidstab.so.0.9 libvidstab-0.98b_1
 libxdo.so.3 xdotool-3.20150503.1_1
 libabigail.so.0 libabigail-1.0.rc3_1

--- a/srcpkgs/mongodb/template
+++ b/srcpkgs/mongodb/template
@@ -1,7 +1,7 @@
 # Template file for 'mongodb'
 pkgname=mongodb
 version=3.4.4
-revision=1
+revision=2
 wrksrc="mongodb-src-r${version}"
 hostmakedepends="scons"
 makedepends="boost-devel pcre-devel snappy-devel libressl-devel libpcap-devel


### PR DESCRIPTION
mongodb is currently broken since the wiredtiger update to 2.9.2 (049af646e87c1e599f39799048e9d5a1f5b8e924)