### PR TITLE
android-studio: fix dependency conflict

### DIFF
--- a/srcpkgs/android-studio/template
+++ b/srcpkgs/android-studio/template
@@ -21,6 +21,8 @@ license="Apache-2.0"
 homepage="http://tools.android.com/"
 nopie=yes
 nostrip=yes
+noverifyrdeps=yes
+depends="openjdk-jre libgcc libXtst libXrender libXi libXext libX11 glibc freetype alsa-lib"
 
 do_install() {
 	unzip android-studio-ide-${_studio_build}-linux.zip


### PR DESCRIPTION
android-studio package fails to install, see
https://github.com/voidlinux/void-packages/issues/9830