### PR TITLE
New package: php-imagick-3.4.3

### DIFF
--- a/srcpkgs/php-imagick/INSTALL.msg
+++ b/srcpkgs/php-imagick/INSTALL.msg
@@ -1,0 +1,3 @@
+To enable the Imagick extension add the following line to your php.ini:
+
+	extension=imagick.so

--- a/srcpkgs/php-imagick/template
+++ b/srcpkgs/php-imagick/template
@@ -1,0 +1,26 @@
+pkgname=php-imagick
+version=3.4.3
+revision=1
+build_style=gnu-configure
+hostmakedepends="php-devel autoconf pcre-devel pkg-config"
+makedepends="php-devel libmagick-devel"
+depends="php"
+short_desc="Provides a PHP wrapper to the ImageMagick library"
+maintainer="Alin Dobre <alin.dobre@outlook.com>"
+license="PHP"
+homepage="https://pecl.php.net/package/imagick"
+distfiles="https://pecl.php.net/get/imagick-$version.tgz"
+checksum=1f3c5b5eeaa02800ad22f506cd100e8889a66b2ec937e192eaaa30d74562567c
+wrksrc="imagick-$version"
+
+pre_configure() {
+	phpize
+}
+
+pre_install() {
+	make_install_args="INSTALL_ROOT=$DESTDIR"
+}
+
+post_install() {
+	rm -r $DESTDIR/usr/include
+}


### PR DESCRIPTION
This package is needed for image editing features in Wordpress as an alternative to the GD library. It's the PHP extension that wraps around ImageMagick libraries.