### PR TITLE
perl-X11-Protocol-Other: update to 30.

### DIFF
--- a/srcpkgs/perl-X11-Protocol-Other/template
+++ b/srcpkgs/perl-X11-Protocol-Other/template
@@ -1,10 +1,11 @@
 # Template build file for 'perl-X11-Protocol-Other'.
 pkgname=perl-X11-Protocol-Other
-version=29
+version=30
 revision=1
 wrksrc="${pkgname#*-}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
+makedepends="perl"
 depends="perl perl-X11-Protocol"
 noarch=yes
 short_desc='Miscellaneous extras and helpers for X11::Protocol'
@@ -12,4 +13,4 @@ maintainer="Enguerrand de Rochefort <voidlinux@rochefort.de>"
 homepage="https://metacpan.org/pod/X11::Protocol::Other"
 license="GPL-3"
 distfiles="$CPAN_SITE/X11/X11-Protocol-Other-${version}.tar.gz"
-checksum=04e96a3f068eca498b7e91fe0abe24173b4152c91b556e21d84d4a802cffbd5f
+checksum=323fe7736e20480a8b0940ab5695c6c028709cf088061eb9407236764a5c55d5

--- a/srcpkgs/perl-X11-Protocol/template
+++ b/srcpkgs/perl-X11-Protocol/template
@@ -5,6 +5,7 @@ revision=1
 wrksrc="${pkgname#*-}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
+makedepends="perl"
 depends="perl"
 noarch=yes
 short_desc='X11::Protocol - Rough equivalent of Xlib'


### PR DESCRIPTION
Fixes cross-compilation issues by adding `perl` to `makedepends`

This also includes a commit that adds the same thing to perl-X11-Protocol so it can be cross-compiled too.