### PR TITLE
New package: perl-Crypt-CBC-2.33

### DIFF
--- a/srcpkgs/perl-Crypt-CAST5/template
+++ b/srcpkgs/perl-Crypt-CAST5/template
@@ -1,0 +1,16 @@
+# Template file for 'perl-Crypt-CAST5'
+pkgname=perl-Crypt-CAST5
+version=0.05
+revision=1
+wrksrc="${pkgname#perl-}-${version}"
+build_style=perl-module
+hostmakedepends="perl"
+makedepends="perl"
+checkdepends="perl-Crypt-CBC"
+depends="perl"
+short_desc="Perl interface to CAST5 block cipher"
+maintainer="newbluemoon <blaumolch@mailbox.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
+homepage="https://metacpan.org/release/Crypt-CAST5"
+distfiles="${CPAN_SITE}/Crypt/Crypt-CAST5-${version}.tar.gz"
+checksum=9b51fc769c34ebb7b605927705af31af277e2532f0c03ed53755d064cdde1307

--- a/srcpkgs/perl-Crypt-CBC/template
+++ b/srcpkgs/perl-Crypt-CBC/template
@@ -1,0 +1,18 @@
+# Template file for 'perl-Crypt-CBC'
+pkgname=perl-Crypt-CBC
+version=2.33
+revision=1
+noarch=yes
+wrksrc="${pkgname#perl-}-${version}"
+build_style=perl-module
+hostmakedepends="perl"
+makedepends="perl"
+checkdepends="perl-Crypt-Blowfish perl-Crypt-Blowfish_PP perl-Crypt-CAST5
+ perl-Crypt-DES perl-Crypt-DES_EDE3 perl-Crypt-IDEA perl-Crypt-Rijndael"
+depends="perl"
+short_desc="Encrypt Data with Cipher Block Chaining Mode"
+maintainer="newbluemoon <blaumolch@mailbox.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
+homepage="https://metacpan.org/release/Crypt-CBC"
+distfiles="${CPAN_SITE}/Crypt/Crypt-CBC-${version}.tar.gz"
+checksum=6a70de21b6cc7f2b100067e8e188db966e9a8001b5db6fa976e7cb5b294ae645

--- a/srcpkgs/perl-Crypt-DES/template
+++ b/srcpkgs/perl-Crypt-DES/template
@@ -1,0 +1,20 @@
+# Template file for 'perl-Crypt-DES'
+pkgname=perl-Crypt-DES
+version=2.07
+revision=1
+wrksrc="${pkgname#perl-}-${version}"
+build_style=perl-module
+hostmakedepends="perl"
+makedepends="perl"
+checkdepends="perl-Crypt-CBC"
+depends="perl"
+short_desc="Perl interface to DES block cipher"
+maintainer="newbluemoon <blaumolch@mailbox.org>"
+license="Custom"
+homepage="https://metacpan.org/release/Crypt-DES"
+distfiles="${CPAN_SITE}/Crypt/Crypt-DES-${version}.tar.gz"
+checksum=2db1ebb5837b4cb20051c0ee5b733b4453e3137df0a92306034c867621edd7e7
+
+post_install() {
+	vlicense COPYRIGHT
+}

--- a/srcpkgs/perl-Crypt-DES_EDE3/template
+++ b/srcpkgs/perl-Crypt-DES_EDE3/template
@@ -1,0 +1,16 @@
+# Template file for 'perl-Crypt-DES_EDE3'
+pkgname=perl-Crypt-DES_EDE3
+version=0.01
+revision=1
+noarch=yes
+wrksrc="${pkgname#perl-}-${version}"
+build_style=perl-module
+hostmakedepends="perl"
+makedepends="perl perl-Crypt-DES"
+depends="perl"
+short_desc="Perl interface to Triple-DES EDE block cipher"
+maintainer="newbluemoon <blaumolch@mailbox.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
+homepage="https://metacpan.org/release/Crypt-DES_EDE3"
+distfiles="${CPAN_SITE}/Crypt/Crypt-DES_EDE3-${version}.tar.gz"
+checksum=9cb2e04b625e9cc0833cd499f76fd12556583ececa782a9758a55e3f969748d6

--- a/srcpkgs/perl-Crypt-IDEA/template
+++ b/srcpkgs/perl-Crypt-IDEA/template
@@ -1,0 +1,19 @@
+# Template file for 'perl-Crypt-IDEA'
+pkgname=perl-Crypt-IDEA
+version=1.10
+revision=1
+wrksrc="${pkgname#perl-}-${version}"
+build_style=perl-module
+hostmakedepends="perl"
+makedepends="perl"
+depends="perl"
+short_desc="Perl interface to IDEA block cipher"
+maintainer="newbluemoon <blaumolch@mailbox.org>"
+license="Custom"
+homepage="https://metacpan.org/release/Crypt-IDEA"
+distfiles="${CPAN_SITE}/Crypt/Crypt-IDEA-${version}.tar.gz"
+checksum=33bd78c11924a0fc1ff3eedde94078cbbf6b6ca9ede046d2b2f561e9e9a72019
+
+post_install() {
+	vlicense COPYRIGHT
+}


### PR DESCRIPTION
As requested on the forum:
https://forum.voidlinux.eu/t/where-can-regular-users-request-new-packages/5399

<s>Of the ciphers which can be used with Crypt::CBC there are currently Crypt::Blowfish and Crypt::Rijndael in the repo. Should the others (Crypt::DES, Crypt::DES_EDE3, Crypt::IDEA, Crypt::CAST5) be added as well in any case?</s> So for convenience I added the missing ciphers which are mentioned in Crypt::CBC’s [description](https://metacpan.org/pod/Crypt::CBC).