### PR TITLE
gtkglextmm: fix cross compilation

### DIFF
--- a/srcpkgs/gtkglextmm/template
+++ b/srcpkgs/gtkglextmm/template
@@ -1,7 +1,7 @@
 # Template file for 'gtkglextmm'
 pkgname=gtkglextmm
 version=1.2.0
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="gtkglext-devel gtkmm2-devel pangomm-devel"
@@ -11,7 +11,6 @@ license="LGPL-2.1"
 homepage="https://projects.gnome.org/gtkglext/"
 distfiles="${SOURCEFORGE_SITE}/gtkglext/${pkgname}-${version}.tar.bz2"
 checksum=6cd4bd2a240e5eb1e3a24c5a3ebbf7ed905b522b888439778043fdeb58771fea
-nocross=yes
 
 gtkglextmm-devel_package() {
 	depends="${makedepends} ${sourcepkg}-${version}_${revision}"


### PR DESCRIPTION
Just removed `nocross`. The package seems to build fine now.