### PR TITLE
mcabber: add mcabberrc.example

### DIFF
--- a/srcpkgs/mcabber/template
+++ b/srcpkgs/mcabber/template
@@ -1,7 +1,7 @@
 # Template file for 'mcabber'
 pkgname=mcabber
 version=1.1.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-hgcset --enable-enchant --enable-otr"
 hostmakedepends="pkg-config"
@@ -13,3 +13,7 @@ license="GPL-2"
 homepage="http://mcabber.com"
 distfiles="${homepage}/files/mcabber-${version}.tar.bz2"
 checksum=04fc2c22c36da75cf4b761b5deccd074a19836368f38ab9d03c1e5708b41f0bd
+
+post_install() {
+	vsconf mcabberrc.example
+}


### PR DESCRIPTION
Install `mcabberrc.example` to `/usr/share/doc/mcabber/` for reference.