### PR TITLE
nvidia: added missing vulkan icd file to vinstall

### DIFF
--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -4,7 +4,7 @@ _desc="NVIDIA drivers for linux (long-lived series)"
 
 pkgname=nvidia
 version=381.22
-revision=1
+revision=2
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="Proprietary NVIDIA license"
 homepage="http://www.nvidia.com"
@@ -211,6 +211,9 @@ do_install() {
 		${DESTDIR}/usr/lib/libnvidia-opencl.so
 	ln -sf libnvidia-opencl.so.${version} \
 		${DESTDIR}/usr/lib/libnvidia-opencl.so.1
+
+	# vulkan icd
+	vinstall nvidia_icd.json 644 usr/share/vulkan/icd.d
 
 	# dkms pkg
 	vmkdir usr/src/nvidia-${version}


### PR DESCRIPTION
the `nvidia` template was missing the file `nvidia_icd.json` in the vinstall step, resulting in `VK_ERROR_INITIALIZATION_FAILED` errors trying to use vulkan