### PR TITLE
helm: fix musl and recreate fix_sigemptyset.patch

### DIFF
--- a/srcpkgs/helm/patches/fix-musl.patch
+++ b/srcpkgs/helm/patches/fix-musl.patch
@@ -1,0 +1,40 @@
+--- JUCE/modules/juce_core/juce_core.cpp	2016-08-30 06:24:27.000000000 +0200
++++ JUCE/modules/juce_core/juce_core.cpp	2016-12-12 14:53:23.532613378 +0100
+@@ -97,7 +97,7 @@
+  #include <net/if.h>
+  #include <sys/ioctl.h>
+ 
+- #if ! JUCE_ANDROID
++ #if ! JUCE_ANDROID && defined(__GLIBC__)
+   #include <execinfo.h>
+  #endif
+ #endif
+--- JUCE/modules/juce_core/system/juce_SystemStats.cpp	2016-08-30 06:24:27.000000000 +0200
++++ JUCE/modules/juce_core/system/juce_SystemStats.cpp	2016-12-12 14:58:35.988986030 +0100
+@@ -134,6 +134,8 @@
+         }
+     }
+ 
++   #elif !defined(__GLIBC__)
++    jassertfalse; // sorry, not implemented yet!
+    #else
+     void* stack[128];
+     int frames = backtrace (stack, numElementsInArray (stack));
+--- JUCE/modules/juce_core/native/juce_linux_SystemStats.cpp	2016-08-30 06:24:27.000000000 +0200
++++ JUCE/modules/juce_core/native/juce_linux_SystemStats.cpp	2016-12-12 15:07:35.046607788 +0100
+@@ -142,8 +142,15 @@
+     return result;
+ }
+ 
++#if defined(__GLIBC__)
+ String SystemStats::getUserLanguage()    { return getLocaleValue (_NL_IDENTIFICATION_LANGUAGE); }
+ String SystemStats::getUserRegion()      { return getLocaleValue (_NL_IDENTIFICATION_TERRITORY); }
++#else
++// The identifiers _NL_INDENTIFICATION_LANGUAGE and _TERRIRTORY are not defined in musl libc.
++// TODO: Find a better fix than just returning nonsense. Inspect env("LANG") perhaps?
++String SystemStats::getUserLanguage()    { return String("en"); }
++String SystemStats::getUserRegion()      { return String("US"); }
++#endif
+ String SystemStats::getDisplayLanguage() { return getUserLanguage() + "-" + getUserRegion(); }
+ 
+ //==============================================================================

--- a/srcpkgs/helm/patches/fix_sigemptyset.patch
+++ b/srcpkgs/helm/patches/fix_sigemptyset.patch
@@ -1,8 +1,6 @@
-diff --git JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/cpu.c JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/cpu.c
-index 4eac42e..b477709 100644
---- JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/cpu.c
-+++ JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/cpu.c
-@@ -244,11 +244,7 @@ void FLAC__cpu_info(FLAC__CPUInfo *info)
+--- JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/cpu.c	2017-07-08 23:40:42.000000000 +0200
++++ -	2018-02-20 22:11:47.567333249 +0100
+@@ -244,11 +244,7 @@
  		struct sigaction sigill_save;
  		struct sigaction sigill_sse;
  		sigill_sse.sa_sigaction = sigill_handler_sse_os;

--- a/srcpkgs/helm/template
+++ b/srcpkgs/helm/template
@@ -4,7 +4,8 @@ version=0.9.0
 revision=1
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
-makedepends="alsa-lib-devel libcurl-devel libX11-devel libXext-devel libXinerama-devel freetype-devel MesaLib-devel jack-devel libXcursor-devel"
+makedepends="alsa-lib-devel libcurl-devel libX11-devel libXext-devel
+ libXinerama-devel freetype-devel MesaLib-devel jack-devel libXcursor-devel"
 maintainer="Olga Ustuzhanina <me@laserbat.pw>"
 short_desc="Polyphonic synth with lots of modulation"
 homepage="http://tytel.org/helm"
@@ -12,7 +13,3 @@ license="GPL-3"
 distfiles="https://github.com/mtytel/helm/archive/v${version}.tar.gz"
 checksum=4004c11fd1d773cc2a12adb5336873bc86c5ecbd370b8da2820fed6ef5ec58ad
 nocross="Uses uname -m to set SIMDFLAGS. Should be based on the target, not the host, architecture"
-
-case "$XBPS_TARGET_MACHINE" in
-	*-musl) broken="Doesn't compile on musl because JUCE depends on execinfo.h"
-esac


### PR DESCRIPTION
The musl patch is the one form libopenshot-audio with patched paths.
Also the fix_sigemptyset.patch was failing locally because of different line endings (the source code uses DOS ones). It seems like it got converted when it was meged.