### PR TITLE
libcaca: add (optional) support for imlib2

### DIFF
--- a/srcpkgs/libcaca/template
+++ b/srcpkgs/libcaca/template
@@ -1,12 +1,12 @@
 # Template file for 'libcaca'
 pkgname=libcaca
 version=0.99.beta19
-revision=7
+revision=8
 build_style=gnu-configure
 hostmakedepends="libtool automake pkg-config"
 short_desc="Graphics library that outputs text instead of pixels"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-makedepends="ncurses-devel $(vopt_if x11 libX11-devel)"
+makedepends="ncurses-devel $(vopt_if x11 'libX11-devel imlib2-devel')"
 homepage="http://caca.zoy.org/wiki/libcaca"
 license="WTFPL"
 distfiles="https://github.com/cacalabs/libcaca/archive/v${version}.tar.gz"


### PR DESCRIPTION
According to `img2txt`’s manpage libcaca needs imlib2 to load other image formats than regular BMP files. 

Because `imlib2-devel` needs `libX11-devel` (else the build fails with `/usr/include/Imlib2.h:28:22: fatal error: X11/Xlib.h: No such file or directory`; it’s not a package dependency, though) and there already is a build option ‘x11’ I just added `imlib2-devel` to that option and didn’t enable it per default.

Alternatively one could add `libX11-devel` as a dependency to `imlib2-devel` (should it be added anyway because Imlib2.h includes Xlib.h?) and add an extra build option.