### PR TITLE
sddm: fix display of user avatars

### DIFF
--- a/srcpkgs/sddm/patches/0001-Fix-Avatars.patch
+++ b/srcpkgs/sddm/patches/0001-Fix-Avatars.patch
@@ -1,0 +1,34 @@
+
+From ecb903e48822bd90650bdd64fe80754e3e9664cb Mon Sep 17 00:00:00 2001
+From: Bastian Beischer <bastian.beischer@gmail.com>
+Date: Fri, 2 Sep 2016 13:05:18 +0200
+Subject: [PATCH] Fix display of user avatars. (#684)
+
+QFile::exists("...") does not understand file:// URLs, at least in Qt
+5.7.0 and Qt 4.8.7.
+---
+ src/greeter/UserModel.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git src/greeter/UserModel.cpp src/greeter/UserModel.cpp
+index 41a9f10c..94c492d0 100644
+--- src/greeter/UserModel.cpp
++++ src/greeter/UserModel.cpp
+@@ -107,13 +107,13 @@ namespace SDDM {
+                 d->lastIndex = i;
+
+             if (avatarsEnabled) {
+-                const QString userFace = QStringLiteral("file://%1/.face.icon").arg(user->homeDir);
+-                const QString systemFace = QStringLiteral("file://%1/%2.face.icon").arg(facesDir).arg(user->name);
++                const QString userFace = QStringLiteral("%1/.face.icon").arg(user->homeDir);
++                const QString systemFace = QStringLiteral("%1/%2.face.icon").arg(facesDir).arg(user->name);
+
+                 if (QFile::exists(userFace))
+-                    user->icon = userFace;
++                    user->icon = QStringLiteral("file://%1").arg(userFace);
+                 else if (QFile::exists(systemFace))
+-                    user->icon = systemFace;
++                    user->icon = QStringLiteral("file://%1").arg(systemFace);
+             }
+         }
+     }

--- a/srcpkgs/sddm/template
+++ b/srcpkgs/sddm/template
@@ -14,6 +14,10 @@ homepage="http://github.com/sddm/sddm"
 distfiles="https://github.com/${pkgname}/${pkgname}/archive/v${version}.tar.gz"
 checksum=a551551a6ba324e9c384c89bc63e871de65fea3740eadbea2d63df86045f8205
 
+if [ -n "$CROSS_BUILD" ]; then
+	hostmakedepends+=" sddm qt5-host-tools qt5-qmake qt5-tools"
+fi
+
 system_accounts="sddm"
 sddm_homedir="/var/lib/sddm"
 sddm_groups="video"

--- a/srcpkgs/sddm/template
+++ b/srcpkgs/sddm/template
@@ -1,7 +1,7 @@
 # Template file for 'sddm'
 pkgname=sddm
 version=0.14.0
-revision=3
+revision=4
 build_style=cmake
 configure_args="-DBUILD_MAN_PAGES=1 -DNO_SYSTEMD=1 -DLOGIN_DEFS_PATH=/etc/login.defs"
 hostmakedepends="extra-cmake-modules pkg-config python-docutils"


### PR DESCRIPTION
sddm 0.14.0 introduced an issue with displaying user avatars.  The
simple fix was committed to master, but wasn't released.
https://github.com/sddm/sddm/issues/807

It looks like at least Arch and Gentoo include this patch, as it's rather
simple but provides a major advantage.  It's not clear when sddm
plans to have a new release.