### PR TITLE
avrdude: enable cross

### DIFF
--- a/srcpkgs/avrdude/template
+++ b/srcpkgs/avrdude/template
@@ -1,7 +1,7 @@
 # Template file for 'avrdude'
 pkgname="avrdude"
 version=6.3
-revision=1
+revision=2
 build_style=gnu-configure
 short_desc="An utility to manipulate ROM and EEPROM of AVR microcontrollers"
 maintainer="allan <mail@may.mooo.com>"
@@ -9,7 +9,6 @@ license="GPL-2"
 homepage="http://www.nongnu.org/avrdude/"
 distfiles="$NONGNU_SITE/$pkgname/${pkgname}-$version.tar.gz"
 checksum=0f9f731b6394ca7795b88359689a7fa1fba818c6e1d962513eb28da670e0a196
-only_for_archs="i686 x86_64"
 hostmakedepends="flex"
 makedepends="elfutils-devel libusb-compat-devel"
 depends="avr-libc"


### PR DESCRIPTION
I found that avrdude compiles without patches on alpine.
Testing: I build avrdude for x86_64-musl, installed it and made it initate communication with an AVR device.