### PR TITLE
python-neovim: fix python-msgpack name change.

### DIFF
--- a/srcpkgs/python-neovim/template
+++ b/srcpkgs/python-neovim/template
@@ -1,7 +1,7 @@
 # Template file for 'python-neovim'
 pkgname=python-neovim
 version=0.2.0
-revision=1
+revision=2
 noarch=yes
 wrksrc="python-client-${version}"
 build_style=python-module
@@ -14,6 +14,12 @@ license="Apache-2.0"
 homepage="https://github.com/neovim/python-client"
 distfiles="${homepage}/archive/${version}.tar.gz"
 checksum=936b8c5a137436499328362da165f7ef16492a628d5a6d9f7b7f182c0200f8ab
+
+pre_build() {
+	# python-msgpack had a name transition from msgpack-python to msgpack
+	# adapt.
+	sed -i 's|msgpack-python>=0.4.0|msgpack>=0.5.0|g' setup.py
+}
 
 python3-neovim_package() {
 	noarch=yes


### PR DESCRIPTION
neovim/python-client#293