### PR TITLE
New package: kickassembler-4.19

### DIFF
--- a/srcpkgs/kickassembler/template
+++ b/srcpkgs/kickassembler/template
@@ -1,0 +1,27 @@
+# Template file for 'kickassembler'
+pkgname="kickassembler"
+version=4.19
+revision=1
+depends="virtual?java-environment"
+hostmakedepends="unzip"
+short_desc="A combination of 6510 assembler and high level script language"
+maintainer="Jakub Skrzypnik <jakub.skrzypnik@interia.pl>"
+homepage="http://www.theweb.dk/KickAssembler"
+license="GPL-2"
+distfiles="http://www.theweb.dk/KickAssembler/KickAssembler.zip"
+checksum=d55977be83f38d6fbd3c9b87a189298baf03c4b241cbad239194e3e1a22e9184
+noarch="yes"
+create_wrksrc="yes"
+
+do_build() {
+	mv KickAss.jar ${pkgname}-${version}.jar
+	echo "#!/bin/sh" > kickass
+	echo "java -jar /usr/share/java/${pkgname}-${version}.jar \$@" >> kickass
+	chmod 755 kickass
+}
+
+do_install() {
+	vbin kickass
+	vinstall ${pkgname}-${version}.jar 644 usr/share/java ${pkgname}-${version}.jar
+}
+


### PR DESCRIPTION
Also x65xx assembler, but mostly targeted at C64: http://www.theweb.dk/KickAssembler/
Contains the very featureful metaprogramming "language".

I've used the `plantuml` package as a boilerplate to generate shell loader and store JAR in its own directory.