### PR TITLE
Build glibc with --enable-obsolete-nsl for the cross-* packages

### DIFF
--- a/srcpkgs/cross-aarch64-linux-gnu/template
+++ b/srcpkgs/cross-aarch64-linux-gnu/template
@@ -11,7 +11,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.24
-revision=1
+revision=2
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
 homepage="http://www.voidlinux.eu"
@@ -156,6 +156,7 @@ _glibc_headers() {
 	_args+=" --with-headers=${_sysroot}/usr/include"
 	_args+=" --config-cache"
 	_args+=" --enable-obsolete-rpc"
+	_args+=" --enable-obsolete-nsl"
 	_args+=" --enable-kernel=2.6.27"
 
 	../glibc-${_glibc_version}/configure ${_args}
@@ -191,6 +192,7 @@ _glibc_build() {
 	_args+=" --with-headers=${_sysroot}/usr/include"
 	_args+=" --config-cache"
 	_args+=" --enable-obsolete-rpc"
+	_args+=" --enable-obsolete-nsl"
 	_args+=" --disable-profile"
 	_args+=" --enable-kernel=2.6.27"
 

--- a/srcpkgs/cross-arm-linux-gnueabi/template
+++ b/srcpkgs/cross-arm-linux-gnueabi/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.24
-revision=1
+revision=2
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -160,6 +160,7 @@ _glibc_headers() {
 	_args+=" --with-headers=${_sysroot}/usr/include"
 	_args+=" --config-cache"
 	_args+=" --enable-obsolete-rpc"
+	_args+=" --enable-obsolete-nsl"
 	_args+=" --enable-kernel=2.6.27"
 	_args+=" ${_fpuflags}"
 
@@ -195,6 +196,7 @@ _glibc_build() {
 	_args+=" --config-cache"
 	_args+=" --disable-profile"
 	_args+=" --enable-obsolete-rpc"
+	_args+=" --enable-obsolete-nsl"
 	_args+=" --disable-werror"
 	_args+=" --enable-kernel=2.6.27"
 	_args+=" ${_fpuflags}"

--- a/srcpkgs/cross-arm-linux-gnueabihf/template
+++ b/srcpkgs/cross-arm-linux-gnueabihf/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.24
-revision=1
+revision=2
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -161,6 +161,7 @@ _glibc_headers() {
 	_args+=" --with-headers=${_sysroot}/usr/include"
 	_args+=" --config-cache"
 	_args+=" --enable-obsolete-rpc"
+	_args+=" --enable-obsolete-nsl"
 	_args+=" --enable-kernel=2.6.27"
 	_args+=" ${_fpuflags}"
 
@@ -196,6 +197,7 @@ _glibc_build() {
 	_args+=" --config-cache"
 	_args+=" --disable-profile"
 	_args+=" --enable-obsolete-rpc"
+	_args+=" --enable-obsolete-nsl"
 	_args+=" --disable-werror"
 	_args+=" --enable-kernel=2.6.27"
 	_args+=" ${_fpuflags}"

--- a/srcpkgs/cross-armv7l-linux-gnueabihf/template
+++ b/srcpkgs/cross-armv7l-linux-gnueabihf/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.24
-revision=1
+revision=2
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -161,6 +161,7 @@ _glibc_headers() {
 	_args+=" --with-headers=${_sysroot}/usr/include"
 	_args+=" --config-cache"
 	_args+=" --enable-obsolete-rpc"
+	_args+=" --enable-obsolete-nsl"
 	_args+=" --enable-kernel=2.6.27"
 	_args+=" ${_fpuflags}"
 
@@ -196,6 +197,7 @@ _glibc_build() {
 	_args+=" --config-cache"
 	_args+=" --disable-profile"
 	_args+=" --enable-obsolete-rpc"
+	_args+=" --enable-obsolete-nsl"
 	_args+=" --disable-werror"
 	_args+=" --enable-kernel=2.6.27"
 	_args+=" ${_fpuflags}"

--- a/srcpkgs/cross-i686-pc-linux-gnu/template
+++ b/srcpkgs/cross-i686-pc-linux-gnu/template
@@ -11,7 +11,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.24
-revision=1
+revision=2
 short_desc="GNU Cross toolchain for the ${_triplet} target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.voidlinux.eu"
@@ -161,6 +161,7 @@ _glibc_headers() {
 	_args+=" --with-headers=${_sysroot}/usr/include"
 	_args+=" --config-cache"
 	_args+=" --enable-obsolete-rpc"
+	_args+=" --enable-obsolete-nsl"
 	_args+=" --enable-kernel=2.6.27"
 	_args+=" ${_fpuflags}"
 
@@ -194,6 +195,7 @@ _glibc_build() {
 	_args+=" --with-headers=${_sysroot}/usr/include"
 	_args+=" --config-cache"
 	_args+=" --enable-obsolete-rpc"
+	_args+=" --enable-obsolete-nsl"
 	_args+=" --enable-kernel=2.6.27"
 	_args+=" ${_fpuflags}"
 


### PR DESCRIPTION
follow-up to #7928 regarding #7846