### PR TITLE
libvirt: update to 3.4.0

### DIFF
--- a/srcpkgs/libvirt/template
+++ b/srcpkgs/libvirt/template
@@ -1,6 +1,6 @@
 # Template file for 'libvirt'
 pkgname=libvirt
-version=3.3.0
+version=3.4.0
 revision=1
 build_style=gnu-configure
 patch_args="-Np1"
@@ -10,15 +10,15 @@ short_desc="The virtualization API for controlling virtualization engines"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="https://libvirt.org"
 license="LGPL-2.1"
-distfiles="https://libvirt.org/sources/${pkgname}-${version}.tar.xz"
-checksum=29e00984174e33cf2183b478382c017de26860452ffee17b73871051264ebb1b
+distfiles="http://libvirt.org/sources/${pkgname}-${version}.tar.xz"
+checksum=42186af6225904d2ada0b494fda4fa777fe5e662a9134686816e7919332c248d
 
 # FIX https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=701649
 system_accounts="libvirt"
 libvirt_groups="disk,kvm"
 
 hostmakedepends="automake libtool perl pkg-config lvm2 parted gettext-devel
- iptables libxslt docbook-xsl dnsmasq"
+ iptables libxslt docbook-xsl dnsmasq python"
 makedepends="readline-devel libcap-ng-devel libnl3-devel attr-devel
  gnutls-devel libsasl-devel libcurl-devel libpcap-devel libxml2-devel
  libparted-devel device-mapper-devel dbus-devel eudev-libudev-devel libblkid-devel


### PR DESCRIPTION
distfiles URL changed to http for now because they use a StartCom certificate
which is no longer trusted