### PR TITLE
SDL2: enable x11, opengl and pulse on aarch64

### DIFF
--- a/srcpkgs/SDL2/template
+++ b/srcpkgs/SDL2/template
@@ -1,7 +1,7 @@
 # Template file for 'SDL2'
 pkgname=SDL2
 version=2.0.8
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-alsa --disable-esd --disable-rpath --enable-libudev
  --enable-clock_gettime --disable-nas --disable-arts --disable-x11-shared
@@ -21,6 +21,9 @@ build_options="gles opengl pulseaudio sndio wayland x11"
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*)
 		build_options_default="opengl pulseaudio x11"
+		;;
+	aarch64*)
+		build_options_default="gles opengl pulseaudio x11"
 		;;
 	arm*)
 		# Enable OpenGL/ES on rpi platforms


### PR DESCRIPTION
We can use desktop OpenGL as well as X11 with the open source
graphics stack on Tegra hardware besides others, so enable
options to match x86.

I'm currently in process of porting Void to the Google Pixel C tablet and this is so that SDL2 games and other applications can work properly under X11 with the open source graphics stack. Additionally, enable OpenGL ES in addition to desktop GL.