### PR TITLE
unison: install unison-fsmonitor utility

### DIFF
--- a/srcpkgs/unison/template
+++ b/srcpkgs/unison/template
@@ -1,7 +1,7 @@
 # Template file for 'unison'
 pkgname="unison"
 version=2.48.4
-revision=2
+revision=3
 short_desc="A file-synchronization tool"
 maintainer="allan <mail@may.mooo.com>"
 license="GPL-3"
@@ -18,4 +18,5 @@ do_build() {
 }
 do_install() {
 	vbin unison
+	vbin unison-fsmonitor
 }


### PR DESCRIPTION
Currently, when unison is run on Void Linux with `repeat -watch`, it spits out an error about no file watching utility being present. Locate reveals that `unison-fsmonitor` is missing. 

Poking around with xbps-src, the binary is built but not installed. This commit modifies the template to install it. `unison repeat -watch` functions correctly with this change. 