### PR TITLE
gnote: update to 3.26.0.

### DIFF
--- a/srcpkgs/gnote/template
+++ b/srcpkgs/gnote/template
@@ -1,6 +1,6 @@
 # Template file for 'gnote'
 pkgname=gnote
-version=3.24.1
+version=3.26.0
 revision=1
 lib32disabled=yes
 build_style=gnu-configure
@@ -13,4 +13,4 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-3"
 homepage="http://live.gnome.org/Gnote"
 distfiles="${GNOME_SITE}/gnote/${version%.*}/gnote-${version}.tar.xz"
-checksum=1da5887c6d4221de292bd9fd310525bd05d60b9483bb1596e0cfb41f39995a7f
+checksum=de205ace226a010aba576654db6a8e06eab064522549d3bdd6eb8a0bc9163be9


### PR DESCRIPTION
Testing has shown that trying to use a custom font causes segfault ( also applies to 3.24.1 )

```
(gnote:7739): Gtk-CRITICAL **: file gtkcssenumvalue.c: line 528 (_gtk_css_font_weight_value_new): should not be reached
fish: “gnote” terminated by signal SIGSEGV (Address boundary error)
```

but i don't have the full gnome stack installed and running.