### PR TITLE
Version bump: libpurple-facebook

### DIFF
--- a/srcpkgs/libpurple-facebook/template
+++ b/srcpkgs/libpurple-facebook/template
@@ -1,9 +1,8 @@
 # Template file for 'libpurple-facebook'
 
 pkgname="libpurple-facebook"
-_release_date="20160409"
-_upstream_version="66ee77378d82"
-version="${_release_date}.${_upstream_version}"
+_upstream_version="0.9.4-c9b74a765767"
+version="0.9.4"
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -11,7 +10,8 @@ makedepends="libpurple-devel json-glib-devel"
 short_desc="A Facebook plugin for libpurple"
 maintainer="John Regan <john@jrjrtech.com>"
 license="GPL-2"
-homepage="https://github.com/jgeboski/purple-facebook"
-distfiles="https://github.com/jgeboski/purple-facebook/releases/download/${_upstream_version}/purple-facebook-${_upstream_version}.tar.gz"
-checksum=bc4420bc46295700af42c2e35adda210ab62ebb8bf9808adc2baba94205d6454
+homepage="https://github.com/dequis/purple-facebook"
+distfiles="https://github.com/dequis/purple-facebook/releases/download/v${_upstream_version}/purple-facebook-${_upstream_version}.tar.gz"
+checksum=cde5ef255668380abccf74b76844f95adf33e06421775ae302b93afbcb4eae8e
 wrksrc="purple-facebook-${_upstream_version}"
+


### PR DESCRIPTION
Facebook changed it's API and old libpurple-facebook plugin stoped working. This is the new version of this plugin which works fine.