### PR TITLE
rust: update to 1.25.0. [CI Skip]

### DIFF
--- a/srcpkgs/rust/patches/link-musl-dynamically.patch
+++ b/srcpkgs/rust/patches/link-musl-dynamically.patch
@@ -1,44 +1,69 @@
---- rustc-1.21.0-src/src/liblibc/src/unix/mod.rs.orig
-+++ rustc-1.21.0-src/src/liblibc/src/unix/mod.rs
-@@ -228,10 +228,6 @@
-     } else if #[cfg(feature = "use_std")] {
-         // cargo build, don't pull in anything extra as the libstd dep
-         // already pulls in all libs.
--    } else if #[cfg(any(all(target_env = "musl", not(target_arch = "mips"))))] {
--        #[link(name = "c", kind = "static", cfg(target_feature = "crt-static"))]
--        #[link(name = "c", cfg(not(target_feature = "crt-static")))]
--        extern {}
-     } else if #[cfg(target_os = "emscripten")] {
-         #[link(name = "c")]
-         extern {}
---- rustc-1.21.0-src/src/bootstrap/compile.rs.orig
-+++ rustc-1.21.0-src/src/bootstrap/compile.rs
-@@ -127,9 +127,6 @@
- fn copy_musl_third_party_objects(build: &Build,
-                                  target: Interned<String>,
-                                  into: &Path) {
+--- rustc-1.25.0-src/src/bootstrap/compile.rs	2018-03-25 16:26:14.000000000 +0200
++++ rustc-1.25.0-src/src/bootstrap/compile.rs	2018-03-28 18:31:04.332764856 +0200
+@@ -78,13 +78,6 @@
+             });
+             println!("Uplifting stage1 std ({} -> {})", from.host, target);
+ 
+-            // Even if we're not building std this stage, the new sysroot must
+-            // still contain the musl startup objects.
+-            if target.contains("musl") {
+-                let libdir = builder.sysroot_libdir(compiler, target);
+-                copy_musl_third_party_objects(build, target, &libdir);
+-            }
+-
+             builder.ensure(StdLink {
+                 compiler: from,
+                 target_compiler: compiler,
+@@ -97,11 +90,6 @@
+         println!("Building stage{} std artifacts ({} -> {})", compiler.stage,
+                 &compiler.host, target);
+ 
+-        if target.contains("musl") {
+-            let libdir = builder.sysroot_libdir(compiler, target);
+-            copy_musl_third_party_objects(build, target, &libdir);
+-        }
+-
+         let out_dir = build.stage_out(compiler, Mode::Libstd);
+         build.clear_if_dirty(&out_dir, &builder.rustc(compiler));
+         let mut cargo = builder.cargo(compiler, Mode::Libstd, target, "build");
+@@ -119,19 +107,6 @@
+     }
+ }
+ 
+-/// Copies the crt(1,i,n).o startup objects
+-///
+-/// Since musl supports fully static linking, we can cross link for it even
+-/// with a glibc-targeting toolchain, given we have the appropriate startup
+-/// files. As those shipped with glibc won't work, copy the ones provided by
+-/// musl so we have them on linux-gnu hosts.
+-fn copy_musl_third_party_objects(build: &Build,
+-                                 target: Interned<String>,
+-                                 into: &Path) {
 -    for &obj in &["crt1.o", "crti.o", "crtn.o"] {
 -        copy(&build.musl_root(target).unwrap().join("lib").join(obj), &into.join(obj));
 -    }
- }
+-}
  
  /// Configure cargo to compile the standard library, adding appropriate env vars
---- rustc-1.21.0-src/src/bootstrap/sanity.rs.orig
-+++ rustc-1.21.0-src/src/bootstrap/sanity.rs
-@@ -21,7 +21,6 @@
+ /// and such.
+
+--- rustc-1.25.0-src-orig/src/bootstrap/sanity.rs       2018-03-25 16:26:14.000000000 +0200
++++ rustc-1.25.0-src/src/bootstrap/sanity.rs    2018-03-29 12:49:49.192705213 +0200
+@@ -21,7 +21,7 @@
  use std::collections::HashMap;
  use std::env;
  use std::ffi::{OsString, OsStr};
--use std::fs;
- use std::process::Command;
+-use std::fs::{self, File};
++use std::fs::File;
+ use std::io::Read;
  use std::path::PathBuf;
- 
-@@ -168,34 +167,6 @@
+ use std::process::Command;
+@@ -169,34 +169,6 @@
              panic!("the iOS target is only supported on macOS");
          }
- 
+
 -        // Make sure musl-root is valid
--        if target.contains("musl") && !target.contains("mips") {
+-        if target.contains("musl") {
 -            // If this is a native target (host is also musl) and no musl-root is given,
 -            // fall back to the system toolchain in /usr before giving up
 -            if build.musl_root(*target).is_none() && build.config.build == *target {
@@ -68,8 +93,26 @@
          if target.contains("msvc") {
              // There are three builds of cmake on windows: MSVC, MinGW, and
              // Cygwin. The Cygwin build does not have generators for Visual
---- rustc-1.21.0-src/src/librustc_back/target/x86_64_unknown_linux_musl.rs.orig
-+++ rustc-1.21.0-src/src/librustc_back/target/x86_64_unknown_linux_musl.rs
+
+--- rustc-1.25.0-src/src/liblibc/src/unix/mod.rs	2018-03-25 16:29:43.000000000 +0200
++++ rustc-1.25.0-src/src/liblibc/src/unix/mod.rs	2018-03-28 18:31:35.073467567 +0200
+@@ -276,13 +276,6 @@
+     } else if #[cfg(feature = "use_std")] {
+         // cargo build, don't pull in anything extra as the libstd dep
+         // already pulls in all libs.
+-    } else if #[cfg(target_env = "musl")] {
+-        #[cfg_attr(feature = "stdbuild",
+-                   link(name = "c", kind = "static",
+-                        cfg(target_feature = "crt-static")))]
+-        #[cfg_attr(feature = "stdbuild",
+-                   link(name = "c", cfg(not(target_feature = "crt-static"))))]
+-        extern {}
+     } else if #[cfg(target_os = "emscripten")] {
+         #[link(name = "c")]
+         extern {}
+
+--- rustc-1.25.0-src/src/librustc_back/target/x86_64_unknown_linux_musl.rs	2018-03-25 16:26:14.000000000 +0200
++++ rustc-1.25.0-src/src/librustc_back/target/x86_64_unknown_linux_musl.rs	2018-03-28 18:33:44.758213404 +0200
 @@ -12,7 +12,7 @@
  use target::{Target, TargetResult};
  
@@ -79,88 +122,28 @@
      base.cpu = "x86-64".to_string();
      base.max_atomic_width = Some(64);
      base.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap().push("-m64".to_string());
---- rustc-1.21.0-src/src/libunwind/build.rs.orig
-+++ rustc-1.21.0-src/src/libunwind/build.rs
+
+--- rustc-1.25.0-src/src/libunwind/build.rs	2018-03-25 16:26:14.000000000 +0200
++++ rustc-1.25.0-src/src/libunwind/build.rs	2018-03-28 18:27:35.043788864 +0200
 @@ -15,9 +15,7 @@
      let target = env::var("TARGET").expect("TARGET was not set");
  
      if target.contains("linux") {
--        if target.contains("musl") && !target.contains("mips") {
+-        if target.contains("musl") {
 -            // musl is handled in lib.rs
 -        } else if !target.contains("android") {
 +        if !target.contains("android") {
              println!("cargo:rustc-link-lib=gcc_s");
          }
      } else if target.contains("freebsd") {
---- rustc-1.21.0-src/src/libunwind/lib.rs.orig
-+++ rustc-1.21.0-src/src/libunwind/lib.rs
-@@ -28,7 +28,3 @@
- #[cfg(not(target_env = "msvc"))]
- pub use libunwind::*;
- 
--#[cfg(all(target_env = "musl", not(target_arch = "mips")))]
--#[link(name = "unwind", kind = "static", cfg(target_feature = "crt-static"))]
--#[link(name = "gcc_s", cfg(not(target_feature = "crt-static")))]
--extern {}
---- rustc-1.21.0-src/src/bootstrap/compile.rs.orig
-+++ rustc-1.21.0-src/src/bootstrap/compile.rs
-@@ -82,7 +82,6 @@
-             // still contain the musl startup objects.
-             if target.contains("musl") && !target.contains("mips") {
-                 let libdir = builder.sysroot_libdir(compiler, target);
--                copy_musl_third_party_objects(build, target, &libdir);
-             }
- 
-             builder.ensure(StdLink {
-@@ -99,7 +98,6 @@
- 
-         if target.contains("musl") && !target.contains("mips") {
-             let libdir = builder.sysroot_libdir(compiler, target);
--            copy_musl_third_party_objects(build, target, &libdir);
-         }
- 
-         let out_dir = build.cargo_out(compiler, Mode::Libstd, target);
-@@ -118,17 +116,6 @@
+
+--- rustc-1.25.0-src/src/libunwind/lib.rs	2018-03-25 16:26:14.000000000 +0200
++++ rustc-1.25.0-src/src/libunwind/lib.rs	2018-03-28 18:27:35.044788854 +0200
+@@ -35,7 +35,3 @@
      }
  }
  
--/// Copies the crt(1,i,n).o startup objects
--///
--/// Since musl supports fully static linking, we can cross link for it even
--/// with a glibc-targeting toolchain, given we have the appropriate startup
--/// files. As those shipped with glibc won't work, copy the ones provided by
--/// musl so we have them on linux-gnu hosts.
--fn copy_musl_third_party_objects(build: &Build,
--                                 target: Interned<String>,
--                                 into: &Path) {
--}
--
- /// Configure cargo to compile the standard library, adding appropriate env vars
- /// and such.
- pub fn std_cargo(build: &Build,
---- rustc-1.23.0-src/src/bootstrap/compile.rs.orig
-+++ rustc-1.23.0-src/src/bootstrap/compile.rs
-@@ -78,12 +78,6 @@
-             });
-             println!("Uplifting stage1 std ({} -> {})", from.host, target);
- 
--            // Even if we're not building std this stage, the new sysroot must
--            // still contain the musl startup objects.
--            if target.contains("musl") && !target.contains("mips") {
--                let libdir = builder.sysroot_libdir(compiler, target);
--            }
--
-             builder.ensure(StdLink {
-                 compiler: from,
-                 target_compiler: compiler,
-@@ -96,10 +90,6 @@
-         println!("Building stage{} std artifacts ({} -> {})", compiler.stage,
-                 &compiler.host, target);
- 
--        if target.contains("musl") && !target.contains("mips") {
--            let libdir = builder.sysroot_libdir(compiler, target);
--        }
--
-         let out_dir = build.stage_out(compiler, Mode::Libstd);
-         build.clear_if_dirty(&out_dir, &builder.rustc(compiler));
-         let mut cargo = builder.cargo(compiler, Mode::Libstd, target, "build");
+-#[cfg(target_env = "musl")]
+-#[link(name = "unwind", kind = "static", cfg(target_feature = "crt-static"))]
+-#[link(name = "gcc_s", cfg(not(target_feature = "crt-static")))]
+-extern {}

--- a/srcpkgs/rust/template
+++ b/srcpkgs/rust/template
@@ -1,7 +1,7 @@
 # Template file for 'rust'
 pkgname=rust
-version=1.24.1
-revision=3
+version=1.25.0
+revision=1
 _rust_dist_version=1.24.0
 _cargo_dist_version=0.25.0
 # NB. if you push any(!) new version, don't forget to put a build
@@ -13,17 +13,17 @@ build_style=configure
 make_build_args="dist VERBOSE=1"
 only_for_archs="i686 x86_64 x86_64-musl"
 hostmakedepends="cmake curl pkg-config python"
-makedepends="libffi-devel llvm4.0 ncurses-devel zlib-devel"
+makedepends="libffi-devel llvm ncurses-devel zlib-devel"
 short_desc="Safe, concurrent, practical systems language"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 homepage="http://www.rust-lang.org/"
 license="MIT, Apache-2.0"
 distfiles="https://static.rust-lang.org/dist/rustc-${version}-src.tar.gz"
-checksum=3ea53d45e8d2e9a41afb3340cf54b9745f845b552d802d607707cf04450761ef
+checksum=eef63a0aeea5147930a366aee78cbde248bb6e5c6868801bdf34849152965d2d
 
 case "$XBPS_MACHINE" in
 x86_64-musl)
-	hostmakedepends+=" libcurl libgit2 httperf"  # shoot me twice
+	hostmakedepends+=" libcurl libgit2"
 	distfiles+="
 	 https://repo.voidlinux.eu/distfiles/rustc-${_rust_dist_version}-x86_64-unknown-linux-musl.tar.gz
 	 https://repo.voidlinux.eu/distfiles/rust-std-${_rust_dist_version}-x86_64-unknown-linux-musl.tar.gz


### PR DESCRIPTION
Builds on x86_64, x86_64-musl and i686.
Also, the new rustc is able to build firefox on all supported architectures (needs reduced level of debuginfo on i686 to prevent  running out of memory).