### PR TITLE
common/xbps-src: add stacktraces on build errors

### DIFF
--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -80,9 +80,18 @@ run_step() {
 }
 
 error_func() {
-    if [ -n "$1" -a -n "$2" ]; then
-        msg_red "$pkgver: failed to run $1() at line $2.\n"
-    fi
+    local err=$?
+    local src=
+    local i=
+    [ -n "$1" -a -n "$2" ] || exit 1;
+
+    msg_red "$pkgver: $1: '${BASH_COMMAND}' exited with $err\n"
+    for ((i=1;i<${#FUNCNAME[@]};i++)); do
+        src=${BASH_SOURCE[$i]}
+        src=${src#$XBPS_DISTDIR/}
+        msg_red "  in ${FUNCNAME[$i]}() at $src:${BASH_LINENO[$i-1]}\n"
+        [ "${FUNCNAME[$i]}" = "$1" ] && break;
+    done
     exit 1
 }
 


### PR DESCRIPTION
This commit makes xbps-src print stacktraces when an error occured:
![screenshot from 2018-03-28 11-47-03](https://user-images.githubusercontent.com/1056976/38021662-c5411108-327d-11e8-915a-d0acda5590f1.png)


