### PR TITLE
[WIP] emacs: update to 26.1.

### DIFF
--- a/srcpkgs/emacs/template
+++ b/srcpkgs/emacs/template
@@ -1,12 +1,11 @@
 # Template file for 'emacs'
 pkgname=emacs
-version=25.3
-revision=4
+version=26.1
+revision=1
 nocross=yes
 nopie=yes
-patch_args="-Np1"
 hostmakedepends="pkg-config"
-makedepends="ncurses-devel libXaw-devel gtk+-devel gtk+3-devel webkitgtk-devel
+makedepends="ncurses-devel libXaw-devel gtk+-devel gtk+3-devel webkit2gtk-devel
  dbus-devel acl-devel
  $(vopt_if jpeg libjpeg-turbo-devel) $(vopt_if tiff tiff-devel)
  $(vopt_if gif giflib-devel) $(vopt_if png libpng-devel) $(vopt_if xpm libXpm-devel)
@@ -22,10 +21,10 @@ configure_args="--with-file-notification=inotify --with-modules
  $(vopt_with xml xml2) $(vopt_with gnutls) $(vopt_with sound) $(vopt_with m17n m17n-flt)"
 short_desc="GNU Emacs editor"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/emacs/"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=253ac5e7075e594549b83fd9ec116a9dc37294d415e2f21f8ee109829307c00b
+checksum=1cf4fc240cd77c25309d15e18593789c8dbfba5c2b44d8f77c886542300fd32c
 
 # Package build options
 build_options="jpeg tiff gif png xpm svg xml imagemagick gnutls sound m17n"
@@ -33,12 +32,6 @@ desc_option_xpm="Enable support for XPM images"
 desc_option_sound="Enable support for sound"
 desc_option_m17n="Enable support for m17n multilingual text processing"
 build_options_default="jpeg tiff gif png xpm svg xml gnutls sound m17n"
-
-post_extract() {
-	case "$XBPS_TARGET_MACHINE" in
-		*-musl) patch -p0 <${FILESDIR}/musl.patch
-	esac
-}
 
 pre_configure() {
 	# Just configuring in different directories results in
@@ -76,6 +69,7 @@ do_build() {
 do_install() {
 	make DESTDIR=$DESTDIR -C ${wrksrc}/nox install
 	rm -f ${DESTDIR}/usr/bin/ctags
+	rm -f ${DESTDIR}/usr/lib/systemd/user/emacs.service
 	rm -f ${DESTDIR}/usr/share/man/man1/ctags.1*
 	rm -f ${DESTDIR}/usr/share/info/info.info
 	rm -rf ${DESTDIR}/usr/share/applications
@@ -89,7 +83,6 @@ emacs-common_package() {
 		vmove usr/share/emacs
 		vmove usr/share/man
 		vmove usr/share/info
-		vmove var/games/emacs
 		rm -f ${PKGDESTDIR}/usr/share/info/info.info.gz
 	}
 }
@@ -103,7 +96,7 @@ emacs-x11_package() {
 		make DESTDIR=${PKGDESTDIR} -C ${wrksrc}/x11 install
 		rm -f ${PKGDESTDIR}/usr/bin/ctags
 		rm -rf ${PKGDESTDIR}/usr/share
-		rm -rf ${PKGDESTDIR}/var/games/emacs
+		rm -rf ${PKGDESTDIR}/usr/lib
 	}
 }
 
@@ -116,7 +109,7 @@ emacs-gtk2_package() {
 		make DESTDIR=${PKGDESTDIR} -C ${wrksrc}/gtk2 install
 		rm -f ${PKGDESTDIR}/usr/bin/ctags
 		rm -rf ${PKGDESTDIR}/usr/share/{emacs,man,info}
-		rm -rf ${PKGDESTDIR}/var/games/emacs
+		rm -rf ${PKGDESTDIR}/usr/lib
 	}
 }
 
@@ -129,6 +122,6 @@ emacs-gtk3_package() {
 		make DESTDIR=${PKGDESTDIR} -C ${wrksrc}/gtk3 install
 		rm -f ${PKGDESTDIR}/usr/bin/ctags
 		rm -rf ${PKGDESTDIR}/usr/share/{emacs,man,info}
-		rm -rf ${PKGDESTDIR}/var/games/emacs
+		rm -rf ${PKGDESTDIR}/usr/lib
 	}
 }


### PR DESCRIPTION
Marking as WIP while I test it for a bit, compiles and runs in text mode at least on x86_64-musl.

Dropping usage of unencypted POP3 fetching and using groups to store site-wide highscores.