### PR TITLE
wrk: fix CFLAGS and LDFLAGS

### DIFF
--- a/srcpkgs/wrk/template
+++ b/srcpkgs/wrk/template
@@ -1,7 +1,7 @@
 # Template file for 'wrk'
 pkgname=wrk
 version=4.0.2
-revision=1
+revision=2
 build_style=gnu-makefile
 make_build_args="VER=${version} WITH_OPENSSL=/usr WITH_LUAJIT=/usr"
 hostmakedepends="LuaJIT"
@@ -30,6 +30,9 @@ pre_build() {
 			luajit -b -a x86 src/wrk.lua obj/bytecode.o
 			;;
 	esac
+	# Borrow flags from Makefile
+	CFLAGS="-std=c99 -Wall -D_REENTRANT -D_POSIX_C_SOURCE=200112L -D_BSD_SOURCE -D_DEFAULT_SOURCE ${CFLAGS}"
+	LDFLAGS="-Wl,-E ${LDFLAGS}"
 }
 
 do_install() {


### PR DESCRIPTION
The build for 4.0.2_1 was missing a handful of CFLAGS and LDFLAGS
necessary to correctly build and link wrk. This fixes that by simply
setting both in prebuild, borrowing their values from wrk's Makefile.
This is necessary since wrk's Makefile doesn't handle changes to CFLAGS
or LDFLAGS well (since the gnu-makefile build style passes these, and
hardening sets some flags, wrk's Makefile used only those in 4.0.2_1).