### PR TITLE
blackbox_exporter: shorten name of system account.

### DIFF
--- a/srcpkgs/blackbox_exporter/template
+++ b/srcpkgs/blackbox_exporter/template
@@ -1,7 +1,7 @@
 # Template file for 'blackbox_exporter'
 pkgname=blackbox_exporter
 version=0.8.1
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/prometheus/blackbox_exporter"
 go_ldflags="-X ${go_import_path}/version.Version=${version}
@@ -15,7 +15,7 @@ homepage="https://prometheus.io"
 distfiles="https://github.com/prometheus/blackbox_exporter/archive/v${version}.tar.gz"
 checksum=6a9abef7575fc666c0c456f95e9d0410600e0832e679f8bed8c2069345d60d7e
 
-system_accounts="_blackbox_exporter"
+system_accounts="_bbox_exporter"
 
 post_install() {
 	vsconf example.yml


### PR DESCRIPTION
Group names may only be up to 16 chars long, so the install script fails to create the group `_blackbox_exporter`.