### PR TITLE
dbus: update to 1.10.24

### DIFF
--- a/srcpkgs/dbus/template
+++ b/srcpkgs/dbus/template
@@ -1,6 +1,6 @@
 # Template file for 'dbus'
 pkgname=dbus
-version=1.10.22
+version=1.10.24
 revision=1
 build_style=gnu-configure
 configure_args="--disable-selinux --enable-inotify --with-dbus-user=dbus
@@ -13,7 +13,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://dbus.freedesktop.org/"
 distfiles="${homepage}/releases/dbus/dbus-${version}.tar.gz"
-checksum=e2b1401e3eedc7b5c9a2034d31254c886e1fcbc7858006e0a1c59158fe4b7b97
+checksum=71184eb27638e224579ffa998e88f01d0f1fef17a7811406e53350735eaecd1b
 
 hostmakedepends="pkg-config intltool gperf xmlto"
 makedepends="expat-devel libX11-devel libcap-devel"


### PR DESCRIPTION
* Minor bigfix release [Changelog](https://cgit.freedesktop.org/dbus/dbus/tree/NEWS?h=dbus-1.10)
* Compiles fine locally on x86_64{-musl} , armv7l{-musl} and aarch64{-musl}