### PR TITLE
keepassxc: update to 2.2.0

### DIFF
--- a/srcpkgs/keepassxc/template
+++ b/srcpkgs/keepassxc/template
@@ -1,16 +1,16 @@
 # Template file for 'keepassxc'
 pkgname=keepassxc
-version=2.1.4
-revision=2
+version=2.2.0
+revision=1
 build_style=cmake
 configure_args="-DWITH_XC_HTTP=ON -DWITH_XC_YUBIKEY=ON -DWITH_XC_AUTOTYPE=ON -DWITH_TESTS=OFF"
 makedepends="libXtst-devel libgcrypt-devel libykpers-devel libyubikey-devel qt5-tools-devel qt5-x11extras-devel"
 short_desc="KeePassXC is a cross-platform port of “Keepass Password Safe”"
 maintainer="ibrokemypie <ibrokemypie@bastardi.net>"
-license="GPL-3, BSD-3-clause, LGPL-2, LGPL-2.1, LGPL-3+, Boost-1.0, CC-0"
+license="GPL-3, GPL-2, BSD-3-clause, LGPL-2, LGPL-2.1, LGPL-3+, Boost-1.0, CC-0"
 homepage="https://keepassxc.org/"
 distfiles="https://github.com/keepassxreboot/keepassxc/releases/download/${version}/keepassxc-${version}-src.tar.xz"
-checksum=22c564fab78bd960b9af5a779c7bd59f0cc04a9988b00c6b82329059e59b0035
+checksum=71c47ebd9a661fc439c61566e4a4aa482e4d463c0eaa4f7562e7216eb0327e59
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-devel qt5-qmake qt5-tools"
@@ -24,6 +24,5 @@ post_install() {
 	vlicense LICENSE.NOKIA-LGPL-EXCEPTION
 	vlicense LICENSE.LGPL-3
 	vlicense LICENSE.LGPL-2.1
-	vlicense LICENSE.GPL-3
 	vlicense LICENSE.GPL-2
 }


### PR DESCRIPTION
https://github.com/keepassxreboot/keepassxc/releases/tag/2.2.0

also added GPL-2, and removed GPL-3 since it is provided.