### PR TITLE
keybase: update to 1.0.28-20170815161818+fed6e3db9

### DIFF
--- a/srcpkgs/keybase/template
+++ b/srcpkgs/keybase/template
@@ -1,8 +1,8 @@
 # Template file for 'keybase'
 pkgname=keybase
-version=1.0.22
-revision=2
-wrksrc="client-${version}"
+_commit="fed6e3db999943d98e2d32057a9d7a3e7196e0c0"
+version="1.0.28.0.20170815"
+revision=1
 build_style=go
 go_import_path="github.com/keybase/client"
 go_package="${go_import_path}/go/keybase"
@@ -12,8 +12,9 @@ short_desc="Client for keybase.io"
 maintainer="Toyam Cox <Vaelatern@gmail.com>"
 license="BSD"
 homepage="https://keybase.io/"
-distfiles="https://github.com/keybase/client/archive/v${version}.tar.gz"
-checksum=202a56ea6d25b0f0de2e7529839eb62266ad1665297483cef4948678c95c12f9
+distfiles="https://github.com/keybase/client/archive/${_commit}.tar.gz"
+checksum=7fd94b28797896f22bc648d7bff815a850e925525a11e1ea3678ae73db6dc0a8
+wrksrc="client-${_commit}"
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Since keybase don't really support their actual release tags and advices people to follow pre-release I feel we should too since you actually face problems if you don't

1: https://github.com/keybase/client/issues/7907
2: https://github.com/keybase/client/issues/8110
3: See their release log: https://github.com/keybase/client/releases , it's full of holes!