### PR TITLE
khard: update to 0.12.0.

### DIFF
--- a/srcpkgs/khard/template
+++ b/srcpkgs/khard/template
@@ -1,19 +1,19 @@
 # Template file for 'khard'
 pkgname=khard
-version=0.11.4
-revision=2
+version=0.12.1
+revision=1
 noarch=yes
 build_style=python3-module
 pycompile_module="khard"
 hostmakedepends="python3-setuptools"
 depends="python3-setuptools python3-atomicwrites python3-configobj
- python3-vobject python3-yaml"
+ python3-vobject python3-Unidecode python3-ruamel.yaml"
 short_desc="Command-line addressbook built around CardDAV"
 maintainer="Oliver Kiddle <okiddle@yahoo.co.uk>"
 license="GPL-3"
 homepage="https://github.com/scheibler/khard"
 distfiles="${PYPI_SITE}/k/khard/khard-${version}.tar.gz"
-checksum=81776d05e8f121f8969daf561f5c774c665378255ba0064b02a82d490da610ea
+checksum=230cff736a6ec2bbe9f4456fad69e586fc88e64f1bc7245b753e68976829fff6
 
 post_install() {
 	vsconf misc/khard/khard.conf.example

--- a/srcpkgs/python-ruamel.yaml/template
+++ b/srcpkgs/python-ruamel.yaml/template
@@ -1,0 +1,28 @@
+# Template file for 'python-ruamel.yaml'
+pkgname=python-ruamel.yaml
+version=0.15.35
+revision=1
+wrksrc="ruamel.yaml-${version}"
+build_style=python-module
+pycompile_module="ruamel/yaml"
+hostmakedepends="python-setuptools python3-setuptools"
+makedepends="python-devel python3-devel"
+short_desc="YAML parser/emitter in Python2"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="MIT"
+homepage="https://bitbucket.org/ruamel/yaml"
+distfiles="${PYPI_SITE}/r/ruamel.yaml/ruamel.yaml-${version}.tar.gz"
+checksum=8dc74821e4bb6b21fb1ab35964e159391d99ee44981d07d57bf96e2395f3ef75
+
+post_install() {
+	vlicense LICENSE
+}
+
+python3-ruamel.yaml_package() {
+	pycompile_module="ruamel/yaml"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vmove usr/lib/python3*
+		vlicense LICENSE
+	}
+}

--- a/srcpkgs/python3-ruamel.yaml
+++ b/srcpkgs/python3-ruamel.yaml
@@ -1,0 +1,1 @@
+python-ruamel.yaml


### PR DESCRIPTION
New dependencies: `python3-Unidecode`, `python3-ruamel-yaml` (new package)

original name is ruamel.yaml on PYPI and ruamel/yaml on BitBucket (homepage) so i just used dash ( - )