### PR TITLE
xbps-src: make it easier to run the check stage

### DIFF
--- a/common/xbps-src/shutils/chroot.sh
+++ b/common/xbps-src/shutils/chroot.sh
@@ -198,7 +198,7 @@ chroot_handler() {
         [ -n "$XBPS_BUILD_FORCEMODE" ] && arg="$arg -f"
         [ -n "$XBPS_MAKEJOBS" ] && arg="$arg -j$XBPS_MAKEJOBS"
         [ -n "$XBPS_DEBUG_PKGS" ] && arg="$arg -g"
-        [ -z "$XBPS_CHECK_PKGS" -o "$XBPS_CHECK_PKGS" = "0" -o "$XBPS_CHECK_PKGS" = "no" ] && arg="$arg -Q"
+        [ -z "$XBPS_CHECK_PKGS" -o "$XBPS_CHECK_PKGS" = "0" -o "$XBPS_CHECK_PKGS" = "no" ] || arg="$arg -Q"
         [ -n "$XBPS_BUILD_ONLY_ONE_PKG" -a "$XBPS_BUILD_ONLY_ONE_PKG" != "0" -a "$XBPS_BUILD_ONLY_ONE_PKG" != "no" ] && arg="$arg -1"
         [ -n "$XBPS_QUIET" ] && arg="$arg -q"
         [ -n "$XBPS_SKIP_DEPS" ] && arg="$arg -I"

--- a/xbps-src
+++ b/xbps-src
@@ -146,6 +146,8 @@ $(print_cross_targets)
 
 -G  Enable XBPS_USE_GIT_REVS (see etc/defaults.conf for more information).
 
+-Q  Enable running the check stage.
+
 -g  Enable building -dbg packages with debugging symbols.
 
 -H  <hostdir>
@@ -438,7 +440,7 @@ while getopts "$XBPS_OPTSTRING" opt; do
         N) readonly XBPS_SKIP_REMOTEREPOS=1; XBPS_OPTIONS+=" -N";;
         o) readonly XBPS_PKG_OPTIONS="$OPTARG"; XBPS_OPTIONS+=" -o $OPTARG";;
         q) export XBPS_QUIET=1; XBPS_OPTIONS+=" -q";;
-        Q) export XBPS_CHECK_PKGS=0; XBPS_OPTIONS+=" -Q";;
+        Q) export XBPS_CHECK_PKGS=1; XBPS_OPTIONS+=" -Q";;
         r) readonly XBPS_ALT_REPOSITORY="$OPTARG"; XBPS_OPTIONS+=" -r $OPTARG";;
         t) export XBPS_TEMP_MASTERDIR=1; XBPS_OPTIONS+=" -t -C";;
         V) echo $XBPS_SRC_VERSION && exit 0;;

--- a/xbps-src
+++ b/xbps-src
@@ -707,6 +707,9 @@ case "$XBPS_TARGET" in
         fi
         ;;
     fetch|extract|build|check|configure|install|pkg)
+        if [ "$XBPS_TARGET" = "check" ]; then
+            export XBPS_CHECK_PKGS=1
+        fi
         read_pkg
         if [ -n "$CHROOT_READY" -a -z "$IN_CHROOT" ]; then
             chroot_handler $XBPS_TARGET $XBPS_TARGET_PKG


### PR DESCRIPTION
Since the default is to not run checks, having '-Q' enable running checks seems more useful. This allows to
build with checks enabled via `./xbps-src -Q pkg ...`  in the default config.

The second commit always enables XBPS_CHECK_PKGS if the check target is given on the commandline.