### PR TITLE
rng-tools: update to version 6

### DIFF
--- a/srcpkgs/rng-tools/INSTALL.msg
+++ b/srcpkgs/rng-tools/INSTALL.msg
@@ -1,0 +1,2 @@
+Note that version 6 of rng-tools has modified the rngd options, so if
+you have a custom /etc/sv/rngd/conf file, then it may need to be changed.

--- a/srcpkgs/rng-tools/patches/musl-needs-limits_h-include.patch
+++ b/srcpkgs/rng-tools/patches/musl-needs-limits_h-include.patch
@@ -1,0 +1,12 @@
+See https://github.com/nhorman/rng-tools/issues/11
+
+--- rngd.c	2017-09-09 21:28:33.134525565 +0200
++++ rngd.c	2017-09-09 21:34:36.535633815 +0200
+@@ -38,6 +38,7 @@
+ #include <stdint.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <limits.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>

--- a/srcpkgs/rng-tools/template
+++ b/srcpkgs/rng-tools/template
@@ -1,21 +1,27 @@
 # Template file for 'rng-tools'
 pkgname=rng-tools
-version=5
-revision=5
+version=6
+revision=1
+wrksrc=rng-tools-${pkgname}-${version}
 build_style=gnu-configure
-makedepends="libgcrypt-devel"
+makedepends="libgcrypt-devel libsysfs-devel"
+hostmakedepends="automake"
 short_desc="Random number generator related utilities"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="GPL-3"
-homepage="http://sourceforge.net/projects/gkernel"
-distfiles="${SOURCEFORGE_SITE}/gkernel/${pkgname}-${version}.tar.gz"
-checksum=60a102b6603bbcce2da341470cad42eeaa9564a16b4490e7867026ca11a3078e
+homepage="https://github.com/nhorman/rng-tools/releases"
+distfiles="https://github.com/nhorman/rng-tools/archive/${pkgname}-${version}.tar.gz"
+checksum=6d9c3f72824d1ea15dd2a80bfcf71f6a73c8843c6344f7f774a97a4ca7641b4c
 configure_args="--sbindir=/usr/bin"
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl)	makedepends+=" argp-standalone"
 		;;
 esac
+
+pre_configure() {
+	sh autogen.sh
+}
 
 do_build() {
 	case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
Note that this update required a minor patch for compilation with
musl, and that the upstream location has moved.

Also note the command line options for rngd have changed.