### PR TITLE
musl: add bigstack build option

### DIFF
--- a/srcpkgs/musl/patches/bigstack-option.patch
+++ b/srcpkgs/musl/patches/bigstack-option.patch
@@ -1,0 +1,14 @@
+--- src/internal/pthread_impl.h.orig	2017-06-28 22:52:51.000000000 +0000
++++ src/internal/pthread_impl.h	2017-06-28 22:52:59.297555622 +0000
+@@ -141,7 +141,11 @@
+ void __block_app_sigs(void *);
+ void __restore_sigs(void *);
+ 
++#ifdef VOID_BIGSTACK
++#define DEFAULT_STACK_SIZE 8388608
++#else
+ #define DEFAULT_STACK_SIZE 81920
++#endif
+ #define DEFAULT_GUARD_SIZE 4096
+ 
+ #define __ATTRP_C11_THREAD ((void*)(uintptr_t)-1)

--- a/srcpkgs/musl/template
+++ b/srcpkgs/musl/template
@@ -17,6 +17,11 @@ nostrip_files="libc.so"
 shlib_provides="libc.so"
 only_for_archs="i686-musl x86_64-musl armv5tel-musl armv6l-musl armv7l-musl aarch64-musl mips-musl mipsel-musl mipselhf-musl"
 
+desc_option_bigstack="bigger default pthread stack size"
+build_options="bigstack"
+
+CFLAGS="$(vopt_if bigstack -DVOID_BIGSTACK)"
+
 post_build() {
 	$CC $CFLAGS $LDFLAGS ${FILESDIR}/getent.c -o getent
 	$CC $CFLAGS $LDFLAGS ${FILESDIR}/getconf.c -o getconf


### PR DESCRIPTION
This enables building musl with a bigger default pthread stack size
(currently 8MB to match glibc default stack size), to make it easier to
diagnose these issues.

#4147