### PR TITLE
freetype: downgrade to 2.8, fixes fonts in electron apps

### DIFF
--- a/srcpkgs/freetype/template
+++ b/srcpkgs/freetype/template
@@ -1,7 +1,8 @@
 # Template build file 'freetype'.
 pkgname=freetype
-version=2.8.1
+version=2.8
 revision=1
+reverts="2.8.1_1"
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="zlib-devel bzip2-devel libpng-devel"
@@ -10,7 +11,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.freetype.org/"
 license="GPL-2"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.tar.bz2"
-checksum=e5435f02e02d2b87bb8e4efdcaa14b1f78c9cf3ab1ed80f94b6382fb6acc7d78
+checksum=a3c603ed84c3c2495f9c9331fe6bba3bb0ee65e06ec331e0a0fb52158291b40b
 
 build_options="v35 v38 v40"
 build_options_default="v40"


### PR DESCRIPTION
Freetype 2.8.1 causes artifacting on electron apps, reverting the package until this is fixed in electron or a newer freetype version. Here's the tracking issue for the problem https://github.com/electron/libchromiumcontent/issues/384