### PR TITLE
deadbeef: Allow building with GTK2 using build options

### DIFF
--- a/srcpkgs/deadbeef/patches/fix-narrowing_arm.patch
+++ b/srcpkgs/deadbeef/patches/fix-narrowing_arm.patch
@@ -1,0 +1,48 @@
+diff -Naur ./plugins/adplug/adplug/s3m.cpp ../deadbeef-0.7.2/plugins/adplug/adplug/s3m.cpp
+--- ./plugins/adplug/adplug/s3m.cpp	2016-06-19 13:26:18.000000000 +0200
++++ ../deadbeef-0.7.2/plugins/adplug/adplug/s3m.cpp	2017-07-22 10:38:22.694537750 +0200
+@@ -26,7 +26,7 @@
+ #include <string.h>
+ #include "s3m.h"
+ 
+-const char Cs3mPlayer::chnresolv[] =	// S3M -> adlib channel conversion
++const signed char Cs3mPlayer::chnresolv[] =	// S3M -> adlib channel conversion
+   {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,0,1,2,3,4,5,6,7,8,-1,-1,-1,-1,-1,-1,-1};
+ 
+ const unsigned short Cs3mPlayer::notetable[12] =		// S3M adlib note table
+diff -Naur ./plugins/adplug/adplug/s3m.h ../deadbeef-0.7.2/plugins/adplug/adplug/s3m.h
+--- ./plugins/adplug/adplug/s3m.h	2016-06-19 13:26:18.000000000 +0200
++++ ../deadbeef-0.7.2/plugins/adplug/adplug/s3m.h	2017-07-22 10:43:59.836740736 +0200
+@@ -92,7 +92,7 @@
+   char filetype[30];
+ 
+  private:
+-  static const char chnresolv[];
++  static const signed char chnresolv[];
+   static const unsigned short notetable[12];
+   static const unsigned char vibratotab[32];
+ 
+diff -Naur ./plugins/sid/sidplay-libs/libsidplay/src/xsid/xsid.cpp ../deadbeef.old/plugins/sid/sidplay-libs/libsidplay/src/xsid/xsid.cpp
+--- ./plugins/sid/sidplay-libs/libsidplay/src/xsid/xsid.cpp	2017-07-22 11:09:15.117275762 +0200
++++ ../deadbeef.old/plugins/sid/sidplay-libs/libsidplay/src/xsid/xsid.cpp	2016-06-19 13:26:18.000000000 +0200
+@@ -81,7 +81,7 @@
+     '\x08', '\x19', '\x2a', '\x3b', '\x4c', '\x5d', '\x6e', '\x7f'
+ };
+ */
+-const int8_t XSID::sampleConvertTable[16] =
++const char XSID::sampleConvertTable[16] =
+ {
+     '\x80', '\x94', '\xa9', '\xbc', '\xce', '\xe1', '\xf2', '\x03',
+     '\x1b', '\x2a', '\x3b', '\x49', '\x58', '\x66', '\x73', '\x7f'
+diff -Naur ./plugins/sid/sidplay-libs/libsidplay/src/xsid/xsid.h ../deadbeef.old/plugins/sid/sidplay-libs/libsidplay/src/xsid/xsid.h
+--- ./plugins/sid/sidplay-libs/libsidplay/src/xsid/xsid.h	2017-07-22 11:08:43.054046487 +0200
++++ ../deadbeef.old/plugins/sid/sidplay-libs/libsidplay/src/xsid/xsid.h	2016-06-19 13:26:18.000000000 +0200
+@@ -234,7 +234,7 @@
+     uint8_t             sidData0x18;
+     bool                _sidSamples;
+     int8_t              sampleOffset;
+-    static const int8_t sampleConvertTable[16];
++    static const char sampleConvertTable[16];
+     bool                wasRunning;
+ 
+ private:

--- a/srcpkgs/deadbeef/template
+++ b/srcpkgs/deadbeef/template
@@ -1,15 +1,15 @@
 # Template file for 'deadbeef'.
 pkgname=deadbeef
 version=0.7.2
-revision=3
+revision=4
 build_style=gnu-configure
-configure_args="--disable-static --disable-gtk2 --disable-oss"
+configure_args="--disable-static $(vopt_if gtk3 --disable-gtk2 --disable-gtk3) --disable-oss"
 hostmakedepends="pkg-config intltool yasm"
 makedepends="
  libSM-devel alsa-lib-devel ffmpeg-devel libvorbis-devel libcurl-devel
  libjpeg-turbo-devel libpng-devel libmad-devel libflac-devel wavpack-devel
  libsndfile-devel libcdio-devel libcddb-devel dbus-devel glu-devel
- pulseaudio-devel faad2-devel libsamplerate-devel imlib2-devel gtk+3-devel
+ pulseaudio-devel faad2-devel libsamplerate-devel imlib2-devel $(vopt_if gtk3 gtk+3-devel gtk+-devel)
  jansson-devel mpg123-devel"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Ultimate Music Player For GNU/Linux"
@@ -18,6 +18,11 @@ license="GPL-2, LGPL-2.1"
 homepage="http://deadbeef.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.bz2"
 checksum=8a63abdf00c2f37c33e018ae0b39d391873e037434074b84bb47381bf283c884
+
+build_options="gtk3"
+build_options_default="gtk3"
+
+desc_option_gtk3="Build the GTK+3 toolkit GUI. Disable to use GTK+2"
 
 post_configure() {
 	# XXX


### PR DESCRIPTION
I've experienced errors with GTK+3 version of deadbeef such as broken progress bar:
![przechwycenie obrazu ekranu_2017-07-22_09-54-47](https://user-images.githubusercontent.com/29679513/28489417-e78e72b0-6ec3-11e7-84c0-2bd228148581.png)
Compiling with GTK+2 fixes this error:
![przechwycenie obrazu ekranu_2017-07-22_10-05-51](https://user-images.githubusercontent.com/29679513/28489534-60de5076-6ec5-11e7-94df-2e77645feabb.png)
