### PR TITLE
nvidia: update to 390.48

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -143,7 +143,7 @@ libnvidia-gtk2.so.346.47 nvidia-gtklibs-346.47_1 ignore
 libnvidia-gtk3.so.346.47 nvidia-gtklibs-346.47_1 ignore
 libnvidia-glcore.so.346.47 nvidia340-libs-340.46_1 ignore
 libnvidia-glsi.so.346.72 nvidia-libs-346.72_1 ignore
-libnvidia-fatbinaryloader.so.390.25 nvidia-libs-390.25_1 ignore
+libnvidia-fatbinaryloader.so.390.48 nvidia-libs-390.48_1 ignore
 libglapi.so.0 libglapi-7.11_1
 libgbm.so.1 libgbm-9.0_1
 librsvg-2.so.2 librsvg-2.26.0_1

--- a/srcpkgs/nvidia/files/nvidia-swiotlb-linux_4_16.patch
+++ b/srcpkgs/nvidia/files/nvidia-swiotlb-linux_4_16.patch
@@ -1,0 +1,14 @@
+disable check for swiotlb for kernels newer as 4.16 because it uses a symbol
+that isn't exported anymore
+
+--- kernel/common/inc/nv-linux.h.orig	2018-04-23 14:33:53.184275029 +0200
++++ kernel/common/inc/nv-linux.h	2018-04-23 15:26:38.892322165 +0200
+@@ -1209,7 +1209,7 @@
+ static inline NvBool nv_dma_maps_swiotlb(struct pci_dev *dev)
+ {
+     NvBool swiotlb_in_use = NV_FALSE;
+-#if defined(CONFIG_SWIOTLB)
++#if defined(CONFIG_SWIOTLB) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+   #if defined(NV_DMA_OPS_PRESENT) || defined(NV_GET_DMA_OPS_PRESENT)
+     /*
+      * We only use the 'dma_ops' symbol on older x86_64 kernels; later kernels,

--- a/srcpkgs/nvidia/files/nvidia-x86_64-uvm8_va_block-linux_4_14_9.patch
+++ b/srcpkgs/nvidia/files/nvidia-x86_64-uvm8_va_block-linux_4_14_9.patch
@@ -2,8 +2,8 @@ Since linux-4.14.9 there has been some kernel headers reordering.
 Fix that issue by including linux/sched/task_stack.h for kernels
 newer than 4.14.9.
 
---- NVIDIA-Linux-x86_64-390.25-no-compat32/kernel/nvidia-uvm/uvm8_va_block.c	2017-10-27 01:19:54.000000000 +0200
-+++ NVIDIA-Linux-x86_64-390.25-no-compat32/kernel/nvidia-uvm/uvm8_va_block.c	2018-01-02 02:50:05.260588964 +0100
+--- NVIDIA-Linux-x86_64-390.48-no-compat32/kernel/nvidia-uvm/uvm8_va_block.c	2017-10-27 01:19:54.000000000 +0200
++++ NVIDIA-Linux-x86_64-390.48-no-compat32/kernel/nvidia-uvm/uvm8_va_block.c	2018-01-02 02:50:05.260588964 +0100
 @@ -36,6 +36,10 @@
  #include "uvm8_perf_prefetch.h"
  #include "uvm8_mem.h"

--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -44,6 +44,10 @@ do_extract() {
 			nvidia-uvm8_va_block-linux_4_14_9.patch
 		patch -p0 < nvidia-uvm8_va_block-linux_4_14_9.patch
 	fi
+	cd ${_pkg}
+	cp ${FILESDIR}/nvidia-swiotlb-linux_4_16.patch \
+		nvidia-swiotlb-linux_4_16.patch
+	patch -p0 < nvidia-swiotlb-linux_4_16.patch
 }
 
 pre_install() {

--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -3,7 +3,7 @@
 _desc="NVIDIA drivers for linux (long-lived series)"
 
 pkgname=nvidia
-version=390.25
+version=390.48
 revision=1
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="Proprietary NVIDIA license"
@@ -24,11 +24,11 @@ build_options_default="glvnd"
 if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
 	_pkg="NVIDIA-Linux-x86-${version}"
 	distfiles="http://uk.download.nvidia.com/XFree86/Linux-x86/${version}/${_pkg}.run"
-	checksum=1183552b46409a3c09caa172da5a296b56078d178c5ad272bed7101a40bf6b3a
+	checksum=5115894ebb9d5d4c75c11e73a79093b7687328ebcf85d1de81a0edf41d14d6f8
 else
 	_pkg="NVIDIA-Linux-x86_64-${version}-no-compat32"
 	distfiles="http://uk.download.nvidia.com/XFree86/Linux-x86_64/${version}/${_pkg}.run"
-	checksum=02263bc81b66e68fc8224447b249f4f0ca4ae201c467e236d917be2fe187f3d6
+	checksum=2d4bf72801f101a85df6fd1464021380ad51f5a30df05dadaf1fb546a175a441
 fi
 
 subpackages="nvidia-gtklibs nvidia-dkms nvidia-opencl nvidia-libs"
@@ -65,9 +65,9 @@ do_install() {
 	# GLX client libs
 	if [ "${build_option_glvnd}" ]; then
 		# ----- Also provided by the libglvnd package (todo)
-		vinstall libGL.so.1.0.0 755 usr/lib
-		ln -sf libGL.so.1.0.0 ${DESTDIR}/usr/lib/libGL.so
-		ln -sf libGL.so.1.0.0 ${DESTDIR}/usr/lib/libGL.so.1
+		vinstall libGL.so.1.7.0 755 usr/lib
+		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so
+		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so.1
 
 		vinstall libGLX.so.0 755 usr/lib
 		ln -sf libGLX.so.0 ${DESTDIR}/usr/lib/libGLX.so
@@ -102,11 +102,13 @@ do_install() {
 
 	vinstall libGLdispatch.so.0 755 usr/lib
 
-	vinstall libGLESv1_CM.so.1 755 usr/lib
-	ln -sf libGLESv1_CM.so.1 ${DESTDIR}/usr/lib/libGLESv1_CM.so
+	vinstall libGLESv1_CM.so.1.2.0 755 usr/lib
+	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/usr/lib/libGLESv1_CM.so
+	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/usr/lib/libGLESv1_CM.so.1
 
-	vinstall libGLESv2.so.2 755 usr/lib
-	ln -sf libGLESv2.so.2 ${DESTDIR}/usr/lib/libGLESv2.so
+	vinstall libGLESv2.so.2.1.0 755 usr/lib
+	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/usr/lib/libGLESv2.so
+	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/usr/lib/libGLESv2.so.2
 
 	vinstall libnvidia-egl-wayland.so.1.0.2 755 usr/lib
 	ln -sf libnvidia-egl-wayland.so.1.0.2 ${DESTDIR}/usr/lib/libnvidia-egl-wayland.so.1
@@ -115,8 +117,9 @@ do_install() {
 	vinstall 10_nvidia_wayland.json 755 usr/share/egl/egl_external_platform.d
 	# --------------------------------------------------
 
-	vinstall libEGL.so.1 755 usr/lib
-	ln -sf libEGL.so.1 ${DESTDIR}/usr/lib/libEGL.so
+	vinstall libEGL.so.1.1.0 755 usr/lib
+	ln -sf libEGL.so.1.1.0 ${DESTDIR}/usr/lib/libEGL.so
+	ln -sf libEGL.so.1.1.0 ${DESTDIR}/usr/lib/libEGL.so.1
 
 	vinstall libEGL_nvidia.so.${version} 755 usr/lib
 	ln -sf libEGL_nvidia.so.${version} ${DESTDIR}/usr/lib/libEGL_nvidia.so.0


### PR DESCRIPTION
this doesn't fix broken drivers on linux4.16 but it does fix screen flickering when composition pipeline is on on 4.15