### PR TITLE
 libsodium: update to 1.0.15. (soname bump) 

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1705,7 +1705,7 @@ libnftnl.so.4 libnftnl-1.0.5_1
 libfcgi.so.0 fcgi-2.4.0_2
 libdshconfig.so.1 libdshconfig-0.20.13_1
 libpar2.so.1 libpar2-0.4_1
-libsodium.so.18 libsodium-1.0.7_1
+libsodium.so.23 libsodium-1.0.15_1
 libstrophe.so.0 libstrophe-0.8.6_1
 libganv-1.so.1 ganv-1.4.2_1
 libblas.so.3 blas-3.5.0_1

--- a/srcpkgs/dnscrypt-proxy/template
+++ b/srcpkgs/dnscrypt-proxy/template
@@ -1,7 +1,7 @@
 # Template file for 'dnscrypt-proxy'
 pkgname=dnscrypt-proxy
 version=1.9.5
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="libsodium-devel"
 short_desc="DNS proxy that encrypts queries"

--- a/srcpkgs/fastd/template
+++ b/srcpkgs/fastd/template
@@ -1,7 +1,7 @@
 # Template file for 'fastd'
 pkgname=fastd
 version=18
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config bison"
 makedepends="libuecc-devel libsodium-devel json-c-devel libcap-devel"

--- a/srcpkgs/fastd/template
+++ b/srcpkgs/fastd/template
@@ -11,7 +11,7 @@ license="BSD"
 homepage="https://projects.universe-factory.net/projects/fastd"
 distfiles="https://git.universe-factory.net/fastd/snapshot/fastd-${version}.tar"
 checksum=dce99ee057f43e3d732a120fb0cb60acb3b86e8231d3dd64ab72fc1254c2491a
-configure_args="ENABLE_LTO=ON"
+configure_args="ENABLE_LTO=ON -DWITH_CIPHER_AES128_CTR_NACL=OFF"
 conf_files="
  /etc/fastd/secret.conf
  /etc/fastd/fastd.conf"

--- a/srcpkgs/fwup/template
+++ b/srcpkgs/fwup/template
@@ -1,7 +1,7 @@
 # Template file for 'fwup'
 pkgname=fwup
 version=0.15.4
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="ac_vc_func_open_memstream=yes"
 hostmakedepends="automake libtool pkg-config"

--- a/srcpkgs/libsodium/template
+++ b/srcpkgs/libsodium/template
@@ -1,6 +1,6 @@
 # Template file for 'libsodium'
 pkgname=libsodium
-version=1.0.14
+version=1.0.15
 revision=1
 build_style=gnu-configure
 configure_args="lt_cv_prog_compiler_static_works=yes"
@@ -9,7 +9,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="ISC"
 homepage="https://github.com/jedisct1/libsodium"
 distfiles="https://github.com/jedisct1/libsodium/releases/download/${version}/${pkgname}-${version}.tar.gz"
-checksum=3cfc84d097fdc891b40d291f2ac2c3f99f71a87e36b20cc755c6fa0e97a77ee7
+checksum=fb6a9e879a2f674592e4328c5d9f79f082405ee4bb05cb6e679b90afe9e178f4
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/minisign/template
+++ b/srcpkgs/minisign/template
@@ -1,7 +1,7 @@
 # Template file for 'minisign'
 pkgname=minisign
 version=0.7
-revision=1
+revision=2
 build_style=cmake
 makedepends="libsodium-devel"
 short_desc="A simple tool to sign files and verify signatures"

--- a/srcpkgs/nix/template
+++ b/srcpkgs/nix/template
@@ -1,7 +1,7 @@
 # Template file for 'nix'
 pkgname=nix
 version=1.11.4
-revision=7
+revision=8
 build_style=gnu-configure
 # Use /nix/var as suggested by the official Manual.
 configure_args="--localstatedir=/nix/var"

--- a/srcpkgs/python-pynacl/template
+++ b/srcpkgs/python-pynacl/template
@@ -1,7 +1,7 @@
 # Template file for 'python-pynacl'
 pkgname=python-pynacl
 version=1.1.2
-revision=2
+revision=3
 wrksrc="PyNaCl-${version}"
 build_style=python-module
 pycompile_module="nacl"

--- a/srcpkgs/qtox/template
+++ b/srcpkgs/qtox/template
@@ -1,7 +1,7 @@
 # Template file for 'qtox'
 pkgname=qtox
 version=1.11.0
-revision=2
+revision=3
 build_style=cmake
 short_desc="QT-based TOX instant messenger client"
 maintainer="Spencer Hill <spencernh77@gmail.com>"

--- a/srcpkgs/reop/template
+++ b/srcpkgs/reop/template
@@ -1,7 +1,7 @@
 # Template file for 'reop'
 pkgname=reop
 version=2.1.0
-revision=1
+revision=2
 makedepends="libsodium-devel"
 short_desc="Create and verify cryptographic signatures"
 maintainer="Duncaen <duncaen@voidlinux.eu>"

--- a/srcpkgs/reop/template
+++ b/srcpkgs/reop/template
@@ -10,6 +10,13 @@ homepage="http://www.tedunangst.com/flak/post/reop"
 distfiles="http://www.tedunangst.com/flak/files/reop-${version}.tgz"
 checksum=e429c7ff47f130bd465eaa0c23a1783b476bc484d32793592b54a568b55e49af
 
+pre_fetch() {
+       # 301 redirect to https://www.tedunangst.com/flak/files/reop-2.1.0.tgz
+       # [...]
+       # Certificate verification failed for /C=US/ST=PA/O=tedunangst.com/CN=www.tedunangst.com/emailAddress=tedu@tedunangst.com
+       export SSL_NO_VERIFY_PEER=1
+}
+
 do_build() {
 	make -f GNUmakefile \
 		CC="$CC" CFLAGS="$CFLAGS" \

--- a/srcpkgs/toxcore/template
+++ b/srcpkgs/toxcore/template
@@ -1,7 +1,7 @@
 # Template file for 'toxcore'
 pkgname=toxcore
 version=0.1.10
-revision=1
+revision=2
 build_style=gnu-configure
 wrksrc="c-toxcore-${version}"
 hostmakedepends="autoconf automake libtool pkg-config"

--- a/srcpkgs/unbound/template
+++ b/srcpkgs/unbound/template
@@ -1,7 +1,7 @@
 # Template file for 'unbound'
 pkgname=unbound
 version=1.6.6
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-libevent --with-conf-file=/etc/unbound/unbound.conf
  --with-pidfile=/run/unbound.pid --with-ssl=${XBPS_CROSS_BASE}/usr

--- a/srcpkgs/utox/template
+++ b/srcpkgs/utox/template
@@ -1,7 +1,7 @@
 # Template file for 'utox'
 pkgname=utox
 version=0.15.0
-revision=3
+revision=4
 wrksrc="uTox-${version}"
 build_style=cmake
 configure_args="-DENABLE_ASAN=OFF"

--- a/srcpkgs/zeromq/template
+++ b/srcpkgs/zeromq/template
@@ -1,7 +1,7 @@
 # Template file for 'zeromq'
 pkgname=zeromq
 version=4.2.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-libsodium"
 hostmakedepends="pkg-config asciidoc xmlto"


### PR DESCRIPTION
broken:
- ~fastd uses removed apis (cc @Gottox)~
- ~reop can't fetch distfile. untrusted cert and http redirects to https~