### PR TITLE
New package: blackbox-1.20170611

### DIFF
--- a/srcpkgs/blackbox/INSTALL.msg
+++ b/srcpkgs/blackbox/INSTALL.msg
@@ -1,0 +1,2 @@
+blackbox requires GnuGP 1 or 2, install gnupg or gnupg2.
+Needs environment variable GPG=gpg2 if used with GnuPG 2.

--- a/srcpkgs/blackbox/template
+++ b/srcpkgs/blackbox/template
@@ -1,0 +1,40 @@
+# Template file for 'blackbox'
+pkgname=blackbox
+version=1.20170611
+revision=1
+noarch=yes
+depends="bash"
+short_desc="Safely store secrets in Git/Mercurial/Subversion"
+maintainer="Daniel A. Maierhofer <git@damadmai.at>"
+license="MIT"
+homepage="https://github.com/StackExchange/blackbox"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=dcdc7a9b7c9fd7144c90baa5f48041af434ed4c8f77c8e41f1017789a2f9c017
+
+do_install() {
+	vbin bin/_blackbox_common.sh
+	vbin bin/_blackbox_common_test.sh
+	vbin bin/_stack_lib.sh
+	vbin bin/blackbox_addadmin
+	vbin bin/blackbox_cat
+	vbin bin/blackbox_decrypt_all_files
+	vbin bin/blackbox_deregister_file
+	vbin bin/blackbox_diff
+	vbin bin/blackbox_edit
+	vbin bin/blackbox_edit_end
+	vbin bin/blackbox_edit_start
+	vbin bin/blackbox_initialize
+	vbin bin/blackbox_list_admins
+	vbin bin/blackbox_list_files
+	vbin bin/blackbox_listadmins
+	vbin bin/blackbox_postdeploy
+	vbin bin/blackbox_recurse
+	vbin bin/blackbox_register_new_file
+	vbin bin/blackbox_removeadmin
+	vbin bin/blackbox_shred_all_files
+	vbin bin/blackbox_update_all_files
+	vbin bin/blackbox_whatsnew
+	vdoc README.md
+	vdoc AUTHORS
+	vlicense LICENSE.txt
+}


### PR DESCRIPTION
No dependency on gnupg or gnupg2 to let users decide which to install.
Needs `GPG=gpg2` if used with GnuPG 2