### PR TITLE
more: replace with less

### DIFF
--- a/srcpkgs/less/template
+++ b/srcpkgs/less/template
@@ -14,5 +14,5 @@ checksum=02a476dccd12e1b76e5d91259cba5dac1b8c8e5a730465c1c89c798b19741509
 
 post_install() {
 	rm -f /usr/bin/more
-	ln /usr/bin/less /usr/bin/more
+	ln -s ${DESTDIR}/usr/bin/less /usr/bin/more
 }

--- a/srcpkgs/less/template
+++ b/srcpkgs/less/template
@@ -1,7 +1,7 @@
 # Template file for 'less'
 pkgname=less
 version=494
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-regex=pcre"
 makedepends="ncurses-devel pcre-devel"
@@ -11,3 +11,8 @@ license="GPL-3"
 homepage="http://www.greenwoodsoftware.com/less"
 distfiles="${homepage}/less-${version}.tar.gz"
 checksum=02a476dccd12e1b76e5d91259cba5dac1b8c8e5a730465c1c89c798b19741509
+
+post_install() {
+	rm -f /usr/bin/more
+	ln /usr/bin/less /usr/bin/more
+}

--- a/srcpkgs/less/template
+++ b/srcpkgs/less/template
@@ -9,7 +9,7 @@ short_desc="Pager program similar to more(1)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-3"
 homepage="http://www.greenwoodsoftware.com/less"
-distfiles="${homepage}/less-${version}.tar.gz"
+distfiles="https://sources.voidlinux.eu/less-${version}/less-${version}.tar.gz"
 checksum=02a476dccd12e1b76e5d91259cba5dac1b8c8e5a730465c1c89c798b19741509
 
 post_install() {

--- a/srcpkgs/util-linux/template
+++ b/srcpkgs/util-linux/template
@@ -1,7 +1,7 @@
 # Template file for 'util-linux'
 pkgname=util-linux
 version=2.30.1
-revision=1
+revision=2
 short_desc="Miscellaneous linux utilities"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="https://www.kernel.org/pub/linux/utils/util-linux/"
@@ -26,7 +26,7 @@ alternatives="
 "
 
 pre_configure() {
-	NOCONFIGURE=1 ./autogen.sh
+	NOCONFIGURE=1 ./autogen.sh --disable-more
 }
 do_configure() {
 	./configure ${configure_args} \

--- a/srcpkgs/util-linux/template
+++ b/srcpkgs/util-linux/template
@@ -26,7 +26,7 @@ alternatives="
 "
 
 pre_configure() {
-	NOCONFIGURE=1 ./autogen.sh --disable-more
+	NOCONFIGURE=1 ./autogen.sh
 }
 do_configure() {
 	./configure ${configure_args} \
@@ -38,7 +38,8 @@ do_configure() {
 		--enable-vipw --enable-newgrp --enable-chfn-chsh \
 		--with-systemdsystemunitdir=no \
 		--without-udev --without-python \
-		--enable-write --localstatedir=/run
+		--enable-write --localstatedir=/run \
+		--disable-more
 }
 do_build() {
 	make ${makejobs}


### PR DESCRIPTION
Given the recent breakage of mdocml due to the post_extract sed -i 's,"more -s","less -s",g' main.c and the likely future breakage from patching its source to use more, I see it fit to replace
more with less. Less has a more-compatibility mode (LESS_IS_MORE=1) which is automatically invoked if called from a link named 'more'.

This stops building more, and removes and replaces it with a hardlink to less.