### PR TITLE
busybox: update to 1.27.1

### DIFF
--- a/srcpkgs/busybox/template
+++ b/srcpkgs/busybox/template
@@ -1,6 +1,6 @@
 # Build template for 'busybox'.
 pkgname=busybox
-version=1.27.0
+version=1.27.1
 revision=1
 hostmakedepends="perl"
 short_desc="The Swiss Army Knife of Embedded Linux"
@@ -8,7 +8,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://www.busybox.net"
 distfiles="${homepage}/downloads/busybox-$version.tar.bz2"
-checksum=a5dfbd5e9b942f24a49d8e980d8159809fdd5319910e47340d838119b70499cd
+checksum=c890ac53fb218eb4c6ad9ed3207a896783b142e6d306f292b8d9bec82af5f936
 
 alternatives="
  awk:awk:/usr/bin/busybox


### PR DESCRIPTION
> Bug fix release. 1.27.1 has fixes for uuencode (allow space
> instead of "`" as padding char), dd (fixed status=none),
> setpriv (option parsing should not eat options in PROG ARGS),
> fix for "applet (for example halt) as login shell" use case,
> a few fixes for less typical build environments.
