### PR TITLE
firefox, thunderbird, icecat: fix build

### DIFF
--- a/srcpkgs/firefox/template
+++ b/srcpkgs/firefox/template
@@ -10,7 +10,6 @@ distfiles="${MOZILLA_SITE}/${pkgname}/releases/${version}/source/${pkgname}-${ve
 checksum=6f7d284c31383a9860d7b52f05f866526d5a7c31e3ef2959d79122ba074f5ca1
 
 only_for_archs="i686 i686-musl x86_64 x86_64-musl"
-nopie=yes
 lib32disabled=yes
 
 hostmakedepends="autoconf213 unzip zip pkg-config perl python yasm rust cargo

--- a/srcpkgs/icecat/template
+++ b/srcpkgs/icecat/template
@@ -10,7 +10,6 @@ distfiles="${GNU_SITE}/${pkgname}/${version}/${pkgname}-${version}-gnu1.tar.bz2"
 checksum=699ab2b41d4428ef5e360f3f33d98bc52723315cedac20bb03619846ca895302
 
 only_for_archs="i686 i686-musl x86_64 x86_64-musl"
-nopie=yes
 lib32disabled=yes
 
 hostmakedepends="autoconf213 unzip zip pkg-config perl python yasm rust cargo"

--- a/srcpkgs/thunderbird/template
+++ b/srcpkgs/thunderbird/template
@@ -10,7 +10,6 @@ distfiles="${MOZILLA_SITE}/${pkgname}/releases/${version}/source/${pkgname}-${ve
 checksum=7f57b5b4d4ec42b04afcff8327abc2d3c6185c0bcc1ad138825d021a2d3f578c
 
 only_for_archs="i686 i686-musl x86_64 x86_64-musl"
-nopie=yes
 lib32disabled=yes
 
 hostmakedepends="autoconf213 unzip zip pkg-config perl python yasm


### PR DESCRIPTION
All fail with:
```
/builddir/firefox-56.0.2/obj-x86_64-unknown-linux-gnu/_virtualenv/bin/python /builddir/firefox-56.0.2/config/expandlibs_exec.py -- /usr/lib/ccache/bin/cc -std=gnu99 -o nsinstall_real -DXP_UNIX -MD -MP -MF .deps/nsinstall_real.pp -fno-PIE -mtune=generic -O2 -pipe -fno-delete-null-pointer-checks -fno-lifetime-dse -fno-schedule-insns2  -DNDEBUG=1 -DTRIMMED=1 -D_UNICODE -DUNICODE   host_nsinstall.o host_pathsub.o                                        
Executing: /usr/lib/ccache/bin/cc -std=gnu99 -o nsinstall_real -DXP_UNIX -MD -MP -MF .deps/nsinstall_real.pp -fno-PIE -mtune=generic -O2 -pipe -fno-delete-null-pointer-checks -fno-lifetime-dse -fno-schedule-insns2 -DNDEBUG=1 -DTRIMMED=1 -D_UNICODE -DUNICODE host_nsinstall.o host_pathsub.o                                                  
/usr/bin/ld: host_nsinstall.o: relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC                                                                                  
/usr/bin/ld: host_pathsub.o: relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC                                                                                    
/usr/bin/ld: final link failed: Nonrepresentable section on output                                               
collect2: error: ld returned 1 exit status  
```