### PR TITLE
Fix building kodi/kodi-rpi against crossguid-0.2.x

### DIFF
--- a/srcpkgs/kodi-rpi/template
+++ b/srcpkgs/kodi-rpi/template
@@ -1,7 +1,7 @@
 # Template file for 'kodi-rpi'
 pkgname=kodi-rpi
 version=17.4
-revision=1
+revision=2
 build_style=cmake
 patch_args="-Np1"
 _codename="Krypton"

--- a/srcpkgs/kodi/patches/crossguid-0.2.patch
+++ b/srcpkgs/kodi/patches/crossguid-0.2.patch
@@ -1,0 +1,37 @@
+--- a/project/cmake/modules/FindCrossGUID.cmake.orig	2017-09-04 14:23:17.801957041 +0200
++++ b/project/cmake/modules/FindCrossGUID.cmake	2017-09-04 14:23:55.258390977 +0200
+@@ -44,10 +44,10 @@
+   set(CROSSGUID_LIBRARIES ${CROSSGUID_LIBRARY})
+   set(CROSSGUID_INCLUDE_DIRS ${CROSSGUID_INCLUDE_DIR})
+ else()
+-  find_path(CROSSGUID_INCLUDE_DIR NAMES guid.h)
++  find_path(CROSSGUID_INCLUDE_DIR NAMES Guid.hpp)
+ 
+-  find_library(CROSSGUID_LIBRARY_RELEASE NAMES crossguid)
+-  find_library(CROSSGUID_LIBRARY_DEBUG NAMES crossguidd)
++  find_library(CROSSGUID_LIBRARY_RELEASE NAMES xg)
++  find_library(CROSSGUID_LIBRARY_DEBUG NAMES xg)
+ 
+   include(SelectLibraryConfigurations)
+   select_library_configurations(CROSSGUID)
+--- a/xbmc/utils/StringUtils.cpp.orig	2017-09-04 14:39:15.802986978 +0200
++++ b/xbmc/utils/StringUtils.cpp	2017-09-04 14:41:00.026267037 +0200
+@@ -28,7 +28,7 @@
+ //
+ //------------------------------------------------------------------------
+ 
+-#include <guid.h>
++#include <Guid.hpp>
+ 
+ #include "StringUtils.h"
+ #include "CharsetConverter.h"
+@@ -1191,8 +1191,7 @@
+ 
+ std::string StringUtils::CreateUUID()
+ {
+-  static GuidGenerator guidGenerator;
+-  auto guid = guidGenerator.newGuid();
++  auto guid = xg::newGuid();
+ 
+   std::stringstream strGuid; strGuid << guid;
+   return strGuid.str();

--- a/srcpkgs/kodi/template
+++ b/srcpkgs/kodi/template
@@ -1,8 +1,9 @@
 # Template file for 'kodi'
 pkgname=kodi
 version=17.4
-revision=1
+revision=2
 build_style=cmake
+configure_args="-DENABLE_INTERNAL_CROSSGUID=OFF"
 patch_args="-Np1"
 _codename="Krypton"
 wrksrc="xbmc-${version}-${_codename}"


### PR DESCRIPTION
Building of the kodi-rpi update in #7485 failed because crossguid was updated in the meantime and kodi still uses a version based on the incompatible 0.1 branch. Building the version bundled by kodi fails when cross-compiling so I added a small patch to build kodi against the current version from the repository.