### PR TITLE
compton-git: update to 20170430

### DIFF
--- a/srcpkgs/compton-git/template
+++ b/srcpkgs/compton-git/template
@@ -1,14 +1,14 @@
 # Template file for 'compton-git'
 pkgname=compton-git
-version=20160504
+version=20170430
 revision=1
 build_style="gnu-makefile"
-hostmakedepends="pkg-config asciidoc pcre-devel git"
-makedepends="dbus-devel libXcomposite-devel libXdamage-devel libXrandr-devel pcre-devel
- libconfig-devel libdrm-devel MesaLib-devel libXinerama-devel"
+hostmakedepends="pkg-config asciidoc git"
+makedepends="dbus-devel libXcomposite-devel libXrandr-devel pcre-devel
+ libconfig-devel MesaLib-devel libXinerama-devel"
 depends="desktop-file-utils"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="https://github.com/garnetius/compton"
+homepage="https://github.com/chjj/compton"
 license="MIT"
 short_desc="A compositor for X (fork of xcompmgr-dana)"
 
@@ -16,9 +16,13 @@ provides="compton-${version}_${revision}"
 replaces="compton>=0"
 
 do_fetch() {
-	local url="git://github.com/garnetius/compton.git"
+	local url="git://github.com/chjj/compton.git"
 	msg_normal "Fetching source from $url ...\n"
 	git clone ${url} ${wrksrc}
 	cd ${wrksrc}
-	git reset --hard e5074a5129a5e45b1839c3025f3358ac6903d611
+	git reset --hard 316eac0613bf342ff91cc645a6c3c80e6b9083fb
+}
+
+post_install() {
+	vlicense LICENSE
 }


### PR DESCRIPTION
Back to the same repository as the Arch [package](https://www.archlinux.org/packages/community-testing/x86_64/compton/).