### PR TITLE
dmenu: get distfiles from https

### DIFF
--- a/srcpkgs/dmenu/template
+++ b/srcpkgs/dmenu/template
@@ -6,8 +6,8 @@ makedepends="libXinerama-devel libXft-devel freetype-devel"
 short_desc="A generic menu for X"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="MIT"
-homepage="http://tools.suckless.org/dmenu/"
-distfiles="http://dl.suckless.org/tools/${pkgname}-${version}.tar.gz"
+homepage="https://tools.suckless.org/dmenu/"
+distfiles="https://dl.suckless.org/tools/${pkgname}-${version}.tar.gz"
 checksum=a75635f8dc2cbc280deecb906ad9b7594c5c31620e4a01ba30dc83984881f7b9
 
 build_options="fuzzymatch"


### PR DESCRIPTION
dl.suckless.org now supports TLS using LetsEncrypt