### PR TITLE
libdwarf: fix cross-compilation

### DIFF
--- a/srcpkgs/libdwarf/template
+++ b/srcpkgs/libdwarf/template
@@ -1,7 +1,7 @@
 # Template build file for 'libdwarf'
 pkgname=libdwarf
 version=20170709
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--prefix=/usr --enable-shared"
 short_desc="DWARF Debugging Information Format Library"
@@ -13,8 +13,15 @@ distfiles="http://prevanders.net/${pkgname}-${version}.tar.gz"
 checksum=46ccfb24ecd24bd7cce466d67a7bfeb62b9ed405dafdc924918d58c529abccb8
 wrksrc="dwarf-${version}"
 build_wrksrc="libdwarf"
-nocross="yes"
-# XXX need to fix cross-compile
+
+if [ -n "$CROSS_BUILD" ]; then
+	make_cmd="make HOSTCC=cc HOSTCFLAGS=-I./ HOSTLDFLAGS="
+
+	pre_build() {
+		# Makefile doesn’t use $HOSTLDFLAGS when using $HOSTCC
+		sed -i -e 's|\$(HOSTCC) \$(HOSTCFLAGS) \$(LDFLAGS)|\$(HOSTCC) \$(HOSTCFLAGS) \$(HOSTLDFLAGS)|' Makefile
+	}
+fi
 
 do_install() {
 	install -dm755 $DESTDIR/usr/lib


### PR DESCRIPTION
According to the README:

<pre>When cross-compiling, gennames has to be built by the
native compiler. So try
  make HOSTCC=cc gennames
as a first step before the normal make.</pre>

I adjusted `make_cmd` and fixed an error in the `Makefile` where the $HOSTCC used (target) $LDFLAGS.
The `gennames` binary is just used for building purposes and not in the final package.