### PR TITLE
common/shlibs: cleanup

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1361,7 +1361,6 @@ libcacard.so.0 libcacard-1.6.1_1
 libxcb-cursor.so.0 xcb-util-cursor-0.1.0_1
 libgldi.so.3 libgldi-3.3.1_1
 libevdev.so.2 libevdev-1.2_1
-libmutter-wayland.so.0 mutter-wayland-3.10.1_1
 libgdiplus.so.0 libgdiplus-2.10.9_1
 libmonosgen-2.0.so.1 mono-3.2.3_1
 libshout-idjc.so.3 libshout-idjc-2.3.1_1


### PR DESCRIPTION
1. I found this when I was trying to build [gala](https://github.com/elementary/gala). 

2. Seems like there's a problem with `mutter-devel` package: `libmutter` is not correctly detected when we try to build gala, we discussed it on the forum.