### PR TITLE
meson: add preliminary support for cross compilation

### DIFF
--- a/common/build-style/meson.sh
+++ b/common/build-style/meson.sh
@@ -4,6 +4,54 @@
 do_configure() {
 	: ${meson_cmd:=meson}
 	: ${meson_builddir:=build}
+	: ${meson_crossfile:=xbps_meson.cross}
+
+	if [ "$CROSS_BUILD" ]; then
+		_MESON_TARGET_ENDIAN=little
+		_MESON_TARGET_CPU=${XBPS_TARGET_MACHINE}
+		case "$XBPS_TARGET_MACHINE" in
+			mips|mips-musl)
+				_MESON_TARGET_ENDIAN=big
+				;;
+		esac
+
+		# Record cross-compiling information in cross file.
+		# CFLAGS and LDFLAGS must be set as c_args and c_link_args.
+		cat > ${meson_crossfile} <<EOF
+[binaries]
+c = '${CC}'
+cpp = '${CXX}'
+ar = '${AR}'
+ld = '${LD}'
+strip = '${STRIP}'
+readelf = '${READELF}'
+pkgconfig = 'pkg-config'
+
+[properties]
+needs_exe_wrapper = true
+c_args = ['$(echo ${CFLAGS} | sed -r "s/\s+/','/g")']
+c_link_args = ['$(echo ${LDFLAGS} | sed -r "s/\s+/','/g")']
+
+[host_machine]
+system = 'linux'
+cpu_family = '${XBPS_MACHINE}'
+cpu = '${XBPS_MACHINE}'
+endian = 'little'
+
+[target_machine]
+system = 'linux'
+cpu_family = '${_MESON_TARGET_CPU}'
+cpu = '${_MESON_TARGET_CPU}'
+endian = '${_MESON_TARGET_ENDIAN}'
+EOF
+		configure_args+=" --cross-file=${meson_crossfile}"
+
+		# Meson tries to compile natively with CC, CXX, so when cross
+		# compiling, we need to set those to the host versions.
+		export CC=${CC_host} CXX=${CXX_host}
+
+		unset _MESON_TARGET_CPU _MESON_TARGET_ENDIAN
+	fi
 
 	${meson_cmd} --prefix=/usr --buildtype=plain ${configure_args} . ${meson_builddir}
 }


### PR DESCRIPTION
This should address (or begin to address) #7656.

I've tested this with armv6, armv6l-musl, armv7l for the ncmpc and fuse-sshfs packages.