### PR TITLE
New package: python-mysqlclient-1.3.12

### DIFF
--- a/srcpkgs/python-mysqlclient/template
+++ b/srcpkgs/python-mysqlclient/template
@@ -1,0 +1,24 @@
+pkgname=python-mysqlclient
+version=1.3.12
+revision=1
+wrksrc="mysqlclient-${version}"
+build_style=python-module
+pycompile_module="mysqlclient"
+hostmakedepends="python-setuptools python3-setuptools"
+makedepends="libmysqlclient-devel python-devel python3-devel zlib-devel libressl-devel"
+depends="python"
+short_desc="Python2 interface to MySQL/MariaDB"
+maintainer="Alin Dobre <alin.dobre@outlook.com>"
+license="GPL-2"
+homepage="https://github.com/PyMySQL/mysqlclient-python"
+distfiles="${PYPI_SITE}/m/mysqlclient/mysqlclient-${version}.tar.gz"
+checksum=2d9ec33de39f4d9c64ad7322ede0521d85829ce36a76f9dd3d6ab76a9c8648e5
+
+python3-mysqlclient_package() {
+	pycompile_module="mysqlclient"
+	depends="python3"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vmove usr/lib/python3*
+	}
+}

--- a/srcpkgs/python3-mysqlclient
+++ b/srcpkgs/python3-mysqlclient
@@ -1,0 +1,1 @@
+python-mysqlclient


### PR DESCRIPTION
This package is necessary so a Void Linux host with mariadb/mysql installed can be managed with Ansible using any of its own internal mysql_* module (check [1] for full list of modules, but `mysql_db` and `mysql_user` is what i would need).

Without this module, I wouldn't be able to use Ansible unless I would write my own recipes using the `mysql` command line client or some other workaround, which is a bit out of hand.

[1] http://docs.ansible.com/ansible/latest/list_of_database_modules.html