### PR TITLE
compiz: update to 0.8.14

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2703,7 +2703,7 @@ libuim.so.8 uim-1.8.6_1
 libuim-scm.so.0 uim-1.8.6_1
 libuim-custom.so.2 uim-1.8.6_1
 libgcroots.so.0 uim-1.8.6_1
-libdecoration.so.0 compiz-core-0.8.12.3_1
+libdecoration.so.0 compiz-core-0.8.14_1
 libcompizconfig.so.0 libcompizconfig-0.8.14_1
 libemeraldengine.so.0 emerald-0.8.12.4_1
 libhangul.so.1 libhangul-0.1.0_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -2704,7 +2704,7 @@ libuim-scm.so.0 uim-1.8.6_1
 libuim-custom.so.2 uim-1.8.6_1
 libgcroots.so.0 uim-1.8.6_1
 libdecoration.so.0 compiz-core-0.8.12.3_1
-libcompizconfig.so.0 libcompizconfig-0.8.12.1_1
+libcompizconfig.so.0 libcompizconfig-0.8.14_1
 libemeraldengine.so.0 emerald-0.8.12.4_1
 libhangul.so.1 libhangul-0.1.0_1
 libmutter-clutter-1.0.so mutter-3.22.0_1

--- a/srcpkgs/ccsm/template
+++ b/srcpkgs/ccsm/template
@@ -1,7 +1,7 @@
 # Template file for 'ccsm' of Compiz Reloaded
 pkgname=ccsm
-version=0.8.12.4
-revision=2
+version=0.8.14
+revision=1
 build_style=python2-module
 
 hostmakedepends="automake intltool libtool pkg-config python"
@@ -13,7 +13,7 @@ maintainer="CoolOhm <micvlas@gmail.com>"
 homepage="https://github.com/compiz-reloaded"
 license="GPL-2"
 distfiles="https://github.com/compiz-reloaded/ccsm/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=173375ea22ae97bc4be3e0dc3a7df894e9e20845c59bfdeafbac3a8c39d5151a
+checksum=74f2e3ab0f7334e1c2fe1ad54244399475f4ab90f999f86655f39f852a94b365
 
 if [ -z "$CROSS_BUILD" ]; then
 	depends+=" python-gobject"

--- a/srcpkgs/compiz-bcop/template
+++ b/srcpkgs/compiz-bcop/template
@@ -1,6 +1,6 @@
 # Template file for 'compiz-bcop' of Compiz Reloaded
 pkgname=compiz-bcop
-version=0.8.12
+version=0.8.14
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake intltool libtool pkg-config libxslt"
@@ -12,7 +12,7 @@ maintainer="CoolOhm <micvlas@gmail.com>"
 homepage="https://github.com/compiz-reloaded"
 license="GPL-2"
 distfiles="https://github.com/compiz-reloaded/compiz-bcop/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=11b9e15b3fd8aa2d9a1717ccbda74e743af6593989bf4bae1a197b59b2f456d9
+checksum=b1a2a472d20f4ae1cc15611faf1dc302862a53e0dfe1bafdb2a521fc3a9e8f47
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh

--- a/srcpkgs/compiz-core/template
+++ b/srcpkgs/compiz-core/template
@@ -1,6 +1,6 @@
 # Template file for 'compiz-core' of Compiz Reloaded
 pkgname=compiz-core
-version=0.8.12.3
+version=0.8.14
 revision=1
 wrksrc="compiz-${version}"
 build_style=gnu-configure
@@ -17,7 +17,7 @@ maintainer="CoolOhm <micvlas@gmail.com>"
 homepage="https://github.com/compiz-reloaded"
 license="MIT, LGPL-2, GPL-2"
 distfiles="https://github.com/compiz-reloaded/compiz/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=2ffccaffcdc8b1a2fd3d7533e28cbeb36e1e8102dce9a6edbf165d842374cee9
+checksum=162189adbecf6ad667df81c0d97fe8aa6a86e121beb9783af71e196e83ffa2f3
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh

--- a/srcpkgs/compizconfig-python/template
+++ b/srcpkgs/compizconfig-python/template
@@ -1,6 +1,6 @@
 # Template file for 'compizconfig-python' of Compiz Reloaded
 pkgname=compizconfig-python
-version=0.8.12.1
+version=0.8.14
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static"
@@ -14,7 +14,7 @@ maintainer="CoolOhm <micvlas@gmail.com>"
 homepage="https://github.com/compiz-reloaded"
 license="GPL-2"
 distfiles="https://github.com/compiz-reloaded/compizconfig-python/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=0d169cab08f8b1f4b54326df9e1abc6da5bc3e0a43d4d9062808d835ec43dfba
+checksum=03822784f4ebadcb73e6492236209eae6f6fbb2c89d6242ed212e64bbf1425dc
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh

--- a/srcpkgs/libcompizconfig/template
+++ b/srcpkgs/libcompizconfig/template
@@ -1,7 +1,7 @@
 # Template file for 'libcompizconfig' of Compiz Reloaded
 pkgname=libcompizconfig
-version=0.8.12.1
-revision=2
+version=0.8.14
+revision=1
 build_style=gnu-configure
 configure_args="--disable-static"
 
@@ -15,7 +15,7 @@ maintainer="CoolOhm <micvlas@gmail.com>"
 homepage="https://github.com/compiz-reloaded"
 license="GPL-2"
 distfiles="https://github.com/compiz-reloaded/libcompizconfig/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=16a0746b8e882859e257780136589b08f7c8e96b4f3b51c551ebb5ee0b704af4
+checksum=e91b9768ecaebd456062a839c3d56caee487c5580b5180a0680db1577c89f07f
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh


### PR DESCRIPTION
Update compiz-reloaded from 0.8.12.x to 0.8.14. .

This PR will at first attempted to update all compiz packages, that failed.

EDIT: the all-in-one PR has failed. Thus emerald will be in another PR and the comiz-plugins-* will be in yet another PR.