### PR TITLE
mcabber: update to 1.1.0

### DIFF
--- a/srcpkgs/mcabber/template
+++ b/srcpkgs/mcabber/template
@@ -1,6 +1,6 @@
 # Template file for 'mcabber'
 pkgname=mcabber
-version=1.0.5
+version=1.1.0
 revision=1
 build_style=gnu-configure
 configure_args="--enable-hgcset --enable-enchant --enable-otr"
@@ -10,6 +10,6 @@ makedepends="enchant-devel ncurses-devel glib-devel loudmouth-devel gpgme-devel
 short_desc="Small XMPP (Jabber) console client"
 maintainer="Lukas Epple <sternenseemann@lukasepple.de>"
 license="GPL-2"
-homepage="https://mcabber.com"
+homepage="http://mcabber.com"
 distfiles="${homepage}/files/mcabber-${version}.tar.bz2"
-checksum=a0f200817d2b6196fe4d37918ce16f6fed83a3cef861d7165161e8b1cafcad47
+checksum=04fc2c22c36da75cf4b761b5deccd074a19836368f38ab9d03c1e5708b41f0bd


### PR DESCRIPTION
distfiles URL changed to http for now because they use a StartCom certificate which is no longer trusted