### PR TITLE
discord: add libcxx dependency

### DIFF
--- a/srcpkgs/discord/template
+++ b/srcpkgs/discord/template
@@ -3,8 +3,8 @@
 
 pkgname="discord"
 version="0.0.2"
-revision=2
-depends="alsa-lib dbus-glib gtk+3 GConf libnotify nss libXtst"
+revision=3
+depends="alsa-lib dbus-glib gtk+3 GConf libnotify nss libXtst libcxx"
 wrksrc="Discord"
 only_for_archs="x86_64"
 nopie=yes


### PR DESCRIPTION
Discord 0.0.2 requires `libcxx` as a dependency. Application starts but does not properly function without it.