### PR TITLE
libGLES: fix common/shlibs for Opera

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -121,6 +121,7 @@ libEGL.so.1 libEGL-7.11_1
 libEGL.so.1 nvidia-libs-346.72_2
 libGLESv1_CM.so.1 libGLES-1.0_1
 libGLESv2.so.2 libGLES-1.0_1
+libGLESv2.so libGLES-1.0_1
 libEGL.so rpi-userland-0.0.0.0.20150907_1
 libGLES.so rpi-userland-0.0.0.0.20150907_1
 libGLESv2.so rpi-userland-0.0.0.0.20150907_1

--- a/srcpkgs/libGL/template
+++ b/srcpkgs/libGL/template
@@ -100,6 +100,7 @@ post_install() {
 		mv "$DESTDIR/usr/lib32/d3d" "$DESTDIR/usr/lib"
 		mv "$DESTDIR/usr/lib32/pkgconfig"/* "$DESTDIR/usr/lib/pkgconfig"
 	fi
+	vlicense docs/license.html LICENSE.html
 }
 
 libglapi_package() {

--- a/srcpkgs/libGL/template
+++ b/srcpkgs/libGL/template
@@ -1,7 +1,7 @@
 # Template build file for 'libGL'.
 pkgname=libGL
 version=17.1.6
-revision=1
+revision=2
 wrksrc="mesa-${version}"
 build_style=gnu-configure
 configure_args="--enable-shared-glapi --enable-gbm
@@ -124,6 +124,7 @@ libEGL_package() {
 libGLES_package() {
 	depends="libudev"
 	short_desc="Free implementation of the OpenGL|ES 1.x and 2.x API"
+	shlib_provides="libGLESv2.so"
 	pkg_install() {
 		vmove "usr/lib/libGLES*.so*"
 	}

--- a/srcpkgs/opera/template
+++ b/srcpkgs/opera/template
@@ -1,7 +1,7 @@
 # Template file for 'opera'
 pkgname=opera
 version=47.0.2631.39
-revision=1
+revision=2
 only_for_archs="x86_64"
 hostmakedepends="freetype-devel"
 depends="ffmpeg desktop-file-utils"


### PR DESCRIPTION
The new version of opera looks for libGLESv2.so