### PR TITLE
eog: update to 3.26.1.

### DIFF
--- a/srcpkgs/eog/patches/fix-markdown-itstool.patch
+++ b/srcpkgs/eog/patches/fix-markdown-itstool.patch
@@ -1,0 +1,50 @@
+--- help/lv/lv.po
++++ help/lv/lv.po
+@@ -1807,7 +1807,7 @@ msgid ""
+ "check <gui>Slideshow Shuffle</gui> and close the dialog."
+ msgstr ""
+ "Lai to izdarītu, atveriet lietotnes izvēlni augšējā joslā, spiediet uz <gui"
+-" style=\"menuitem\">Iestatījumi, ejiet uz cilni <gui>Spraudņi</gui> un"
++" style=\"menuitem\">Iestatījumi</gui>, ejiet uz cilni <gui>Spraudņi</gui> un"
+ " atzīmējiet <gui>Slīdrādes maisītājs</gui> un aizveriet dialoglodziņu."
+ 
+ #. (itstool) path: info/desc
+--- help/es/es.po
++++ help/es/es.po
+@@ -631,7 +631,7 @@ msgid ""
+ "\"menuitem\">Save</gui>."
+ msgstr ""
+ "Si quiere mantener la imagen volteada así, pulse <gui style=\"menuitem"
+-"\"><gui>Guardar</gui>."
++"\">Guardar</gui>."
+ 
+ #. (itstool) path: item/p
+ #: C/flip-rotate.page:33 C/flip-rotate.page:46
+@@ -742,7 +742,7 @@ msgid ""
+ "Click <gui style=\"menuitem\">Save As…</gui>. The <gui>Save Image</gui> "
+ "window will pop up."
+ msgstr ""
+-"Pulse <gui style=\"menuitem\"><gui>Guardar como</gui>. Se mostrará la "
++"Pulse <gui style=\"menuitem\">Guardar como</gui>. Se mostrará la "
+ "ventana emergente <gui>Guardar imagen</gui>."
+ 
+ #. (itstool) path: item/p
+@@ -1370,7 +1370,7 @@ msgid ""
+ "\"menuitem\">Preferences</gui> and go to the <gui>Plugins</gui> tab. Then, "
+ "check <gui>Date in statusbar</gui>."
+ msgstr ""
+-"Para ello, pulse <gui style=\"menuitem\"><gui>Preferencias</gui> y vaya a la "
++"Para ello, pulse <gui style=\"menuitem\">Preferencias</gui> y vaya a la "
+ "pestaña <gui>Complementos</gui>. Después, marque <gui>Fecha en la barra de "
+ "estado</gui>."
+ 
+@@ -2888,7 +2888,7 @@ msgstr "<link xref=\"open\">Abra</link> una de las imágenes de la carpeta."
+ #| "<key>F5</key>."
+ msgid "Click <gui style=\"menuitem\">Slideshow</gui> or press <key>F5</key>."
+ msgstr ""
+-"Pulse <gui style=\"menuitem\"><gui>Diapositivas</gui> o pulse <key>F5</key>."
++"Pulse <gui style=\"menuitem\">Diapositivas</gui> o pulse <key>F5</key>."
+ 
+ #. (itstool) path: item/p
+ #: C/slideshow.page:33
+

--- a/srcpkgs/eog/template
+++ b/srcpkgs/eog/template
@@ -1,6 +1,6 @@
 # Template file for 'eog'
 pkgname=eog
-version=3.26.0
+version=3.26.1
 revision=1
 lib32disabled=yes
 build_style=gnu-configure
@@ -17,7 +17,7 @@ maintainer="Enno Boland <gottox@voidlinux.eu>"
 homepage="http://www.gnome.org"
 license="GPL-2"
 distfiles="${GNOME_SITE}/eog/${version%.*}/eog-$version.tar.xz"
-checksum=e0e16210dfc5cd34327fff2874d8c54d64eb4ab9ad903d4f8218b10d77126095
+checksum=98dbeb535bc55a818ce544267ee50202a7b2fb971c8ae5965799445543febc88
 
 if [ -z "$CROSS_BUILD" ]; then
 	build_options_default="gir"


### PR DESCRIPTION
resolves #8238

the fix is a combination of the following commits https://github.com/GNOME/eog/commit/382503eff951270eaa833245b7ac4bf551e52d79 https://github.com/GNOME/eog/commit/8ac2e6bf805c5accf88495f14fa903cbb904dc86 they were added after the 3.26.1 bump, when 3.26.2 comes the patch should be removed

Tested only on x86_64