### PR TITLE
libogre: build against freeimage

### DIFF
--- a/srcpkgs/libogre/template
+++ b/srcpkgs/libogre/template
@@ -1,7 +1,7 @@
 # Template file for 'ogre'
 pkgname=libogre
 version=1.9.0
-revision=8
+revision=9
 build_style=cmake
 _hgrev=108ab0bcc69603dba32c0ffd4bbbc39051f421c9
 configure_args="-DCMAKE_INSTALL_PREFIX=/usr \
@@ -13,7 +13,8 @@ configure_args="-DCMAKE_INSTALL_PREFIX=/usr \
 	-DCMAKE_BUILD_TYPE=Release"
 hostmakedepends="pkg-config graphviz doxygen dejavu-fonts-ttf"
 makedepends="boost-devel freetype-devel libXaw-devel libXrandr-devel
- MesaLib-devel zziplib-devel libcppunit-devel glu-devel libatomic-devel"
+ MesaLib-devel zziplib-devel libcppunit-devel glu-devel libatomic-devel
+ freeimage-devel"
 short_desc="Scene-oriented, flexible 3D engine"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 homepage="http://www.ogre3d.org"


### PR DESCRIPTION
Our libogre build doesn't support any image formats other than dds (no png, jpg, etc). For better support it needs to link to devil or freeimage.

I've gone with freeimage here, as that's what the ogre folks choose as default.
