### PR TITLE
common/travis: switch to mirror for travis builds

### DIFF
--- a/common/travis/prepare.sh
+++ b/common/travis/prepare.sh
@@ -21,3 +21,6 @@ wget -q -O - https://github.com/chneukirchen/xtools/archive/master.tar.gz | \
 echo XBPS_CHROOT_CMD=uchroot >> etc/conf
 echo XBPS_MAKEJOBS=4 >> etc/conf
 echo XBPS_ALLOW_RESTRICTED=yes >> etc/conf
+
+/bin/echo -e '\x1b[32mUpdating etc/repos-remote.conf...\x1b[0m'
+sed -i 's#https\?://repo\.voidlinux\.eu#http://repo3.voidlinux.eu#' etc/repos-remote.conf


### PR DESCRIPTION
This PR switches travis to an US mirror. This should result in less traffic on the main repository and faster build times on travis as the bits don't have to cross oceans anymore.