### PR TITLE
st: get distfiles from https

### DIFF
--- a/srcpkgs/st/template
+++ b/srcpkgs/st/template
@@ -10,8 +10,8 @@ depends="ncurses"
 short_desc="Simple terminal implementation for X"
 maintainer='Juan RP <xtraeme@voidlinux.eu>'
 license="MIT"
-homepage="http://st.suckless.org"
-distfiles="http://dl.suckless.org/${pkgname}/${pkgname}-${version}.tar.gz"
+homepage="https://st.suckless.org"
+distfiles="https://dl.suckless.org/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=f7870d906ccc988926eef2cc98950a99cc78725b685e934c422c03c1234e6000
 
 pre_build() {


### PR DESCRIPTION
dl.suckless.org now supports TLS using LetsEncrypt