### PR TITLE
cava-gui: missing portaudio dependency

### DIFF
--- a/srcpkgs/cava-gui/template
+++ b/srcpkgs/cava-gui/template
@@ -1,11 +1,11 @@
 # Template file for 'cava-gui'
 pkgname=cava-gui
 version=0.6.1
-revision=1
+revision=2
 wrksrc="cava-${version}"
 build_style=gnu-configure
 hostmakedepends="automake libtool"
-makedepends="SDL2-devel iniparser-devel ncurses-devel sndio-devel"
+makedepends="SDL2-devel iniparser-devel ncurses-devel sndio-devel portaudio-devel"
 short_desc="Console-based Audio Visualizer for ALSA (GUI branch)"
 maintainer="nik123 <pavlica.nikola@gmail.com>"
 license="MIT"


### PR DESCRIPTION
Portaudio input support has been added to the project since 0.6.1 and it hasn't been included.