### PR TITLE
vivaldi: update to 1.10.867.38

### DIFF
--- a/srcpkgs/vivaldi/template
+++ b/srcpkgs/vivaldi/template
@@ -1,9 +1,9 @@
 # Template file for 'vivaldi'
 pkgname=vivaldi
-version=1.9.818.50
+version=1.10.867.38
 revision=1
 _release=1
-only_for_archs="i686 x86_64"
+only_for_archs="x86_64"
 short_desc="An advanced browser made with the power user in mind"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="Proprietary"
@@ -11,18 +11,11 @@ homepage="https://vivaldi.com"
 repository="nonfree"
 restricted=yes
 nopie=yes
+checksum=71a7865e83cc6fbb8373947a300c3558ade4f133555d60eb2c2b0fbefff371c0
+distfiles="https://downloads.vivaldi.com/stable/vivaldi-stable_${version}-${_release}_amd64.deb"
 
-if [ "${XBPS_TARGET_MACHINE}" = "x86_64" ];then
-	_debarch=amd64
-	checksum=701ceb20f6f802c4a7162c08a528b679e6ae0215c49b5e78ca12191c3d2fe3c6
-else
-	_debarch=i386
-	checksum=4ca0306a9336124a4ab23049be8e16f2aa5c9f48ce614b4cb551477843e952ce
-fi
-
-distfiles="https://downloads.vivaldi.com/stable/vivaldi-stable_${version}-${_release}_${_debarch}.deb"
 do_extract() {
-	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/vivaldi-stable_${version}-${_release}_${_debarch}.deb
+	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/vivaldi-stable_${version}-${_release}_amd64.deb
 	cd ${wrksrc}
 	tar xfJ data.tar.xz
 }


### PR DESCRIPTION
Now Vivaldi is only for x86_64, see the [website](https://vivaldi.com/download/) and the [PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=vivaldi) from AUR.