### PR TITLE
gcompat: update Web URL and source URL

### DIFF
--- a/srcpkgs/gcompat/template
+++ b/srcpkgs/gcompat/template
@@ -1,18 +1,15 @@
 # Template file for 'gcompat'
 pkgname=gcompat
-version=0.0.1
+version=0.1.0
 revision=1
-wrksrc="${pkgname}-${pkgname}-${version}"
+wrksrc="${pkgname}-${version}"
 build_style="gnu-makefile"
 short_desc="Compatibility layer to allow running glibc binaries on musl systems"
 maintainer="Daniel James <djames@orcadian.net>"
-homepage="https://github.com/AdelieLinux/gcompat"
+homepage="https://code.foxkit.us/adelie/gcompat"
 license="ISC"
-distfiles="https://github.com/AdelieLinux/${pkgname}/archive/${pkgname}-${version}.tar.gz
- https://raw.githubusercontent.com/AdelieLinux/${pkgname}/master/LICENSE"
-checksum="138f4094977268a762415da10c05bcf87fae948faa8ff13a9b8b4ff4d64c91e6
- 9edc99844a4c06b75f200fb96a72af4b8cc2da4c6662b8610157c24d428fa5c4"
-skip_extraction="LICENSE"
+distfiles="https://distfiles.AdelieLinux.org/source/${pkgname}-${version}.tar.xz"
+checksum="3093397f69dfee45b60e3b7ea02b26b625bfb57f9c1dbb5d6ceadda6f823578b"
 
 # https://sourceware.org/glibc/wiki/ABIList
 # https://wiki.linaro.org/RikuVoipio/LdSoTable
@@ -40,8 +37,4 @@ make_install_args="LINKER_PATH=/usr/lib/${_musl} LOADER_NAME=${_glibc}
 
 pre_build() {
 	sed -i 's/gcc/$(CC)/g' Makefile
-}
-
-post_install() {
-	vlicense ${XBPS_SRCDISTDIR}/${pkgname}-${version}/LICENSE
 }


### PR DESCRIPTION
* 0.1.0 is released
* Do not use GitHub as it is not the authoritative Web URL for gcompat
* Official tarballs are on distfiles.adelielinux.org
* LICENSE is included in the tarball now