### PR TITLE
opencv: enable openblas support

### DIFF
--- a/srcpkgs/opencv/template
+++ b/srcpkgs/opencv/template
@@ -1,13 +1,13 @@
 # Template file for 'opencv'
 pkgname=opencv
 version=3.2.0
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DENABLE_PRECOMPILED_HEADERS=OFF -DWITH_OPENMP=ON -WITH_OPENCL=ON"
 hostmakedepends="pkg-config python-devel eigen"
 makedepends="python-numpy ffmpeg-devel libpng-devel libjpeg-turbo-devel tiff-devel
  jasper-devel ocl-icd-devel libgomp-devel libopenexr-devel gtk+-devel gtk+3-devel
- libgphoto2-devel gst-plugins-base1-devel"
+ libgphoto2-devel gst-plugins-base1-devel openblas-devel"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://opencv.org"
 license="BSD"


### PR DESCRIPTION
"OpenCV now can use vendor-provided OpenVX and LAPACK/BLAS (including Intel MKL, Apple’s Accelerate, OpenBLAS and Atlas) for acceleration" (http://opencv.org/opencv-3-2.html)

I've run some tests and obtained a x8 speed-up.

