### PR TITLE
xorg-server: enable glx on aarch64

### DIFF
--- a/srcpkgs/xorg-server/template
+++ b/srcpkgs/xorg-server/template
@@ -1,7 +1,7 @@
 # Template file for 'xorg-server'
 pkgname=xorg-server
 version=1.19.6
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--enable-ipv6 --enable-record --enable-xorg
  --enable-xnest --enable-xephyr --enable-composite --enable-xvfb
@@ -39,7 +39,7 @@ replaces="xf86-video-modesetting>=0"
 subpackages="xorg-server-devel xorg-server-xdmx xorg-server-xephyr xorg-server-xnest xorg-server-xvfb xorg-server"
 
 case "$XBPS_TARGET_MACHINE" in
-i686*|x86_64*)
+i686*|x86_64*|aarch64*)
 	# Enable glamor/dri/opengl/xwayland by default on x86.
 	configure_args+=" --enable-glamor --enable-dri2 --enable-dri3 --enable-glx --enable-xwayland"
 	makedepends+=" MesaLib-devel"


### PR DESCRIPTION
This is necessary so that Tegra-based systems can make use of the
accelerated open source graphics stack in Mesa 18.1.

I'm currently in process of porting Void to the Google Pixel C tablet and without this it is not possible to use X11 with OpenGL on the Tegra X1 SoC; with it (and with Mesa updated to 18.1 with the appropriate features enabled) we can use desktop OpenGL 4.3 as well as GLES 3.1.