### PR TITLE
oracle-jdk: update to 8u144

### DIFF
--- a/srcpkgs/oracle-jdk/template
+++ b/srcpkgs/oracle-jdk/template
@@ -1,11 +1,11 @@
 # Template file for 'oracle-jdk'
 pkgname=oracle-jdk
-version=8u141
+version=8u144
 revision=1
 
-_build=15
+_build=01
 _longVersion=1.${version%u*}.0_${version#*u}
-_tag=336fa29ff2bb4ef291e347e091f7f4a7
+_tag=090f390dda5b47b9b721c7dfaa008135
 
 short_desc="Java Development Kit (JDK)"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
@@ -23,22 +23,22 @@ case "${XBPS_TARGET_MACHINE}" in
 x86_64)
 	_arch=amd64
 	_filename=jdk-${version}-linux-x64.tar.gz
-	checksum=041d5218fbea6cd7e81c8c15e51d0d32911573af2ed69e066787a8dc8a39ba4f
+	checksum=e8a341ce566f32c3d06f6d0f0eeea9a0f434f538d22af949ae58bc86f2eeaae4
 	;;
 i686)
 	_arch=i386
 	_filename=jdk-${version}-linux-i586.tar.gz
-	checksum=6562f2bc8865e9c693b04c591d86d121871f49463ab0ca83fa0bcb070ffe084b
+	checksum=624c090647629394ef0ee08d9d8ac5d3d5a9a60fa245fefb2eb417c36c7cb7c4
 	;;
 arm*)
 	_arch=arm
 	_filename=jdk-${version}-linux-arm32-vfp-hflt.tar.gz
-	checksum=f73fa7631e5173b10a9ffd415b8fa9585a32eeac6fb7a3e1ccc4631270d79f31
+	checksum=cbbd390e19ab4c473e05f60602ce2804db25e4e35be5ab95f4f1a2aeb5b72383
 	;;
 aarch64)
 	_arch=aarch64
 	_filename=jdk-${version}-linux-arm64-vfp-hflt.tar.gz
-	checksum=1721b8f852f63c0889a978a262a58777e061ecdc64be1a6e437cf7464e925804
+	checksum=bbcf4a0805f9bcead32fd988b74cee61ef6ad90e6d1b4e0dce432ac3fd8e0168
 	;;
 esac
 
@@ -124,10 +124,9 @@ do_build() {
 }
 
 do_install() {
-	vmkdir "usr/share/licenses/${pkgname}"
 	vinstall oracle-jdk-vars.sh 644 "usr/lib/jvm/"
 
-	vinstall LICENSE 644 "usr/share/licenses/${pkgname}"
+	vlicense LICENSE
 	vinstall $FILESDIR/java-policy-settings.desktop 644 usr/share/applications
 	ln -s jdk${_longVersion} ${DESTDIR}/usr/lib/jvm/oracle-jdk
 


### PR DESCRIPTION
"Java SE 8u144 includes important bug fixes. Oracle strongly recommends that all Java SE 8 users upgrade to this release."