### PR TITLE
mc: switch ncurses to slang, add mksh support patch

### DIFF
--- a/srcpkgs/mc/patches/mc-mksh-subshell-v2.patch
+++ b/srcpkgs/mc/patches/mc-mksh-subshell-v2.patch
@@ -1,0 +1,73 @@
+--- lib/shell.c	2016-09-22 18:24:12.000000000 +0000
++++ lib/shell.c	2017-02-16 13:47:34.933939000 +0000
+@@ -66,6 +66,10 @@
+     /* 3rd choice: look for existing shells supported as MC subshells.  */
+     if (access ("/bin/bash", X_OK) == 0)
+         mc_shell->path = g_strdup ("/bin/bash");
++    else if (access ("/usr/local/bin/mksh", X_OK) == 0)
++        mc_shell->path = g_strdup ("/usr/local/bin/mksh");
++    else if (access ("/bin/mksh", X_OK) == 0)
++        mc_shell->path = g_strdup ("/bin/mksh");
+     else if (access ("/bin/ash", X_OK) == 0)
+         mc_shell->path = g_strdup ("/bin/ash");
+     else if (access ("/bin/dash", X_OK) == 0)
+@@ -149,6 +153,12 @@
+         mc_shell->type = SHELL_ZSH;
+         mc_shell->name = "zsh";
+     }
++    else if (strstr (mc_shell->path, "/mksh") != NULL
++             || strstr (mc_shell->real_path, "/mksh") != NULL)
++    {
++        mc_shell->type = SHELL_MKSH;
++        mc_shell->name = "mksh";
++    }
+     else if (strstr (mc_shell->path, "/tcsh") != NULL
+              || strstr (mc_shell->real_path, "/tcsh") != NULL)
+     {
+diff -Naur mc-4.8.18.orig/lib/shell.h mc-4.8.18/lib/shell.h
+--- lib/shell.h	2016-03-12 15:45:47.000000000 +0000
++++ lib/shell.h	2017-02-15 21:57:39.000000000 +0000
+@@ -12,6 +12,7 @@
+ typedef enum
+ {
+     SHELL_NONE,
++    SHELL_MKSH,
+     SHELL_SH,
+     SHELL_BASH,
+     SHELL_ASH_BUSYBOX,          /* BusyBox default shell (ash) */
+diff -Naur mc-4.8.18.orig/src/subshell/common.c mc-4.8.18/src/subshell/common.c
+--- src/subshell/common.c	2016-09-22 18:24:12.000000000 +0000
++++ src/subshell/common.c	2017-02-20 18:48:22.681514000 +0000
+@@ -320,6 +320,12 @@
+ 
+         break;
+ 
++    case SHELL_MKSH:
++        init_file = g_strdup (".shrc");
++        putenv_str = g_strconcat ("ENV=", init_file, (char *) NULL);
++        putenv (putenv_str);
++        break;
++
+         /* TODO: Find a way to pass initfile to TCSH, ZSH and FISH */
+     case SHELL_TCSH:
+     case SHELL_ZSH:
+@@ -367,6 +373,7 @@
+ 
+     case SHELL_ASH_BUSYBOX:
+     case SHELL_DASH:
++    case SHELL_MKSH:
+     case SHELL_TCSH:
+     case SHELL_FISH:
+         execl (mc_global.shell->path, mc_global.shell->path, (char *) NULL);
+@@ -801,6 +808,11 @@
+                     "PS1='\\u@\\h:\\w\\$ '\n", subshell_pipe[WRITE]);
+         break;
+ 
++    case SHELL_MKSH:
++        g_snprintf (precmd, buff_size,
++                    "PS1='$(pwd>&%d; kill -STOP $$)'\"$((( USER_ID )) && print '$ ' || print '# ')\"\n", subshell_pipe[WRITE]);
++        break;
++
+     case SHELL_ASH_BUSYBOX:
+         /* BusyBox ash needs a somewhat complicated precmd emulation via PS1, and it is vital
+          * that BB be built with active CONFIG_ASH_EXPAND_PRMT, but this is the default anyway.

--- a/srcpkgs/mc/template
+++ b/srcpkgs/mc/template
@@ -1,11 +1,11 @@
 # Template file for 'mc'
 pkgname=mc
 version=4.8.20
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--with-screen=ncurses --without-x"
+configure_args="--with-screen=slang --without-x"
 hostmakedepends="pkg-config perl"
-makedepends="libglib-devel e2fsprogs-devel ncurses-devel libssh2-devel gpm-devel"
+makedepends="libglib-devel e2fsprogs-devel slang-devel libssh2-devel gpm-devel"
 conf_files="
 	/etc/mc/filehighlight.ini
 	/etc/mc/mc.default.keymap


### PR DESCRIPTION
* Switched to `slang` console library instead of `ncurses`:
  * It's more responsive when used with mouse
  * Does not produce garbage after exiting from programs acting unaccordingly with terminals, refreshes screen nicely
  * Allows to assign own characters for frames and other UI elements
  * Works with 256-16M color terminals
    * (both of these functionalities can be tested with bundled themes)
* Added a patch to support `mksh` shell as subshell, with default configuration it just dropped us to empty pty after pressing ^O