### PR TITLE
oce: unbreak crossbuild

### DIFF
--- a/srcpkgs/oce/template
+++ b/srcpkgs/oce/template
@@ -2,7 +2,7 @@
 pkgname=oce
 _majorver=0.18
 version=${_majorver}.2
-revision=1
+revision=2
 wrksrc="${pkgname}-OCE-${version}"
 build_style=cmake
 configure_args="-DOCE_INSTALL_PREFIX=/usr -DOCE_WITH_FREEIMAGE=ON
@@ -14,17 +14,6 @@ license="LGPL-2.1, OCCT"
 homepage="https://github.com/tpaviot/oce"
 distfiles="https://github.com/tpaviot/oce/archive/OCE-${version}.tar.gz"
 checksum=dc21ddea678a500ad87c773e9a502ed7a71768cf83d9af0bd4c43294186a7fef
-
-case "${XBPS_TARGET_MACHINE}" in
-	arm*)
-		# error on linking with libTKMath.so or libTKMesh.so and tbb:
-		# undefined reference to tbb::internal::allocate_root_proxy::allocate(unsigned int)
-		broken=https://travis-ci.org/voidlinux/void-packages/jobs/136426588
-		;;
-	aarch*)
-		broken="tbb required package is broken"
-		;;
-esac
 
 post_install() {
 	vlicense OCCT_LGPL_EXCEPTION.txt


### PR DESCRIPTION
Following crossbuild fix and update of tbb (PR #7745), related to issue #4317.  
Probably too big for Travis CI, but my personal cross-build are fine.
