### PR TITLE
linux4.4: update to 4.4.70

### DIFF
--- a/srcpkgs/linux4.4/template
+++ b/srcpkgs/linux4.4/template
@@ -1,6 +1,6 @@
 # Template file for 'linux4.4'
 pkgname=linux4.4
-version=4.4.69
+version=4.4.70
 revision=1
 wrksrc="linux-${version}"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -8,7 +8,7 @@ homepage="http://www.kernel.org"
 license="GPL-2"
 short_desc="The Linux kernel and modules (${version%.*} series)"
 distfiles="${KERNEL_SITE}/kernel/v4.x/linux-${version}.tar.xz"
-checksum=207bbc50aaf827d667a2762312bd6127887cc669ff7a7270b876e7102b8f84fa
+checksum=c0a8b36ca9044a91eccb475cc1c467cee1f5b296f30ca06db2b91e0589072dfa
 
 nocross=yes
 nodebug=yes


### PR DESCRIPTION
Looking at the Arch [package](https://aur.archlinux.org/cgit/aur.git/commit/?h=linux-lts44&id=397c6b3cd93812ca2bf292db21a8d1ab46912b01), it _seems like_ there's no change since the last release 4.4.69.