### PR TITLE
udevadm hwdb trigger

### DIFF
--- a/common/hooks/post-install/04-create-xbps-metadata-scripts.sh
+++ b/common/hooks/post-install/04-create-xbps-metadata-scripts.sh
@@ -144,6 +144,12 @@ _EOF
 		fi
         fi
 	#
+	# Handle files in hwdb directory
+	#
+	if [ -d "${PKGDESTDIR}/usr/lib/udev/hwdb.d" ]; then
+		_add_trigger hwdb.d-dir
+    fi
+	#
 	# (Un)Register a shell in /etc/shells.
 	#
 	if [ -n "${register_shell}" ]; then

--- a/srcpkgs/xbps-triggers/files/hwdb.d-dir
+++ b/srcpkgs/xbps-triggers/files/hwdb.d-dir
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# Updates hardware database 
+#
+# Arguments:	$ACTION = [run/targets]
+#		$TARGET = [post-install/pre-remove]
+#		$PKGNAME
+#		$VERSION
+#		$UPDATE = [yes/no]
+#
+ACTION="$1"
+TARGET="$2"
+PKGNAME="$3"
+VERSION="$4"
+UPDATE="$5"
+
+case "$ACTION" in
+targets)
+	echo "post-install pre-remove"
+	;;
+run)
+    usr/bin/udevadm hwdb --update
+	;;
+*)
+	exit 1
+	;;
+esac
+
+exit 0

--- a/srcpkgs/xbps-triggers/files/hwdb.d-dir
+++ b/srcpkgs/xbps-triggers/files/hwdb.d-dir
@@ -19,7 +19,7 @@ targets)
 	echo "post-install pre-remove"
 	;;
 run)
-    usr/bin/udevadm hwdb --update
+    usr/bin/udevadm hwdb --root=. --update
 	;;
 *)
 	exit 1


### PR DESCRIPTION
This xbps trigger runs `udevadm hwdb --root=. --update` whenever a file in `/usr/lib/udev/hwdb.d` is updated. This is required to update the hardware database since that action is not automatic when files are added. See `man 8 udevadm` for more information. cf. #9834 