### PR TITLE
clementine: unbreak armv6

### DIFF
--- a/srcpkgs/clementine/template
+++ b/srcpkgs/clementine/template
@@ -22,14 +22,10 @@ if [ -n "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt-host-tools qt-devel protobuf-c"
 fi
 
-case "$XBPS_TARGET_MACHINE" in
-	armv6*) broken="https://build.voidlinux.eu/builders/armv6l_builder/builds/5092/steps/shell_3/logs/stdio" ;;
-esac
-
 build_options="spotify"
 
 case "$XBPS_TARGET_MACHINE" in
-	x86_64 | i686 | armv6l | armv7l)
+	x86_64 | i686 | armv7l)
 		build_options_default="spotify";;
 	*)
 		build_options_default="";;


### PR DESCRIPTION
Since libspotify is already deprecated and should be useless by the end of this year, I will not bother to get the version fixed in the libspotify template.