### PR TITLE
qemu: disable sdl by default, use gtk instead

### DIFF
--- a/srcpkgs/qemu/template
+++ b/srcpkgs/qemu/template
@@ -1,7 +1,7 @@
 # Template file for 'qemu'
 pkgname=qemu
 version=2.9.0
-revision=2
+revision=3
 short_desc="Open Source Processor Emulator"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://qemu.org"
@@ -17,13 +17,13 @@ makedepends="libpng-devel libjpeg-turbo-devel pixman-devel snappy-devel
  libsasl-devel libglib-devel ncurses-devel libseccomp-devel nss-devel
  libcurl-devel xfsprogs-devel libcap-ng-devel libcap-devel vde2-devel usbredir-devel
  libbluetooth-devel libssh2-devel libusb-devel pulseaudio-devel libnfs-devel
- $(vopt_if sdl SDL-devel) $(vopt_if sdl2 SDL2-devel) $(vopt_if gtk gtk+-devel)
+ $(vopt_if sdl SDL-devel) $(vopt_if sdl2 SDL2-devel) $(vopt_if gtk "gtk+3-devel vte3-devel")
  $(vopt_if spice spice-devel) $(vopt_if virgl virglrenderer-devel)
  $(vopt_if opengl 'libepoxy-devel libdrm-devel MesaLib-devel')
  $(vopt_if smartcard libcacard-devel)"
 
 build_options="gtk opengl sdl sdl2 spice virgl smartcard"
-build_options_default="opengl sdl2 virgl smartcard"
+build_options_default="opengl gtk virgl smartcard"
 desc_option_gtk="Enable GTK display and use it by default"
 desc_option_sdl="Use SDL (1.x) video output"
 desc_option_sdl2="Use SDL (2.x) video output"


### PR DESCRIPTION
This pull request disables sdl support in qemu and replaces it with gtk3.