### PR TITLE
gnustep-make: Fix vars in config.make

### DIFF
--- a/srcpkgs/gnustep-make/template
+++ b/srcpkgs/gnustep-make/template
@@ -1,7 +1,7 @@
 # Template build file for 'gnustep-make'
 pkgname=gnustep-make
 version=2.7.0
-revision=1
+revision=2
 build_style=gnu-configure
 conf_files="/etc/GNUstep/GNUstep.conf"
 short_desc="GNU Step Makefile helpers for a GNUstep-based project"
@@ -10,3 +10,8 @@ license="LGPL-3"
 homepage="http://www.gnustep.org"
 distfiles="http://ftp.gnustep.org/pub/gnustep/core/${pkgname}-${version}.tar.gz"
 checksum=90a01cbfb68aafe01c4cc4123121ebd2da0e1e2076795b5682f0833fddf311ce
+
+post_install() {
+	sed -i 's,/builddir/.xbps-gnustep-make/wrappers,/usr/bin,g' ${DESTDIR}/usr/share/GNUstep/Makefiles/config.make
+	sed -i 's,-specs=/void-packages/[^ ]* ,,g' ${DESTDIR}/usr/share/GNUstep/Makefiles/config.make
+}


### PR DESCRIPTION
Installation process was leaving some parts of the bootstrapped env in the final script.

I wasn't sure what to do with the `-specs` thing, but it seems to be effectively adding `-fPIC` as appropriate. Since for building packages, the env should add it anyway I think it is safe to just leave it out.

Feel free to provide better solution(s), of course.

Fixes #7074 