### PR TITLE
kakoune: update to 0.0.20180301

### DIFF
--- a/srcpkgs/kakoune/template
+++ b/srcpkgs/kakoune/template
@@ -1,18 +1,17 @@
 # Template file for 'kakoune'
 pkgname=kakoune
-version=0.0.20170920
-revision=3
-_commit="0da5cabbfe3009d9d29b0d2d28381b252aadbe40"
+version=0.0.2018301
+revision=1
+_commit="7a54c0edfe36a0a3fb428cfee211a3f87cf4f7a2"
 wrksrc="${pkgname}-${_commit}"
 build_wrksrc="src"
 build_style=gnu-makefile
 make_build_args="debug=no"
-make_install_args="debug=no"
-hostmakedepends="asciidoc"
-makedepends="boost-devel ncurses-devel"
+hostmakedepends="pkg-config asciidoc"
+makedepends="ncurses-devel"
 short_desc="Selection-based vim-like editor with less keystrokes"
 maintainer="Jakub Skrzypnik <j.skrzypnik@openmailbox.org>"
 license="UNLICENSE"
 homepage="http://kakoune.org"
 distfiles="https://github.com/mawww/kakoune/archive/${_commit}.tar.gz"
-checksum=d53c25a17295ad20879a189782db9c5c2af97e359ffb97343d2452babadf4038
+checksum=8ac43c15b696360d99d7f65a14c649d078b465de445812c0168eef09f20e8edd


### PR DESCRIPTION
• Still no release (but I've starting pushing @mawww a little and he's going to do it very soon I think)
• No runtime deps beyond `ncurses` (boost was kicked out when he made its own regexp impl)
• Everything's a bit more faster and sensible.

Release "issues" for reference:

mawww/kakoune#1019
mawww/kakoune#315
mawww/kakoune#89
mawww/kakoune#249
