### PR TITLE
syncthing-gtk: add python-gobject to depends

### DIFF
--- a/srcpkgs/syncthing-gtk/template
+++ b/srcpkgs/syncthing-gtk/template
@@ -1,12 +1,12 @@
 # Template file for 'syncthing-gtk'
 pkgname=syncthing-gtk
 version=0.9.2.6
-revision=1
+revision=2
 short_desc="GTK3 and python based GUI for Syncthing"
 maintainer="maxice8 <thinkabit.ukim@gmail.com>"
 build_style=python2-module
 hostmakedepends="python-setuptools"
-depends="syncthing python-dateutil libnotify librsvg python-bcrypt python-cairo gtk+3"
+depends="syncthing python-dateutil libnotify librsvg python-bcrypt python-cairo gtk+3 python-gobject"
 license="GPL-2"
 homepage="https://github.com/syncthing/syncthing-gtk"
 distfiles="https://github.com/syncthing/syncthing-gtk/archive/v${version}.tar.gz"


### PR DESCRIPTION
Without python-gobject, syncthing-gtk fails with:

```
Traceback (most recent call last):
  File "/usr/bin/syncthing-gtk", line 2, in <module>
    import sys, os, signal, gi
ImportError: No module named gi
```