### PR TITLE
elogind: ensure valid install_items syntax

### DIFF
--- a/srcpkgs/elogind/template
+++ b/srcpkgs/elogind/template
@@ -52,7 +52,7 @@ post_install() {
 	vinstall ./src/systemd/_sd-common.h 644 usr/include
 	vinstall $FILESDIR/elogind.wrapper 755 usr/libexec/elogind
 	vmkdir etc/dracut.conf.d
-	echo "install_items+=\"/usr/libexec/elogind/elogind-uaccess-command\"" >> ${DESTDIR}/etc/dracut.conf.d/elogind.conf
+	echo "install_items+=\" /usr/libexec/elogind/elogind-uaccess-command \"" >> ${DESTDIR}/etc/dracut.conf.d/elogind.conf
 }
 
 elogind-devel_package() {


### PR DESCRIPTION
This ensures that arguments to install_items are space separated when
more than one install_item is present in the dracut configuration.