### PR TITLE
SDL2: add -rpath=/opt/vc/lib on rpi archs 

### DIFF
--- a/srcpkgs/SDL2/template
+++ b/srcpkgs/SDL2/template
@@ -1,7 +1,7 @@
 # Template file for 'SDL2'
 pkgname=SDL2
 version=2.0.6
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-alsa --disable-esd --disable-rpath --enable-libudev
  --enable-clock_gettime --disable-nas --disable-arts --disable-x11-shared
@@ -35,7 +35,7 @@ if [ "$build_option_gles" ]; then
 		# RaspberryPi, use Videocore IV
 		makedepends+=" rpi-userland-devel"
 		CFLAGS="-I${XBPS_CROSS_BASE}/opt/vc/include -I${XBPS_CROSS_BASE}/opt/vc/include/interface/vcos/pthreads"
-		LDFLAGS="-L${XBPS_CROSS_BASE}/opt/vc/lib"
+		LDFLAGS="-L${XBPS_CROSS_BASE}/opt/vc/lib -Wl,-rpath=/opt/vc/lib"
 		;;
 	*)
 		# libGLESv2.so.2 is dynamically loaded with dlopen.

--- a/srcpkgs/logstalgia/template
+++ b/srcpkgs/logstalgia/template
@@ -12,11 +12,3 @@ license="GPL-3"
 homepage="https://github.com/acaudwell/Logstalgia/"
 distfiles="$homepage/releases/download/$pkgname-$version/$pkgname-$version.tar.gz"
 checksum=8b66ec1f98c2d6616846aaa693127f9478ddce19e779a224780b0eb1f19819aa
-
-case "$XBPS_TARGET_MACHINE" in
-	armv[67]*)
-		# configure: error: SDL2_image with PNG support required.
-		broken="https://build.voidlinux.eu/builders/armv7l_builder/builds/5100/steps/shell_3/logs/stdio"
-	;;
-esac
-

--- a/srcpkgs/mgba/template
+++ b/srcpkgs/mgba/template
@@ -14,11 +14,6 @@ homepage="https://www.mgba.io/"
 distfiles="https://github.com/mgba-emu/${pkgname}/archive/${version}.tar.gz"
 checksum=7c78feb0aa12930b993ca1b220d282ed178e306621559e48bb168623030eb876
 
-case "$XBPS_TARGET_MACHINE" in
-	# SDL2/libbcm_host.so
-	armv[67]*) broken="https://build.voidlinux.eu/builders/armv6l_builder/builds/5249/steps/shell_3/logs/stdio";;
-esac
-
 subpackages="libmgba"
 if [ -z "$CROSS_BUILD" ]; then
 	makedepends+=" qt5-multimedia-devel"

--- a/srcpkgs/qtox/template
+++ b/srcpkgs/qtox/template
@@ -7,7 +7,7 @@ short_desc="QT-based TOX instant messenger client"
 maintainer="Spencer Hill <spencernh77@gmail.com>"
 license="GPL-3"
 homepage="https://wiki.tox.chat/clients/qtox"
-hostmakedepends="qt5-qmake pkg-config"
+hostmakedepends="qt5-qmake qt5-host-tools qt5-tools pkg-config"
 makedepends="toxcore-devel filter_audio-devel ffmpeg-devel qt5-svg-devel
  qt5-tools-devel libopencv-devel libopenal-devel libsodium-devel
  libXScrnSaver-devel gdk-pixbuf-devel gtk+-devel libvpx-devel qrencode-devel
@@ -17,5 +17,3 @@ depends="qt5-plugin-sqlite"
 distfiles="https://github.com/tux3/qTox/archive/v${version}.tar.gz"
 checksum=be38517cd915727dbd9b3cd2a51bbaf1cae28290de07a34c759ec8b77c502cd4
 wrksrc="qTox-${version}"
-
-nocross="https://build.voidlinux.eu/builders/armv6l_builder/builds/5203/steps/shell_3/logs/stdio"


### PR DESCRIPTION
Linking against SDL2 currently fails on armv[67] because ld apparently can't find libbcm-host.so. 

Better solutions?