### PR TITLE
haveged: fix missing distfiles

### DIFF
--- a/srcpkgs/haveged/template
+++ b/srcpkgs/haveged/template
@@ -1,14 +1,13 @@
 # Template file for 'haveged'
 pkgname=haveged
 version=1.9.1
-revision=6
+revision=7
 build_style=gnu-configure
 short_desc="Entropy harvesting daemon using CPU timings"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-3"
 homepage="http://www.issihosts.com/haveged"
-#distfiles="$homepage/$pkgname-$version.tar.gz"
-distfiles="http://distfiles.alpinelinux.org/distfiles/haveged-${version}.tar.gz"
+distfiles="${homepage}/${pkgname}-${version}.tar.gz"
 checksum=9c2363ed9542a6784ff08e247182137e71f2ddb79e8e6c1ac4ad50d21ced3715
 configure_args="--sbindir=/usr/bin"
 
@@ -26,6 +25,7 @@ libhaveged_package() {
 		vmove usr/lib/*.so.*
 	}
 }
+
 libhaveged-devel_package() {
 	short_desc+=" - development files"
 	depends="libhaveged-${version}_${revision}"


### PR DESCRIPTION
The distfiles was missing. 

````
$ xgensum -f srcpkgs/haveged/template
=> haveged-1.9.1_6: running do-fetch hook: 00-distfiles ...
=> haveged-1.9.1_6: fetching distfile 'haveged-1.9.1.tar.gz'...
looking up distfiles.alpinelinux.org
connecting to distfiles.alpinelinux.org:80
requesting http://distfiles.alpinelinux.org/distfiles/haveged-1.9.1.tar.gz
http://distfiles.alpinelinux.org/distfiles/haveged-1.9.1.tar.gz: Not Found
=> ERROR: haveged-1.9.1_6: failed to fetch haveged-1.9.1.tar.gz.
````