### PR TITLE
Gnome core: update to 3.26.1

### DIFF
--- a/srcpkgs/gnome-desktop/template
+++ b/srcpkgs/gnome-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-desktop'
 pkgname=gnome-desktop
-version=3.26.0
+version=3.26.1
 revision=1
 build_style=gnu-configure
 configure_args="--with-gnome-distributor=VoidLinux"
@@ -13,7 +13,7 @@ maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="GPL-2, LGPL-2.1"
 homepage="http://www.gnome.org"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=8a99a084ea06fba20f5c547822dd8e36758676714729c7ae7b44ae3deca57be2
+checksum=92fa697af986fb2c6bc6595f0155c968c17e5d1981a50584ff4fb6fd60124e2f
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/gnome-session/template
+++ b/srcpkgs/gnome-session/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-session'
 pkgname=gnome-session
-version=3.26.0
+version=3.26.1
 revision=1
 build_style=gnu-configure
 configure_args="--disable-schemas-compile"
@@ -15,7 +15,7 @@ maintainer="Enno Boland <gottox@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2, LGPL-2.1"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=6f8254b4891f76852b65a7c164dc504dfeff1aa32092e1b262bb670efedac489
+checksum=d9414b368db982d3837ca106e64019f18e6cdd5b13965bea6c7d02ddf5103708
 
 pre_configure() {
 	sed -i "s/^#ifdef HAVE_SYSTEMD/#if 0/" \

--- a/srcpkgs/gnome-settings-daemon/template
+++ b/srcpkgs/gnome-settings-daemon/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-settings-daemon'
 pkgname=gnome-settings-daemon
-version=3.26.0
+version=3.26.1
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --disable-schemas-compile --enable-cups"
@@ -18,7 +18,7 @@ maintainer="Enno Boland <gottox@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-3"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=0e4c0ce3ac14262be022c3c33ebab794d7bd6a36b0246084be452b1ec540dc05
+checksum=711ac9bad06f6a4225f5eb2f4796474662f81f7077e16a4b7ee7ab974b65d893
 
 pre_configure() {
 	# XXX workaround wrong paths for build

--- a/srcpkgs/gnome-shell-extensions/template
+++ b/srcpkgs/gnome-shell-extensions/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-shell-extensions'
 pkgname=gnome-shell-extensions
-version=3.26.0
+version=3.26.1
 revision=1
 noarch="yes"
 build_style=gnu-configure
@@ -13,4 +13,4 @@ maintainer="Enno Boland <gottox@voidlinux.eu>"
 homepage="https://wiki.gnome.org/Projects/GnomeShell/Extensions"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=f51b59b4ae192d7480229657cab2354bee24d40857384a0fde72d0af2635f704
+checksum=2437c6abce399a97ff95c2de9784580a5db82c59b67e09eaf2c8d972cca1d6d0

--- a/srcpkgs/gnome-shell/template
+++ b/srcpkgs/gnome-shell/template
@@ -1,9 +1,9 @@
 # Template file for 'gnome-shell'
 pkgname=gnome-shell
-version=3.26.0
+version=3.26.1
 revision=1
-build_style=gnu-configure
-configure_args="--disable-schemas-compile --disable-systemd"
+build_style=meson
+configure_args="-Denable-systemd=no"
 hostmakedepends="
  pkg-config intltool gnome-doc-utils $(vopt_if gir gobject-introspection) python3
  meson"
@@ -22,7 +22,7 @@ maintainer="Enno Boland <gottox@voidlinux.eu>"
 homepage="https://wiki.gnome.org/Projects/GnomeShell"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=9bc35c206435d6e0ee9e8880578716a7d5bd0ebe7d475fa4f0b3010b44eebaed
+checksum=38d98da06eb0118a0226623494b11765b3981414e804e270dc0cf03e37c708b9
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/mutter/template
+++ b/srcpkgs/mutter/template
@@ -1,6 +1,6 @@
 # Template file for 'mutter'
 pkgname=mutter
-version=3.26.0
+version=3.26.1
 revision=1
 build_style=gnu-configure
 configure_args="--disable-schemas-compile --disable-static --enable-egl-device"
@@ -14,7 +14,7 @@ maintainer="Enno Boland <gottox@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=2a62933a11632830c430570b0f8d762fd9f76a2eb955d54cc14f73274d06e577
+checksum=16faf617aae9be06dc5f9e104f4cd20dfdd4d6ec0bc10053752262e9f79a04c2
 shlib_provides="libmutter-clutter-1.so libmutter-cogl-path-1.so libmutter-cogl-1.so libmutter-cogl-pango-1.so"
 nocross="https://build.voidlinux.eu/builders/armv7l_builder/builds/1295/steps/shell_3/logs/stdio"
 CFLAGS+=' -Wno-error=sign-compare -Wno-error=format'


### PR DESCRIPTION
* This PR bumps the core gnome libs to `3.26.1` as updating them one at a time can cause issues in some cases