### PR TITLE
New package: evtest-1.33_1

### DIFF
--- a/srcpkgs/evtest/template
+++ b/srcpkgs/evtest/template
@@ -1,0 +1,16 @@
+# Template file for 'evtest'
+pkgname=evtest
+version=1.33
+revision=1
+short_desc="Command line tool for displaying device input information"
+maintainer="sen <ethan.k.shackelford@gmail.com>"
+license="GPL-2"
+build_style=gnu-configure
+homepage="https://cgit.freedesktop.org/evtest/"
+distfiles="https://cgit.freedesktop.org/evtest/snapshot/evtest-${version}.tar.xz"
+hostmakedepends="autoconf automake"
+checksum=928f6e81c73bd71ce88be03f7fdad204087a04dccd0250462106af0c2d813532
+
+pre_configure() {
+	./autogen.sh --host "$XBPS_TARGET_MACHINE"
+}


### PR DESCRIPTION
evtest displays information on the input device specified on the command line, including all the events supported by the device. It then monitors the device and displays all the events layer events generated.