### PR TITLE
gnome-online-accounts: update to 3.24.2

### DIFF
--- a/srcpkgs/gnome-online-accounts/template
+++ b/srcpkgs/gnome-online-accounts/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-online-accounts'
 pkgname=gnome-online-accounts
-version=3.24.1
+version=3.24.2
 revision=1
 build_style=gnu-configure
 configure_args="$(vopt_enable gir introspection)
@@ -14,10 +14,10 @@ makedepends="libsoup-gnome-devel webkit2gtk-devel json-glib-devel libnotify-deve
 depends="hicolor-icon-theme"
 short_desc="GNOME service to access online accounts"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.gnome.org"
-license="GPL-2"
+homepage="https://wiki.gnome.org/Projects/GnomeOnlineAccounts"
+license="LGPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=0a30ab4e4e8015fae707c3b38f05163299743725a36136076fce993c2b8ef651
+checksum=b70ad52d1541e1e5192dd060bb11552a3af5007ab477aa81d265d1cd1cf7afba
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then


### PR DESCRIPTION
* Corrected the homepage link and set the right license [License](https://git.gnome.org/browse/gnome-online-accounts/tree/COPYING)