### PR TITLE
xbps-src: use HEAD commit time for SOURCE_DATE_EPOCH

### DIFF
--- a/common/environment/setup/git.sh
+++ b/common/environment/setup/git.sh
@@ -14,6 +14,6 @@ if [ -z "${SOURCE_DATE_EPOCH}" -a -n "$IN_CHROOT" ]; then
 	if $GIT_CMD -C ${XBPS_SRCPKGDIR}/${basepkg} status -u normal --porcelain template | grep "^?? " &> /dev/null; then
 		export SOURCE_DATE_EPOCH="$(stat -c %Y ${XBPS_SRCPKGDIR}/${basepkg}/template)"
 	else
-		export SOURCE_DATE_EPOCH="$($GIT_CMD -C ${XBPS_SRCPKGDIR}/${basepkg} log --pretty='%ct' -n1 .)"
+		export SOURCE_DATE_EPOCH="$($GIT_CMD log --pretty='%ct' -n1 HEAD)"
 	fi
 fi

--- a/etc/defaults.conf
+++ b/etc/defaults.conf
@@ -121,6 +121,6 @@ XBPS_SUCMD="sudo /bin/sh -c"
 
 # [OPTIONAL]
 # Enable to use the standard mtime of files. Otherwise it will be rewritten to
-# the last commit time of the package.
+# the HEAD commit time.
 #
 #XBPS_USE_BUILD_MTIME=yes


### PR DESCRIPTION
In order to make builds more reproducible SOURCE_DATE_EPOCH was set to
the time of the last commit that touched the template. Since trying to
reproduce a build from a different revision is futile and looking up the
commit in question can take several seconds, stop wasting time an just use
HEAD.