### PR TITLE
breeze-gtk: fix gtk3

### DIFF
--- a/srcpkgs/breeze-gtk/template
+++ b/srcpkgs/breeze-gtk/template
@@ -1,9 +1,9 @@
 # Template file for 'breeze-gtk'
 pkgname=breeze-gtk
 version=5.8.7
-revision=1
+revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF"
+configure_args="-DWITH_GTK3_VERSION=3.20"
 hostmakedepends="extra-cmake-modules"
 makedepends="qt5-devel"
 short_desc="A GTK Theme Built to Match KDE's Breeze"
@@ -12,3 +12,7 @@ license="LGPL-2"
 homepage="https://projects.kde.org/projects/plasma/breeze-gtk"
 distfiles="http://download.kde.org/stable/plasma/${version}/${pkgname}-${version}.tar.xz"
 checksum=7a032ba552cf2786c8cbaa8ae5aefcc60d81e1669cf53569db0abb2384e3793e
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" qt5-devel"
+fi


### PR DESCRIPTION
Closes #7762

For GTK3 versions >= 3.20 `WITH_GTK3_VERSION` needs to be set. (default is 3.18)

`BUILD_TESTING` is not used.