### PR TITLE
Fix freshplayerplugin for musl build

### DIFF
--- a/srcpkgs/freshplayerplugin/patches/add_dlfcn.patch
+++ b/srcpkgs/freshplayerplugin/patches/add_dlfcn.patch
@@ -1,0 +1,10 @@
+--- src/gtk_wrapper.c.original	2018-02-15 20:32:49.195111595 +0500
++++ src/gtk_wrapper.c	2018-02-15 20:33:05.219041807 +0500
+@@ -28,6 +28,7 @@
+ #include <link.h>
+ #include <stdio.h>
+ #include <string.h>
++#include <dlfcn.h>
+ #include "trace_core.h"
+ 
+ 

--- a/srcpkgs/freshplayerplugin/template
+++ b/srcpkgs/freshplayerplugin/template
@@ -15,10 +15,6 @@ checksum=e4c67ff382aacbdf6ecc45095fa48c582e89ce70f94fe6499e00f7d664d5e05f
 
 nocross="http://build.voidlinux.eu/builders/armv6l-musl_builder/builds/2815/steps/shell_3/logs/stdio"
 
-case "$XBPS_TARGET_MACHINE" in
-	*-musl) broken="https://build.voidlinux.eu/builders/x86_64-musl_builder/builds/186/steps/shell_3/logs/stdio";;
-esac
-
 do_install() {
 	vinstall build/libfreshwrapper-flashplayer.so 755 usr/lib/mozilla/plugins
 	vsconf data/freshwrapper.conf.example


### PR DESCRIPTION
Fix for building freshplayerplugin for musl.
Minor change, does not break libc build.