### PR TITLE
vice: switch to GTK3 UI by default, replace SDL with SDL2

### DIFF
--- a/srcpkgs/vice/template
+++ b/srcpkgs/vice/template
@@ -1,13 +1,26 @@
 # Template file for 'vice'
 pkgname=vice
 version=3.1
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--enable-sdlui $(vopt_with pulseaudio pulse)
- --disable-option-checking"
+configure_args="
+	$(vopt_enable sdl2 sdlui2)
+	$(vopt_with sdl2 sdlsound)
+	$(vopt_enable gtk3 gnomeui3)
+	$(vopt_with gtk3 pulse)
+	--disable-option-checking
+	--enable-cpuhistory"
 hostmakedepends="pkg-config bdftopcf mkfontdir flex"
-makedepends="zlib-devel readline-devel libpng-devel giflib-devel SDL-devel
- $(vopt_if pulseaudio pulseaudio-devel)"
+makedepends="
+	zlib-devel
+	readline-devel
+	libpng-devel
+	giflib-devel
+	$(vopt_if sdl2 SDL2_mixer-devel)
+	$(vopt_if sdl2 SDL2-devel)
+	$(vopt_if gtk3 gtk+3-devel)
+	$(vopt_if gtk3 pulseaudio-devel)
+	$(vopt_if gtk3 pango-devel)"
 short_desc="Emulator for C64, C128, CBM-II, PET, VIC20, Plus4 and C16"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
@@ -16,8 +29,8 @@ distfiles="${SOURCEFORGE_SITE}/vice-emu/$pkgname-$version.tar.gz"
 checksum=3eb8159633816095006dec36c5c3edd055a87fd8bda193a1194a6801685d1240
 
 # Package build options
-build_options="pulseaudio"
-build_options_default="pulseaudio"
+build_options="sdl2 gtk3"
+build_options_default="gtk3"
 
 pre_configure() {
 	# Do not install data to /usr/lib64


### PR DESCRIPTION
• GTK3 UI has more convenient monitor/debugger than SDL2 UI, and it's overall "better" for development purposes
• SDL UI has been upgraded to SDL2 as it's supported since 3.x. I'm still leaving it as it is because it's more suitable for ad-hoc emulation/gaming.
• I've merged GTK3 vopt with Pulseaudio and told the SDL UI to use SDL's sound subsystem instead (to reduce redundancy, there's no added latency)

**BUT**: I wanted to add `ReSID(fp)` which is the "real" SID emulation (with filters) instead of the "fast SID" emulation, the buildsystem says something weird:
```
configure: WARNING: g++ is not the intended cross-compiler, ReSID will not be configured
```

Surprisinglyy, when compiled out of the `xbps-src`, it builds fine with ReSID too. What could be wrong here?