### PR TITLE
gdk-pixbuf: update to 2.36.8

### DIFF
--- a/srcpkgs/gdk-pixbuf/template
+++ b/srcpkgs/gdk-pixbuf/template
@@ -1,6 +1,6 @@
-# Template build file for 'gdk-pixbuf'.
+# Template file for 'gdk-pixbuf'
 pkgname=gdk-pixbuf
-version=2.36.7
+version=2.36.8
 revision=1
 build_style=gnu-configure
 configure_args="$(vopt_enable gir introspection) --without-libjasper
@@ -9,12 +9,12 @@ hostmakedepends="automake libtool perl pkg-config gettext-devel
  glib-devel $(vopt_if gir gobject-introspection)"
 makedepends="libglib-devel libpng-devel libjpeg-turbo-devel tiff-devel libX11-devel"
 triggers="gtk-pixbuf-loaders"
-short_desc="An Image loading library for The GTK+ toolkit (v2)"
+short_desc="Image loading library for The GTK+ toolkit (v2)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="https://www.gtk.org/"
+homepage="https://wiki.gnome.org/Projects/GdkPixbuf"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=1b6e5eef09d98f05f383014ecd3503e25dfb03d7e5b5f5904e5a65b049a6a4d8
+checksum=5d68e5283cdc0bf9bda99c3e6a1d52ad07a03364fa186b6c26cfc86fcd396a19
 
 # Package build options
 build_options="gir"


### PR DESCRIPTION
Fixes [#7151](https://github.com/voidlinux/void-packages/issues/7151).