### PR TITLE
kernel-libc-headers: ship linux/dma-buf.h

### DIFF
--- a/srcpkgs/kernel-libc-headers/patches/2220fc1ab363e6fab1f321430d69be17a8b92bd7.patch
+++ b/srcpkgs/kernel-libc-headers/patches/2220fc1ab363e6fab1f321430d69be17a8b92bd7.patch
@@ -1,0 +1,42 @@
+From 2220fc1ab363e6fab1f321430d69be17a8b92bd7 Mon Sep 17 00:00:00 2001
+From: Denys Dmytriyenko <denys@ti.com>
+Date: Tue, 14 Feb 2017 15:00:47 -0500
+Subject: uapi: add missing install of dma-buf.h
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+As part of c11e391da2a8fe973c3c2398452000bed505851e "dma-buf: Add ioctls to
+allow userspace to flush" a new uapi header file dma-buf.h was added, but an
+entry was not added on Kbuild to install it. This patch resolves this omission
+so that "make headers_install" installs this header.
+
+Signed-off-by: Denys Dmytriyenko <denys@ti.com>
+Reviewed-by: Tomi Valkeinen <tomi.valkeinen@ti.com>
+Cc: Ville Syrjälä <ville.syrjala@linux.intel.com>
+Cc: David Herrmann <dh.herrmann@gmail.com>
+Cc: Sumit Semwal <sumit.semwal@linaro.org>
+Cc: Daniel Vetter <daniel.vetter@intel.com>
+Cc: Tiago Vignatti <tiago.vignatti@intel.com>
+Cc: Daniel Vetter <daniel.vetter@ffwll.ch>
+Signed-off-by: Daniel Vetter <daniel.vetter@ffwll.ch>
+Link: http://patchwork.freedesktop.org/patch/msgid/1487102447-59265-1-git-send-email-denis@denix.org
+---
+ include/uapi/linux/Kbuild | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/uapi/linux/Kbuild b/include/uapi/linux/Kbuild
+index f330ba4..900129c 100644
+--- include/uapi/linux/Kbuild
++++ include/uapi/linux/Kbuild
+@@ -109,6 +109,7 @@ header-y += dlm_netlink.h
+ header-y += dlm_plock.h
+ header-y += dm-ioctl.h
+ header-y += dm-log-userspace.h
++header-y += dma-buf.h
+ header-y += dn.h
+ header-y += dqblk_xfs.h
+ header-y += edd.h
+-- 
+cgit v1.1
+

--- a/srcpkgs/kernel-libc-headers/template
+++ b/srcpkgs/kernel-libc-headers/template
@@ -1,7 +1,7 @@
 # Template file for 'kernel-libc-headers'
 pkgname=kernel-libc-headers
 version=4.9.8
-revision=2
+revision=3
 bootstrap=yes
 nostrip=yes
 noverifyrdeps=yes


### PR DESCRIPTION
Required by the chromium 59+ build.