### PR TITLE
Clarify description for synfig template

### DIFF
--- a/srcpkgs/synfig/template
+++ b/srcpkgs/synfig/template
@@ -7,7 +7,7 @@ hostmakedepends="boost-build ImageMagick pkg-config"
 makedepends="ETL gettext-devel libxml++-devel mlt-devel
  libmng-devel boost-build boost-devel libopenexr-devel ffmpeg-devel"
 depends="ImageMagick"
-short_desc="Open Source 2D vector and timeline-based animation software"
+short_desc="Open Source 2D vector and timeline-based animation software (command line renderer)"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="GPL-3"
 homepage="http://www.synfig.org/"


### PR DESCRIPTION
The `synfig` template is for the command line renderer. The actual animation software would be `synfigstudio` which does not exist in this repo yet.