### PR TITLE
emerald: update to 0.8.14

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2718,7 +2718,7 @@ libuim-custom.so.2 uim-1.8.6_1
 libgcroots.so.0 uim-1.8.6_1
 libdecoration.so.0 compiz-core-0.8.14_1
 libcompizconfig.so.0 libcompizconfig-0.8.14_1
-libemeraldengine.so.0 emerald-0.8.12.4_1
+libemeraldengine.so.0 emerald-0.8.14_1
 libhangul.so.1 libhangul-0.1.0_1
 libmutter-clutter-1.0.so mutter-3.22.0_1
 libmutter-cogl-pango.so mutter-3.22.0_1

--- a/srcpkgs/emerald-themes/template
+++ b/srcpkgs/emerald-themes/template
@@ -1,6 +1,6 @@
 # Template file for 'emerald-themes' of Compiz Reloaded
 pkgname=emerald-themes
-version=0.8.12.1
+version=0.8.14
 revision=1
 build_style=gnu-configure
 
@@ -13,7 +13,7 @@ homepage="https://github.com/compiz-reloaded"
 license="GPL-2"
 
 distfiles="https://github.com/compiz-reloaded/emerald-themes/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=02dff05e018ffdf8faeb92e20906c4be2627a2363410700cddb12a51c21937f9
+checksum=68273673da24ae1249796e9457581719f4d9bbe1f3330aa446b9f87f5e46a250
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh

--- a/srcpkgs/emerald/patches/CCfix.patch
+++ b/srcpkgs/emerald/patches/CCfix.patch
@@ -1,0 +1,17 @@
+--- configure.ac.old	2017-07-24 11:11:08.588672399 -0700
++++ configure.ac	2017-07-24 11:51:52.841737854 -0700
+@@ -132,8 +132,12 @@
+     AC_MSG_NOTICE([Using decorator interface version ${decor_ver}])
+   ],
+   [
+-    AC_DEFINE(DECOR_INTERFACE_VERSION, 0, [Decorator interface version])
+-    AC_MSG_ERROR([Failed to check the decorator interface version])
++    AC_DEFINE(DECOR_INTERFACE_VERSION, [20110504], [Decorator interface version])
++    AC_MSG_NOTICE([Unable to check decorator version at runtime. Defaulting to number for 0.8.14.])
++  ],
++  [
++    AC_DEFINE(DECOR_INTERFACE_VERSION, [20110504], [Decorator interface version])
++    AC_MSG_NOTICE([Unable to check decorator version at runtime. Defaulting to nnumber for 0.8.14.])
+   ]
+ )
+ CFLAGS="$save_CFLAGS"

--- a/srcpkgs/emerald/template
+++ b/srcpkgs/emerald/template
@@ -1,6 +1,6 @@
 # Template file for 'emerald' of Compiz Reloaded
 pkgname=emerald
-version=0.8.12.4
+version=0.8.14
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static"
@@ -14,7 +14,7 @@ homepage="https://github.com/compiz-reloaded"
 license="GPL-2"
 
 distfiles="https://github.com/compiz-reloaded/emerald/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=00a565cd9f5e4442b94d4a40b81e03a6591d734e58d969f73187cc320eaca20c
+checksum=08cf6c867edd58f1eaf47fd99036abc79d78074f76187408c4db310983b5b861
 
 pre_configure() {
 	mkdir -p m4


### PR DESCRIPTION
This is part 3 of 3 for the compiz upgrade.

compiz core packages. [done]
compiz-plugin-* packages [done]
emerald packages []

Note: The lovely folks over at Compiz-Reloaded  have made it so emerald will not cross compile because of ... interesting.... decisions about their configure.ac file. I have applied a patch that fixes the issue and allows for cross compiling.
