### PR TITLE
tbb: update to 2018, unbreak crossbuild and musl support

### DIFF
--- a/srcpkgs/tbb/patches/hostname-usage.patch
+++ b/srcpkgs/tbb/patches/hostname-usage.patch
@@ -1,0 +1,11 @@
+--- build/version_info_linux.sh.ORIG
++++ build/version_info_linux.sh
+@@ -20,7 +20,7 @@
+ 
+ # Script used to generate version info string
+ echo "#define __TBB_VERSION_STRINGS(N) \\"
+-echo '#N": BUILD_HOST'"\t\t"`hostname -s`" ("`uname -m`")"'" ENDL \'
++echo '#N": BUILD_HOST'"\t\t"`hostname`" ("`uname -m`")"'" ENDL \'
+ # find OS name in *-release and issue* files by filtering blank lines and lsb-release content out
+ echo '#N": BUILD_OS'"\t\t"`lsb_release -sd 2>/dev/null | grep -ih '[a-z] ' - /etc/*release /etc/issue 2>/dev/null | head -1 | sed -e 's/["\\\\]//g'`'" ENDL \'
+ echo '#N": BUILD_KERNEL'"\t"`uname -srv`'" ENDL \'

--- a/srcpkgs/tbb/template
+++ b/srcpkgs/tbb/template
@@ -1,27 +1,34 @@
 # Template file for 'tbb'
 pkgname=tbb
-version=2017.20161128
+_ver=2018
+version=${_ver/_U/.}
 revision=1
-_lv="${version%.*}"
-_rv="${version##*.}"
-wrksrc="$pkgname${_lv}_${_rv}oss"
+wrksrc="${pkgname}-${_ver}"
 build_style=gnu-makefile
 short_desc="Intel Threading Building Blocks"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache-2.0"
 homepage="http://www.threadingbuildingblocks.org"
-distfiles="https://www.threadingbuildingblocks.org/sites/default/files/software_releases/source/tbb${_lv}_${_rv}oss_src.tgz"
-checksum=c009166233c8ea0e34530a1c5f870b79314316d19e6876b37a7e7c854080a540
+distfiles="https://github.com/01org/tbb/archive/${_ver}.tar.gz"
+checksum=94f643f1edfaccb57d64b503c7c96f00dec64e8635c054bbaa33855d72c5822d
 
 only_for_archs="i686-musl x86_64-musl armv7l-musl aarch64-musl i686 x86_64 armv7l aarch64"
+
+case "$XBPS_TARGET_MACHINE" in
+	armv7l*)
+		make_build_args="arch=armv7"
+		;;
+	aarch64*)
+		make_build_args="arch=arm64"
+		;;
+esac
 
 post_extract() {
 	sed -i 's|CPLUS = g..|CPLUS = $(CXX)|g' build/linux.gcc.inc
 	sed -i 's|CONLY = gcc|CONLY = $(CC)|g' build/linux.gcc.inc
-	if [ "$CROSS_BUILD" ]; then
-		sed -i '/-m64/d' build/linux.gcc.inc
-		sed -i '/-mrtm/d' build/linux.gcc.inc
-	fi
+
+	# alternative might be:
+	# https://git.alpinelinux.org/cgit/aports/tree/testing/libtbb/glibc-struct-mallinfo.patch
 	case "$XBPS_TARGET_MACHINE" in
 		*-musl)
 			sed -e "s@#define MALLOC_UNIXLIKE_OVERLOAD_ENABLED __linux__@@" \

--- a/srcpkgs/tbb/update
+++ b/srcpkgs/tbb/update
@@ -1,3 +1,2 @@
-site='https://www.threadingbuildingblocks.org/download'
-pattern='tbb\d+_\K\d+'
-version="$_rv"
+pattern="/01org/tbb/archive/\K[0-9_U]+(?=\.tar\.gz)"
+version="${_ver}"


### PR DESCRIPTION
More details:
* update to last version
* fix crossbuild support and unbreak musl support: fix #4317
    As QA, `oce` can be now crossbuilded (subsequent PR)
* support new numbering scheme (like '2017_U7')
* update check is fine now
* no ABI changes: checked using `freecad` and `embree`
