### PR TITLE
intellij-idea-community-edition: update to 2017.2.

### DIFF
--- a/srcpkgs/intellij-idea-community-edition/template
+++ b/srcpkgs/intellij-idea-community-edition/template
@@ -1,6 +1,6 @@
 # Template file for 'intellij-idea-community-edition'
 pkgname=intellij-idea-community-edition
-version=2017.1.4
+version=2017.2
 revision=1
 depends="virtual?java-environment giflib libXtst"
 short_desc="Java integrated development environment"
@@ -8,7 +8,8 @@ maintainer="Adrian Siekierka <asiekierka@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.jetbrains.org/"
 distfiles="https://download.jetbrains.com/idea/ideaIC-${version}-no-jdk.tar.gz"
-checksum=ea90fce3f93c4eaa58036278f630a0545ae0b191fa3bff48f480f2b268867cb0
+checksum=d88257b17447398ed60e7d774803cbc21e0fe7750add09622a98b936f14cd91f
+repository=nonfree
 nopie=yes
 only_for_archs="i686 x86_64"
 
@@ -28,6 +29,7 @@ do_install() {
 	rm ${DESTDIR}/usr/share/intellij-idea/plugins/android/lib/jogl-all-natives-macosx-*
 	rm ${DESTDIR}/usr/share/intellij-idea/plugins/android/lib/jogl-all-natives-windows-*
 	rm ${DESTDIR}/usr/share/intellij-idea/plugins/gradle/lib/native-platform-freebsd-*
+	rm ${DESTDIR}/usr/share/intellij-idea/plugins/gradle/lib/native-platform-linux-*-ncurses5-*
 	rm ${DESTDIR}/usr/share/intellij-idea/plugins/gradle/lib/native-platform-osx-*
 	rm ${DESTDIR}/usr/share/intellij-idea/plugins/gradle/lib/native-platform-windows-*
 	rm ${DESTDIR}/usr/share/intellij-idea/bin/fsnotifier-arm


### PR DESCRIPTION
Also move to nonfree, which fixes #7094, and remove a few additional unnecessary natives.