### PR TITLE
[WIP] use gcc --enable-default-pie

### DIFF
--- a/common/environment/configure/gccspecs/hardened-cc1
+++ b/common/environment/configure/gccspecs/hardened-cc1
@@ -1,5 +1,0 @@
-*cpp_options:
-+ %{!fpie:%{!fPIE:%{!fpic:%{!fPIC:%{!fno-pic:-fPIE}}}}}
-
-*cc1_options:
-+ %{!fpie:%{!fPIE:%{!fpic:%{!fPIC:%{!fno-pic:-fPIE}}}}}

--- a/common/environment/configure/gccspecs/hardened-ld
+++ b/common/environment/configure/gccspecs/hardened-ld
@@ -1,5 +1,0 @@
-*self_spec:
-+ %{static|Bstatic|shared|Bshareable|i|r|pie|nopie:;:-pie}
-
-*link:
-+ %{!static:-z relro -z now}

--- a/common/environment/configure/gccspecs/hardened-mips-cc1
+++ b/common/environment/configure/gccspecs/hardened-mips-cc1
@@ -1,8 +1,0 @@
-*cpp_options:
-+ %{!fpie:%{!fPIE:%{!fpic:%{!fPIC:%{!fno-pic:-fPIE -mshared}}}}}
-
-*cc1_options:
-+ %{!fpie:%{!fPIE:%{!fpic:%{!fPIC:%{!fno-pic:-fPIE -mshared}}}}}
-
-*asm_options:
-+ %{!fpie:%{!fPIE:%{!fpic:%{!fPIC:%{!fno-pic:-mshared}}}}}

--- a/common/environment/configure/hardening.sh
+++ b/common/environment/configure/hardening.sh
@@ -1,26 +1,24 @@
-# Enable SSP and FORITFY_SOURCE=2 by default.
-_CFLAGS=" -fstack-protector-strong -D_FORTIFY_SOURCE=2 ${CFLAGS}"
-_CXXFLAGS="-fstack-protector-strong -D_FORTIFY_SOURCE=2 ${CXXFLAGS}"
-# Enable as-needed and relro by default.
-_LDFLAGS="-Wl,--as-needed ${LDFLAGS}"
-
-case "$XBPS_TARGET_MACHINE" in
-	i686-musl) # SSP currently broken (see https://github.com/voidlinux/void-packages/issues/2902)
-		_CFLAGS+=" -fno-stack-protector"
-		_CXXFLAGS+=" -fno-stack-protector"
-		;;
-esac
+# Enable as-needed by default.
+LDFLAGS="-Wl,--as-needed ${LDFLAGS}"
 
 if [ -z "$nopie" ]; then
-	_GCCSPECSDIR=${XBPS_COMMONDIR}/environment/configure/gccspecs
+	# Enable FORITFY_SOURCE=2
+	CFLAGS="-D_FORTIFY_SOURCE=2 ${CFLAGS}"
+	CXXFLAGS="-D_FORTIFY_SOURCE=2 ${CXXFLAGS}"
+	LDFLAGS="-Wl,-z,relro -Wl,-z,now ${LDFLAGS}"
 	case "$XBPS_TARGET_MACHINE" in
-		mips*) _GCCSPECSFILE=${_GCCSPECSDIR}/hardened-mips-cc1;;
-		*) _GCCSPECSFILE=${_GCCSPECSDIR}/hardened-cc1;;
+		# needs help finding __stack_chk_fail_local (issue #2902)
+		i686-musl) LDFLAGS="-lssp_nonshared $LDFLAGS";;
 	esac
-	CFLAGS="-specs=${_GCCSPECSFILE} ${_CFLAGS}"
-	CXXFLAGS="-specs=${_GCCSPECSFILE} ${_CXXFLAGS}"
-	# We pass -z relro -z now here too, because libtool drops -specs...
-	LDFLAGS="-specs=${_GCCSPECSDIR}/hardened-ld -Wl,-z,relro -Wl,-z,now ${_LDFLAGS}"
+	# Our compilers use --enable-default-pie and --enable-default-ssp,
+	# but the bootstrap host compiler may not, force them.
+	if [ -z "$CHROOT_READY" ]; then
+		CFLAGS="-fPIE ${CFLAGS}"
+		CXXFLAGS="-fPIE ${CXXFLAGS}"
+		LDFLAGS="-pie ${LDFLAGS}"
+	fi
+else
+	CFLAGS="-fno-PIE ${CFLAGS}"
+	CXXFLAGS="-fno-PIE ${CFLAGS}"
+	LDFLAGS="-no-pie ${LDFLAGS}"
 fi
-
-unset _CFLAGS _CXXFLAGS _LDFLAGS

--- a/srcpkgs/cross-aarch64-linux-gnu/template
+++ b/srcpkgs/cross-aarch64-linux-gnu/template
@@ -10,8 +10,8 @@ _archflags="-march=armv8-a"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.23
-revision=2
+version=0.24
+revision=1
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
 homepage="http://www.voidlinux.eu"
@@ -236,6 +236,8 @@ _gcc_build() {
 	_args+=" --enable-linker-build-id"
 	_args+=" --enable-gnu-unique-object"
 	_args+=" --enable-lto"
+	_args+=" --enable-default-pie"
+	_args+=" --enable-default-ssp"
 	_args+=" --disable-libquadmath"
 	_args+=" --disable-libatomic"
 	_args+=" --disable-libssp"

--- a/srcpkgs/cross-aarch64-linux-musl/template
+++ b/srcpkgs/cross-aarch64-linux-musl/template
@@ -10,8 +10,8 @@ _archflags="-march=armv8-a"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.23
-revision=3
+version=0.24
+revision=1
 short_desc="Cross toolchain for ARM64 LE target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -167,6 +167,8 @@ _gcc_build() {
 	_args+=" --with-sysroot=${_sysroot}"
 	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
+	_args+=" --enable-default-pie"
+	_args+=" --enable-default-ssp"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"
 	_args+=" --disable-nls"

--- a/srcpkgs/cross-arm-linux-gnueabi/template
+++ b/srcpkgs/cross-arm-linux-gnueabi/template
@@ -11,8 +11,8 @@ _archflags="-march=armv5te -msoft-float -mfloat-abi=soft"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.23
-revision=2
+version=0.24
+revision=1
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -241,6 +241,8 @@ _gcc_build() {
 	_args+=" --enable-linker-build-id"
 	_args+=" --enable-gnu-unique-object"
 	_args+=" --enable-lto"
+	_args+=" --enable-default-pie"
+	_args+=" --enable-default-ssp"
 	_args+=" --disable-libquadmath"
 	_args+=" --disable-libatomic"
 	_args+=" --disable-libssp"

--- a/srcpkgs/cross-arm-linux-gnueabihf/template
+++ b/srcpkgs/cross-arm-linux-gnueabihf/template
@@ -11,8 +11,8 @@ _archflags="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.23
-revision=2
+version=0.24
+revision=1
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -241,6 +241,8 @@ _gcc_build() {
 	_args+=" --enable-linker-build-id"
 	_args+=" --enable-gnu-unique-object"
 	_args+=" --enable-lto"
+	_args+=" --enable-default-pie"
+	_args+=" --enable-default-ssp"
 	_args+=" --disable-libquadmath"
 	_args+=" --disable-libatomic"
 	_args+=" --disable-libssp"

--- a/srcpkgs/cross-arm-linux-musleabi/template
+++ b/srcpkgs/cross-arm-linux-musleabi/template
@@ -11,8 +11,8 @@ _archflags="-march=armv5te -msoft-float -mfloat-abi=soft"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.23
-revision=2
+version=0.24
+revision=1
 short_desc="Cross toolchain for ARMv5 TE target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -168,6 +168,8 @@ _gcc_build() {
 	_args+=" --with-sysroot=${_sysroot}"
 	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
+	_args+=" --enable-default-pie"
+	_args+=" --enable-default-ssp"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"
 	_args+=" --disable-nls"

--- a/srcpkgs/cross-arm-linux-musleabihf/template
+++ b/srcpkgs/cross-arm-linux-musleabihf/template
@@ -11,8 +11,8 @@ _archflags="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.23
-revision=2
+version=0.24
+revision=1
 short_desc="Cross toolchain for ARMv6 LE Hard Float target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -167,6 +167,8 @@ _gcc_build() {
 	_args+=" --with-sysroot=${_sysroot}"
 	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
+	_args+=" --enable-default-pie"
+	_args+=" --enable-default-ssp"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"
 	_args+=" --disable-nls"

--- a/srcpkgs/cross-armv7l-linux-gnueabihf/template
+++ b/srcpkgs/cross-armv7l-linux-gnueabihf/template
@@ -11,8 +11,8 @@ _archflags="-march=armv7-a -mfpu=vfpv3 -mfloat-abi=hard"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.23
-revision=2
+version=0.24
+revision=1
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -242,6 +242,8 @@ _gcc_build() {
 	_args+=" --enable-linker-build-id"
 	_args+=" --enable-gnu-unique-object"
 	_args+=" --enable-lto"
+	_args+=" --enable-default-pie"
+	_args+=" --enable-default-ssp"
 	_args+=" --disable-libquadmath"
 	_args+=" --disable-libatomic"
 	_args+=" --disable-libssp"

--- a/srcpkgs/cross-armv7l-linux-musleabihf/template
+++ b/srcpkgs/cross-armv7l-linux-musleabihf/template
@@ -11,8 +11,8 @@ _archflags="-march=armv7-a -mfpu=vfpv3 -mfloat-abi=hard"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.23
-revision=2
+version=0.24
+revision=1
 short_desc="Cross toolchain for ARMv7 LE Hard Float target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -169,6 +169,8 @@ _gcc_build() {
 	_args+=" --with-sysroot=${_sysroot}"
 	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
+	_args+=" --enable-default-pie"
+	_args+=" --enable-default-ssp"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"
 	_args+=" --disable-nls"

--- a/srcpkgs/cross-i686-linux-musl/template
+++ b/srcpkgs/cross-i686-linux-musl/template
@@ -10,8 +10,8 @@ _sysroot="/usr/${_triplet}"
 _archflags="-march=i686"
 
 pkgname=cross-${_triplet}
-version=0.23
-revision=2
+version=0.24
+revision=1
 short_desc="Cross toolchain for i686 target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -165,6 +165,8 @@ _gcc_build() {
 	_args+=" --prefix=/usr"
 	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
+	_args+=" --enable-default-pie"
+	_args+=" --enable-default-ssp"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"
 	_args+=" --disable-libmpx"

--- a/srcpkgs/cross-i686-linux-musl/template
+++ b/srcpkgs/cross-i686-linux-musl/template
@@ -29,7 +29,6 @@ checksum="
 
 lib32disabled=yes
 nocross=yes
-nopie=yes
 nodebug=yes
 create_wrksrc=yes
 hostmakedepends="perl flex"
@@ -66,7 +65,8 @@ _binutils_build() {
 	_args+=" --disable-shared"
 	_args+=" ${_fpuflags}"
 
-	../binutils-${_binutils_version}/configure ${_args}
+	CFLAGS="-O2 -fPIE" CXXFLAGS="-O2 -fPIE" LDFLAGS="-pie" \
+		../binutils-${_binutils_version}/configure ${_args}
 
 	make configure-host
 	make ${makejobs}
@@ -182,7 +182,8 @@ _gcc_build() {
 	_args+=" libat_cv_have_ifunc=no"
 	_args+=" ${_fpuflags}"
 
-	../gcc-${_gcc_version}/configure ${_args}
+	CFLAGS="-O2 -fPIE" CXXFLAGS="-O2 -fPIE" LDFLAGS="-pie" \
+		../gcc-${_gcc_version}/configure ${_args}
 
 	make ${makejobs}
 

--- a/srcpkgs/cross-i686-linux-musl/template
+++ b/srcpkgs/cross-i686-linux-musl/template
@@ -82,6 +82,7 @@ _gcc_bootstrap() {
 
 	cd ${wrksrc}/gcc-${_gcc_version}
 	_apply_patch -p1 ${FILESDIR}/gcc-6.3.0-musl.diff
+	_apply_patch -p1 ${FILESDIR}/gcc-musl-libssp.diff
 	_apply_patch -p0 ${FILESDIR}/libcpp-source_date_epoch.patch
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
 
@@ -146,6 +147,10 @@ _musl_build() {
 
 	make ${makejobs}
 	make DESTDIR=${_sysroot} install
+
+	"${_triplet}-gcc" -c -Os ${_archflags} ${FILESDIR}/__stack_chk_fail_local.c -o  __stack_chk_fail_local.o
+	"${_triplet}-ar" r libssp_nonshared.a __stack_chk_fail_local.o
+	cp libssp_nonshared.a ${_sysroot}/usr/lib
 
 	touch ${wrksrc}/.musl_build_done
 }

--- a/srcpkgs/cross-i686-pc-linux-gnu/template
+++ b/srcpkgs/cross-i686-pc-linux-gnu/template
@@ -10,8 +10,8 @@ _archflags="-march=i686 -mtune=generic"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.23
-revision=2
+version=0.24
+revision=1
 short_desc="GNU Cross toolchain for the ${_triplet} target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -229,6 +229,8 @@ _gcc_build() {
 	_args+=" --enable-linker-build-id"
 	_args+=" --enable-gnu-unique-object"
 	_args+=" --enable-lto"
+	_args+=" --enable-default-pie"
+	_args+=" --enable-default-ssp"
 	_args+=" --enable-gnu-indirect-function"
 	_args+=" --enable-libquadmath"
 	_args+=" --disable-libatomic"

--- a/srcpkgs/cross-mips-linux-musl/template
+++ b/srcpkgs/cross-mips-linux-musl/template
@@ -11,8 +11,8 @@ _archflags="-march=mips32r2 -msoft-float"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.23
-revision=3
+version=0.24
+revision=1
 short_desc="Cross toolchain for MIPS32r2 BE softfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -168,6 +168,8 @@ _gcc_build() {
 	_args+=" --libexecdir=/usr/lib"
 	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
+	_args+=" --enable-default-pie"
+	_args+=" --enable-default-ssp"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"
 	_args+=" --disable-nls"

--- a/srcpkgs/cross-mipsel-linux-musl/template
+++ b/srcpkgs/cross-mipsel-linux-musl/template
@@ -11,8 +11,8 @@ _archflags="-march=mips32r2 -msoft-float"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.23
-revision=3
+version=0.24
+revision=1
 short_desc="Cross toolchain for MIPS32r2 LE softfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -168,6 +168,8 @@ _gcc_build() {
 	_args+=" --with-sysroot=${_sysroot}"
 	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
+	_args+=" --enable-default-pie"
+	_args+=" --enable-default-ssp"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"
 	_args+=" --disable-nls"

--- a/srcpkgs/cross-mipsel-linux-muslhf/template
+++ b/srcpkgs/cross-mipsel-linux-muslhf/template
@@ -11,8 +11,8 @@ _archflags="-march=mips32r2 -mhard-float"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.23
-revision=3
+version=0.24
+revision=1
 short_desc="Cross toolchain for MIPS32r2 LE hardfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -168,6 +168,8 @@ _gcc_build() {
 	_args+=" --with-sysroot=${_sysroot}"
 	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
+	_args+=" --enable-default-pie"
+	_args+=" --enable-default-ssp"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"
 	_args+=" --disable-nls"

--- a/srcpkgs/cross-x86_64-linux-musl/template
+++ b/srcpkgs/cross-x86_64-linux-musl/template
@@ -9,8 +9,8 @@ _triplet=x86_64-linux-musl
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.23
-revision=2
+version=0.24
+revision=1
 short_desc="Cross toolchain for x86_64 with musl"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -167,6 +167,8 @@ _gcc_build() {
 	_args+=" --with-sysroot=${_sysroot}"
 	_args+=" --enable-languages=c,c++,fortran,lto"
 	_args+=" --enable-lto"
+	_args+=" --enable-default-pie"
+	_args+=" --enable-default-ssp"
 	_args+=" --enable-libquadmath"
 	_args+=" --disable-libsanitizer"
 	_args+=" --disable-multilib"

--- a/srcpkgs/gcc/files/gcc-6.3.0-musl.diff
+++ b/srcpkgs/gcc/files/gcc-6.3.0-musl.diff
@@ -87,17 +87,6 @@ diff -r b08d4bc3d2ba libgcc/unwind-dw2-fde-dip.c
      && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ > 2) \
  	|| (__GLIBC__ == 2 && __GLIBC_MINOR__ == 2 && defined(DT_CONFIG)))
 diff -r 1f375ed3689f gcc/gcc.c
---- a/gcc/gcc.c	Thu Dec 24 11:24:53 2015 -0500
-+++ b/gcc/gcc.c	Thu Dec 24 11:24:56 2015 -0500
-@@ -860,7 +860,7 @@
- #ifndef LINK_SSP_SPEC
- #ifdef TARGET_LIBC_PROVIDES_SSP
- #define LINK_SSP_SPEC "%{fstack-protector|fstack-protector-all" \
--		       "|fstack-protector-strong|fstack-protector-explicit:}"
-+		       "|fstack-protector-strong|fstack-protector-explicit:-lssp_nonshared}"
- #else
- #define LINK_SSP_SPEC "%{fstack-protector|fstack-protector-all" \
- 		       "|fstack-protector-strong|fstack-protector-explicit" \
 # HG changeset patch
 # Parent 76b553fabcf19eec5df2df7f05ce15a4bf8c3996
 Support for mips-linux-musl.

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -12,7 +12,6 @@ license="GFDL-1.2, GPL-3, LGPL-2.1"
 distfiles="${GNU_SITE}/gcc/gcc-${version}/gcc-${version}.tar.bz2"
 checksum=f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f
 
-nopie=yes
 lib32disabled=yes
 bootstrap=yes
 
@@ -157,8 +156,9 @@ do_configure() {
 			;;
 	esac
 
-	export CFLAGS="${CFLAGS/-D_FORTIFY_SOURCE=2/}"
-	export CXXFLAGS="${CXXFLAGS/-D_FORTIFY_SOURCE=2/}"
+	export CFLAGS="-fPIE ${CFLAGS/-D_FORTIFY_SOURCE=2/}"
+	export CXXFLAGS="-fPIE ${CXXFLAGS/-D_FORTIFY_SOURCE=2/}"
+	export LDFLAGS="-pie ${LDFLAGS}"
 
 	_args+=" --prefix=/usr"
 	_args+=" --mandir=/usr/share/man"

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -4,7 +4,7 @@ _gcjrel=17
 
 pkgname=gcc
 version=${_majorver}.0
-revision=3
+revision=4
 short_desc="The GNU C Compiler"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://gcc.gnu.org"
@@ -172,6 +172,8 @@ do_configure() {
 	_args+=" --enable-shared"
 	_args+=" --enable-lto"
 	_args+=" --enable-vtable-verify"
+	_args+=" --enable-default-pie"
+	_args+=" --enable-default-ssp"
 	_args+=" --enable-linker-build-id"
 	_args+=" --enable-serial-configure"
 	_args+=" --disable-werror"


### PR DESCRIPTION
Fixes #6590.

Tried so far:
- [x] lr
- [x] ccl (worked, didn't use fnopie)
  - [?] cgrep  (broken lts)
- [x] dev86 (built, didn't use fnopie)
- [x] fpc (built, doesn't use gcc)
- [x] hsb2hs
- [x] ocaml
- [x] ocamlbuild (works pie after ocaml rebuild)
- [x] tcc (now works without nopie)
- [x] emacs (detects it needs -no-pie even)
- [x] polyml
- [x] lr-0.4_1.mips-musl.xbps

TODO:
- [ ] bootstrapping is broken