### PR TITLE
gnome-maps: add geoclue and gfbgraph to dependencies

### DIFF
--- a/srcpkgs/gnome-maps/template
+++ b/srcpkgs/gnome-maps/template
@@ -1,13 +1,13 @@
 # Template file for 'gnome-maps'
 pkgname=gnome-maps
 version=3.24.3
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool glib-devel $(vopt_if gir gobject-introspection)"
 makedepends="
  gjs-devel gnome-desktop-devel geoclue2-devel geocode-glib-devel rest-devel
  libgee08-devel folks-devel libchamplain-devel"
-depends="gjs>=1.40 desktop-file-utils"
+depends="gjs>=1.40 desktop-file-utils gfbgraph geoclue2"
 short_desc="GNOME maps application"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://live.gnome.org/Design/Apps/Maps"


### PR DESCRIPTION
without them gnome-maps is just complaining that they are missing.