### PR TITLE
xf86-video-intel: update to 2.99.917.56

### DIFF
--- a/srcpkgs/xf86-video-intel/template
+++ b/srcpkgs/xf86-video-intel/template
@@ -1,7 +1,7 @@
 # Template build file for 'xf86-video-intel'.
 pkgname=xf86-video-intel
-version=2.99.917.55
-revision=2
+version=2.99.917.56
+revision=1
 lib32disabled=yes
 build_style=gnu-configure
 configure_args="--with-default-dri=3"
@@ -23,8 +23,8 @@ LDFLAGS="-Wl,-z,lazy"
 do_fetch() {
 	git clone git://anongit.freedesktop.org/xorg/driver/xf86-video-intel ${wrksrc}
 	cd ${wrksrc}
-	# Latest commit as of 20170403
-	git reset --hard cb6ba2da056f3298a765b4da5cd626343c00a533
+	# Latest commit as of 20170610
+	git reset --hard 6babcf15dd605ef40de53f5c34f95b7fd195edbe
 }
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh


### PR DESCRIPTION
Same commit as the Arch [package](https://www.archlinux.org/packages/extra/x86_64/xf86-video-intel/).