### PR TITLE
tumbler: update to 0.2.0

### DIFF
--- a/srcpkgs/tumbler/template
+++ b/srcpkgs/tumbler/template
@@ -1,19 +1,19 @@
 # Template file for 'tumbler'.
 pkgname=tumbler
-version=0.1.32
+version=0.2.0
 revision=1
 build_style=gnu-configure
 configure_args="--disable-gstreamer-thumbnailer"
 hostmakedepends="automake libtool pkg-config intltool xfce4-dev-tools
- gettext-devel glib-devel dbus-glib-devel"
-makedepends="libjpeg-turbo-devel libpng-devel gtk+-devel dbus-glib-devel
+ gettext-devel glib-devel"
+makedepends="libjpeg-turbo-devel libpng-devel gtk+-devel
  libgsf-devel poppler-glib-devel libopenraw-devel ffmpegthumbnailer-devel"
 short_desc="D-Bus Thumbnailer service"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="https://xfce.org"
 distfiles="http://archive.xfce.org/src/xfce/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
-checksum=f08c88d9dd3b8781aa218146c11ab4aec307e8eb9232aaf18d90a4bae29adacf
+checksum=4e27a59694b0a5cc69ebccbdb00c724e670b5b7c30bc4dc0b461aac93f234fac
 
 CFLAGS="-I${XBPS_CROSS_BASE}/usr/include/freetype2"
 


### PR DESCRIPTION
No longer requires dbus-glib