### PR TITLE
libvidstab: update to 1.1.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2377,7 +2377,7 @@ libwiredtiger_snappy.so wiredtiger-2.9.0_1
 libwiredtiger_zlib.so wiredtiger-2.9.0_1
 libwiredtiger-2.9.2.so wiredtiger-2.9.2_1
 libwiredtiger-2.9.3.so wiredtiger-2.9.3_1
-libvidstab.so.0.9 libvidstab-0.98b_1
+libvidstab.so.1.1 libvidstab-1.1.0_1
 libxdo.so.3 xdotool-3.20150503.1_1
 libabigail.so.0 libabigail-1.0.rc3_1
 libgnome-games-support-1.so.2 libgnome-games-support-1.2.0_1

--- a/srcpkgs/ffmpeg/template
+++ b/srcpkgs/ffmpeg/template
@@ -1,7 +1,7 @@
 # Template file for 'ffmpeg'
 pkgname=ffmpeg
 version=3.3.3
-revision=1
+revision=2
 short_desc="Decoding, encoding and streaming software"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-3"

--- a/srcpkgs/libvidstab/template
+++ b/srcpkgs/libvidstab/template
@@ -1,16 +1,16 @@
 # Template file for 'libvidstab'
 pkgname=libvidstab
-version=0.98b
+version=1.1.0
 revision=1
-wrksrc=vid.stab-release-${version}
+wrksrc=vid.stab-${version}
 build_style=cmake
 short_desc="Video stabilization library"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
-makedepends="orc-devel"
+makedepends="orc-devel libgomp-devel"
 license="GPL-2"
 homepage="http://public.hronopik.de/vid.stab/"
-distfiles="https://github.com/georgmartius/vid.stab/archive/release-${version}.tar.gz"
-checksum=530f0bf7479ec89d9326af3a286a15d7d6a90fcafbb641e3b8bdb8d05637d025
+distfiles="https://github.com/georgmartius/vid.stab/archive/v${version}.tar.gz"
+checksum=14d2a053e56edad4f397be0cb3ef8eb1ec3150404ce99a426c4eb641861dc0bb
 
 pre_configure() {
 	sed -i -e 's/include (FindSSE)//' CMakeLists.txt
@@ -22,7 +22,7 @@ pre_configure() {
 }
 
 libvidstab-devel_package() {
-	depends="${sourcepkg}>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision} libgomp-devel"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
I was preparing a template for vid.stab and after finishing I realised it’s already there as libvidstab. So I decided to open a pull request to update the package. But that leads me to a question about naming conventions. The [manual](https://github.com/voidlinux/void-packages/blob/master/Manual.md#libs) says:

> Libraries are packages which provide shared objects (*.so) in /usr/lib. They should be named like their upstream package name with the following exceptions:
> 
> The package is a subpackage of a front end application and provides shared objects used by the base package and other third party libraries. In that case it should be prefixed with 'lib'. An exception from that rule is: If an executable is only used for building that package, it moves to the -devel package.

The way I understand this is that the package should have the name ‘vid.stab’ instead of ‘libvidstab’ because it’s not a subpackage? It would be much easier to find.

P.S.: Sorry for being pedantic. ;-)