### PR TITLE
riot-desktop: update to 0.14.0

### DIFF
--- a/srcpkgs/riot-desktop/files/riot-desktop.sh
+++ b/srcpkgs/riot-desktop/files/riot-desktop.sh
@@ -1,1 +1,1 @@
-/usr/share/riot-desktop/dist/electron /usr/share/riot-desktop/electron_app
+/usr/share/riot-desktop/dist/electron /usr/share/riot-desktop/electron_app "$@"

--- a/srcpkgs/riot-desktop/template
+++ b/srcpkgs/riot-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'riot-desktop'
 pkgname=riot-desktop
-version=0.13.5
+version=0.14.0
 revision=1
 only_for_archs="i686 x86_64"
 conf_files="/etc/${pkgname}/config.json"
@@ -12,7 +12,7 @@ maintainer="zethra <jediben97@gmail.com>"
 license="Apache-2.0"
 homepage="https://riot.im"
 distfiles="https://github.com/vector-im/riot-web/archive/v${version}.tar.gz"
-checksum=877512b5a2112e48299de723f251cfa578d130875609a2060fbfc8037bb4480d
+checksum=de16ceaeeea785d812d2e9e2d24581477f2727c812e9628576dc4647db0bae1d
 nocross=yes
 nostrip=yes
 


### PR DESCRIPTION
I've also changed the `riot-desktop.sh` wrapper to pass any of it's arguments to the electron process. For example a valid command line argument for the electron process is `--disable-smooth-scrolling` which does as it says. Let me know if I should instead have that as a separate pull request.