### PR TITLE
mutter: revert a upstream commit

### DIFF
--- a/srcpkgs/mutter/patches/meta-backend-x11.patch
+++ b/srcpkgs/mutter/patches/meta-backend-x11.patch
@@ -1,0 +1,15 @@
+--- src/backends/x11/meta-backend-x11.c	2017-05-11 06:30:09.000000000 -0600
++++ src/backends/x11/meta-backend-x11.c	2017-06-05 12:10:43.010474780 -0600
+@@ -612,12 +612,6 @@
+ static void
+ meta_backend_x11_init (MetaBackendX11 *x11)
+ {
+-  /* XInitThreads() is needed to use the "threaded swap wait" functionality
+-   * in Cogl - see meta_renderer_x11_create_cogl_renderer(). We call it here
+-   * to hopefully call it before any other use of XLib.
+-   */
+-  XInitThreads();
+-
+   clutter_x11_request_reset_on_video_memory_purge ();
+ 
+   /* We do X11 event retrieval ourselves */

--- a/srcpkgs/mutter/patches/meta-renderer-x11.patch
+++ b/srcpkgs/mutter/patches/meta-renderer-x11.patch
@@ -1,0 +1,17 @@
+--- src/backends/x11/meta-renderer-x11.c	2017-05-11 06:30:09.000000000 -0600
++++ src/backends/x11/meta-renderer-x11.c	2017-06-05 12:14:08.090473267 -0600
+@@ -79,14 +79,6 @@
+   cogl_renderer_set_custom_winsys (cogl_renderer, get_x11_cogl_winsys_vtable);
+   cogl_xlib_renderer_set_foreign_display (cogl_renderer, xdisplay);
+ 
+-  /* Set up things so that if the INTEL_swap_event extension is not present,
+-   * but the driver is known to have good thread support, we use an extra
+-   * thread and call glXWaitVideoSync() in the thread. This allows idles
+-   * to work properly, even when Mutter is constantly redrawing new frames;
+-   * otherwise, without INTEL_swap_event, we'll just block in glXSwapBuffers().
+-   */
+-  cogl_xlib_renderer_set_threaded_swap_wait_enabled (cogl_renderer, TRUE);
+-
+   return cogl_renderer;
+ }
+ 

--- a/srcpkgs/mutter/template
+++ b/srcpkgs/mutter/template
@@ -1,7 +1,7 @@
 # Template file for 'mutter'
 pkgname=mutter
 version=3.24.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-schemas-compile --disable-static --enable-egl-device"
 hostmakedepends="pkg-config zenity glib-devel gobject-introspection"


### PR DESCRIPTION
these patches fix a [known](https://bugzilla.gnome.org/show_bug.cgi?id=781835) annoying bug upstream that causes terrible performance in gnome when using nvidia GPUs. This works great on my x86_64 machine with nvidia and in my testing VM but i've not tried anything outside of them.