### PR TITLE
oracle-jre: update to 8u144

### DIFF
--- a/srcpkgs/oracle-jre/template
+++ b/srcpkgs/oracle-jre/template
@@ -1,11 +1,11 @@
 # Template file for 'oracle-jre'
 pkgname=oracle-jre
-version=8u141
+version=8u144
 revision=1
 
 _longVersion=1.${version%u*}.0_${version#*u}
-_build=15
-_tag=336fa29ff2bb4ef291e347e091f7f4a7
+_build=01
+_tag=090f390dda5b47b9b721c7dfaa008135
 
 short_desc="Java Runtime Environment (JRE)"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
@@ -22,12 +22,12 @@ case "${XBPS_TARGET_MACHINE}" in
 x86_64)
 	_arch=amd64
 	_filename=jre-${version}-linux-x64.tar.gz
-	checksum=f268b4d20577be86e1d98451a27b59fd0e99aacd7e9ad7eb35abc3ffa2370c4d
+	checksum=4e6e11aad54ae3c716a5607ee88d81f3f1e8b5b23ee474b0272dba351ee9f28a
 	;;
 i686)
 	_arch=i386
 	_filename=jre-${version}-linux-i586.tar.gz
-	checksum=b1cf6a5161d68fcb16285e9dfdd664e6508287a80c351574327b0257baef3d1a
+	checksum=9ac5b0d6cda9279a4959a6eb635d849d745a37dafc24666539d1c8f7d76ab77a
 	;;
 esac
 
@@ -77,10 +77,9 @@ do_build() {
 }
 
 do_install() {
-	vmkdir "usr/share/licenses/${pkgname}"
 	vinstall oracle-jre-vars.sh 644 "usr/lib/jvm/"
 
-	vinstall LICENSE 644 "usr/share/licenses/${pkgname}"
+	vlicense LICENSE
 	vinstall $FILESDIR/java-policy-settings.desktop 644 usr/share/applications
 	ln -s jre${_longVersion} ${DESTDIR}/usr/lib/jvm/oracle-jre
 


### PR DESCRIPTION
"Java SE 8u144 includes important bug fixes. Oracle strongly recommends that all Java SE 8 users upgrade to this release."