### PR TITLE
sublime-text3: updated to build 3143

### DIFF
--- a/srcpkgs/sublime-text3/template
+++ b/srcpkgs/sublime-text3/template
@@ -1,13 +1,13 @@
 # Template file for 'sublime-text3'
 pkgname=sublime-text3
-version=3126
+version=3143
 revision=1
 if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 	distfiles="https://download.sublimetext.com/sublime_text_3_build_${version}_x64.tar.bz2"
-	checksum=18db132e9a305fa3129014b608628e06f9442f48d09cfe933b3b1a84dd18727a
+	checksum=9ce120c4f28b239d3b3860ee672d9d87e1397a4c08ee6c4e62fd6e261a296519
 else
 	distfiles="https://download.sublimetext.com/sublime_text_3_build_${version}_x32.tar.bz2"
-	checksum=92ffefa470f0777897ed0dfb7c1635426105271da9b5affbe8c1e82039718e29
+	checksum=b1ecc4b70d66b9236b876f1913c4094b6dd51436e45c74883ba70a1939e9f735
 fi
 depends="libpng gtk+ hicolor-icon-theme desktop-file-utils"
 maintainer="Andrea Brancaleoni <miwaxe@pompel.me>"


### PR DESCRIPTION
Hello,
because the sublime-text3 package was pretty outdated, I updated it.
I did bump the version number, so the right tarball gets fetched. Furthermore I updated the checksums.
On my machine both packages build using xbps-src and the 64bit version installed.

Because this is my first pull request on a big project and voidlinux, please correct me if I'm doing something wrong.