### PR TITLE
onedrive-d: update to 0.0.0.20170702

### DIFF
--- a/srcpkgs/onedrive-d/template
+++ b/srcpkgs/onedrive-d/template
@@ -1,8 +1,8 @@
 # Template file for 'onedrive-d'
 pkgname=onedrive-d
-version=0.0.0.20170617
+version=0.0.0.20170702
 revision=1
-_commit="ce4802a434dd75571f13cc988319cadbb296d27b"
+_commit="849dd36276f99af87b36d7541bba79ba314d5b93"
 build_style=gnu-makefile
 hostmakedepends="dmd"
 makedepends="libcurl-devel sqlite-devel"
@@ -13,7 +13,7 @@ license="GPL-3"
 homepage="https://github.com/skilion/onedrive"
 distfiles="${homepage}/archive/${_commit}.tar.gz>${pkgname}-${version}.tar.gz"
 wrksrc="onedrive-${_commit}"
-checksum="17b2027923f18e44751bdfe4deb046936c281197502df1da9af69fa56fe21563"
+checksum="8d1f72efc3b51fa50e02d0bd0ccc406975f2fcd69b96e7f9a2f565ef910df6b2"
 
 post_install() {
 	# We don't care about the systemd service installed here.


### PR DESCRIPTION
a few changes, including a recent commit which fixes a major problem that I and some others were experiencing, which simply caused onedrive to crash whenever it attempted to sync.