### PR TITLE
New package: python-passlib-1.7.1

### DIFF
--- a/srcpkgs/python-passlib/template
+++ b/srcpkgs/python-passlib/template
@@ -1,0 +1,30 @@
+pkgname=python-passlib
+version=1.7.1
+revision=1
+noarch=yes
+wrksrc="passlib-${version}"
+build_style=python-module
+pycompile_module="passlib"
+hostmakedepends="python-setuptools python3-setuptools"
+depends="python"
+short_desc="Comprehensive password hashing framework for Python2"
+maintainer="Alin Dobre <alin.dobre@outlook.com>"
+license="BSD"
+homepage="https://bitbucket.org/ecollins/passlib"
+distfiles="${PYPI_SITE}/p/passlib/passlib-${version}.tar.gz"
+checksum=3d948f64138c25633613f303bcc471126eae67c04d5e3f6b7b8ce6242f8653e0
+
+post_install() {
+	vlicense LICENSE
+}
+
+python3-passlib_package() {
+	noarch=yes
+	pycompile_module="passlib"
+	depends="python3"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vmove usr/lib/python3*
+		vlicense LICENSE
+	}
+}

--- a/srcpkgs/python3-passlib
+++ b/srcpkgs/python3-passlib
@@ -1,0 +1,1 @@
+python-passlib


### PR DESCRIPTION
This package is necessary so the system users on a Void Linux host can be fully managed with Ansible using its own internal [user module](http://docs.ansible.com/ansible/latest/user_module.html). In order for this module to be able to set passwords [it needs](http://docs.ansible.com/ansible/latest/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module) the passlib Python library.